### PR TITLE
Add moderation / viewer banned event and variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Currently supported:
   - Stream started
   - Stream ended
   - Viewer arrived
+  - Viewer banned
 - Effects
   - Chat message (Kick)
   - Chat message (Platform aware)
@@ -47,6 +48,9 @@ Currently supported:
   - `$kickCategoryImageUrl` for your channel or another channel
   - `$kickChatMessage`
   - `$kickCurrentViewerCount` for your channel or another channel
+  - `$kickBanDuration` (in seconds)
+  - `$kickModerator` (for bans)
+  - `$kickModReason` (for bans)
   - `$kickStreamer`
   - `$kickStreamerId`
   - `$kickStreamIsLive` for your channel or another channel
@@ -58,27 +62,32 @@ Things that are not supported now but should be possible:
 
 - Events for subs (renewal, gift, first time)
 - Event for livestream metadata updated
-- Event for user banned
 - Ban user, unban user actions
 - Some chat roles
 
-Limitations, or things that will be difficult to support or will never be supported:
+Limitations due to Kick:
+
+- Many actions on Kick do not generate webhooks and therefore cannot generate Firebot events. Common things that you might expect to be supported but that currently aren't include channel rewards, hosts (raids), and users being unbanned, timed out, or un-timed out.
+
+- Kick user profile images are broken. This is because the Kick API returns URLs that cannot be accessed from anywhere other than the kick.com website. (Kick needs to fix this. Once they do, this integration can work properly.)
+
+- Kick does not have an API endpoint to get the current viewer list or any other similar functionality to determine when users are present in your stream. That means there can be no accural of currency or tracking of watch time for Kick users.
+
+Limitations due to Firebot:
+
+- Firebot's viewer database uses the user id from the Purple site as its primary key, and has assumptions throughout the entire program that any user in the viewer database is a user on the Purple site. Until there is a fundamental design change in Firebot to support multiple platforms, this will always limit the functionality of this integration and may cause strange ripple effects throughout the program.
 
 - Kick user data is not stored between Firebot sessions, making it rather pointless to track currency, chat messages, and the like. (It is possible to enable the "dangerous" option to store Kick user data in the user database, but this causes various incompatibilities throughout Firebot and as such it is strongly discouraged.)
 
 - The user experience for getting the Kick authorization URL is not great because there's not a feasible way (that I found) to present a modal with a clickable URL or have Firebot open a browser window from a script. (Kick's authentication uses a mechanism that Firebot's built in oauth provider does not currently support and I do not want to distribute my bot's client secret to anyone running Firebot who wants to connect to it.)
 
-- Kick user profile images are broken. This is because the Kick API returns URLs that cannot be accessed from anywhere other than the kick.com website. (Kick needs to fix this. Once they do, this integration can work properly.)
-
 - Actions on chat feed messages (e.g. delete, ban user, etc.) will either do nothing or possibly error out when used on Kick messages. These are hard-coded within Firebot to assume the user or message is on the Purple site.
 
 - Cooldowns on commands do not work because Firebot does not expose the "cooldown manager" to scripts.
 
+- Effects and variables defined by Firebot that pertain to events from the Purple site are often hard-coded for only those events. This means, for example, that the `$moderator` variable is not available to the Kick integration, even though the event metadata is the same. For this reason, this integration adds variables like `$kickModerator`. However, you'll need to have separate handlers for all of these.
+
 - Firebot deletes all configuration data for an integration when the integration is unlinked. If you unlink the integration and then exit Firebot without relinking, you'll lose your configuration (webhook URL and preferences). You'll need to reconfigure this under Settings &gt; Integrations. (This integration includes a fix to re-write the current settings to the database upon re-linking to try to minimize the impact.)
-
-- Kick does not have an API endpoint to get the current viewer list or any other similar functionality to determine when users are present in your stream. That means there can be no accural of currency or tracking of watch time for Kick users.
-
-- Many actions on Kick do not generate webhooks and therefore cannot generate Firebot events. Common things that you might expect to be supported but that currently aren't include channel rewards, hosts (raids), and users being unbanned, timed out, or un-timed out.
 
 ## Installation
 

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -6,7 +6,7 @@ export const eventSource: EventSource = {
     events: [
         {
             id: "chat-message",
-            name: "Chat Message",
+            name: "Chat Message (Kick)",
             description: "When someone chats in your channel on Kick",
             cached: false,
             manualMetadata: {
@@ -85,6 +85,38 @@ export const eventSource: EventSource = {
                     return `**${eventData.userDisplayName}${
                         showUserIdName ? ` (${eventData.username})` : ""
                     }** arrived`;
+                }
+            }
+        },
+        {
+            id: "banned",
+            name: "Viewer Banned (Kick)",
+            description: "When someone is banned in your channel",
+            cached: false,
+            manualMetadata: {
+                username: "cavemobster",
+                userDisplayName: "CaveMobster",
+                userId: "",
+                moderator: "Firebot",
+                modReason: "They were extra naughty"
+            },
+            activityFeed: {
+                icon: "fad fa-gavel",
+                getMessage: (eventData) => {
+                    const username = typeof eventData.username === "string" ? eventData.username : "";
+                    const userDisplayName = typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : "";
+                    const showUserIdName = username.toLowerCase() !== userDisplayName.toLowerCase();
+                    const moderator = typeof eventData.moderator === "string" ? eventData.moderator : "Unknown Moderator";
+                    const modReason = typeof eventData.modReason === "string" ? eventData.modReason : "";
+
+                    let message = `**${userDisplayName}${
+                        showUserIdName ? ` (${username})` : ""
+                    }** was banned by **${moderator}**.`;
+
+                    if (modReason) {
+                        message = `${message} Reason: **${modReason}**`;
+                    }
+                    return message;
                 }
             }
         }

--- a/src/events/moderation-banned.ts
+++ b/src/events/moderation-banned.ts
@@ -1,0 +1,54 @@
+import { IntegrationConstants } from "../constants";
+import { integration } from "../integration";
+import { KickUsers } from "../internal/user";
+import { firebot, logger } from "../main";
+import { ModerationBannedEvent, Webhook } from "../shared/types";
+
+export async function handleModerationBanned(webhook: Webhook): Promise<void> {
+    if (!webhook.payload) {
+        logger.error(`[${IntegrationConstants.INTEGRATION_ID}] No payload found in webhook for event: id=${webhook.eventMessageID}, type=${webhook.eventType}`);
+        return;
+    }
+    const payload = webhook.payload as ModerationBannedEvent;
+    logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Handling moderation banned event: id=${webhook.eventMessageID}, bannedUser=${payload.bannedUser.username}`);
+
+    const { frontendCommunicator } = firebot.modules;
+    frontendCommunicator.send("twitch:chat:user:delete-messages", KickUsers.kickifyUsername(payload.bannedUser.username));
+
+    triggerBanned(
+        payload.bannedUser.username,
+        payload.bannedUser.userId.toString(),
+        payload.bannedUser.username, // Kick does not have display names
+        payload.moderator.username,
+        payload.moderator.userId.toString(),
+        payload.moderator.username, // Kick does not have display names
+        payload.metadata.reason || "",
+        payload.metadata.expiresAt // Note: Twitch event handler does not set this metadata
+    );
+}
+
+function triggerBanned(
+    username: string,
+    userId: string,
+    userDisplayName: string,
+    moderatorUsername: string,
+    moderatorId: string,
+    moderatorDisplayName: string,
+    modReason: string,
+    expiresAt: Date | undefined
+): void {
+    const { eventManager } = firebot.modules;
+    for (const source of integration.getEventSources()) {
+        eventManager.triggerEvent(source, "banned", {
+            username: KickUsers.kickifyUsername(username),
+            userId: KickUsers.kickifyUserId(userId),
+            userDisplayName,
+            moderatorUsername: KickUsers.kickifyUsername(moderatorUsername),
+            moderatorId: KickUsers.kickifyUserId(moderatorId),
+            moderatorDisplayName,
+            modReason,
+            expiresAt, // Note: Twitch event handler does not set this metadata
+            moderator: moderatorDisplayName // For compatibility with Twitch `$moderator` variable
+        });
+    }
+}

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -24,6 +24,9 @@ import { kickStreamerVariable } from "./variables/streamer";
 import { kickStreamerIdVariable } from "./variables/streamer-id";
 import { kickUptimeVariable } from "./variables/uptime";
 import { kickUserDisplayNameVariable } from "./variables/user-display-name";
+import { kickBanDuration } from "./variables/banDuration";
+import { kickModReason } from "./variables/mod-reason";
+import { kickModerator } from "./variables/moderator";
 
 type integrationParameters = {
     connectivity: {
@@ -128,6 +131,9 @@ export class KickIntegration extends EventEmitter {
         replaceVariableManager.registerReplaceVariable(kickStreamTitleVariable);
         replaceVariableManager.registerReplaceVariable(kickUptimeVariable);
         replaceVariableManager.registerReplaceVariable(kickUserDisplayNameVariable);
+        replaceVariableManager.registerReplaceVariable(kickBanDuration);
+        replaceVariableManager.registerReplaceVariable(kickModReason);
+        replaceVariableManager.registerReplaceVariable(kickModerator);
 
         const { restrictionManager } = firebot.modules;
         restrictionManager.registerRestriction(platformRestriction);

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -72,6 +72,10 @@ export class Kick {
                 {
                     name: "livestream.status.updated",
                     version: 1
+                },
+                {
+                    name: "moderation.banned",
+                    version: 1
                 }
             ],
             method: "webhook"

--- a/src/internal/parser/moderation.d.ts
+++ b/src/internal/parser/moderation.d.ts
@@ -1,0 +1,10 @@
+interface InboundModerationBannedEvent {
+    broadcaster: InboundKickUser;
+    moderator: InboundKickUser;
+    banned_user: InboundKickUser;
+    metadata: {
+        reason: string;
+        created_at: string;
+        expires_at?: string; // null for permanent bans
+    };
+}

--- a/src/internal/poll.ts
+++ b/src/internal/poll.ts
@@ -2,6 +2,7 @@ import { IntegrationConstants } from "../constants";
 import { handleChatMessageSent } from "../events/chat-message";
 import { handleFollower } from "../events/follower";
 import { handleLivestreamStatusUpdated } from "../events/livestream-status-updated";
+import { handleModerationBanned } from "../events/moderation-banned";
 import { integration } from "../integration";
 import { logger } from "../main";
 import { httpCallWithTimeout } from "./http";
@@ -102,6 +103,9 @@ export class Poller {
                     break;
                 case "livestream.status.updated":
                     handleLivestreamStatusUpdated(webhook);
+                    break;
+                case "moderation.banned":
+                    handleModerationBanned(webhook);
                     break;
                 default:
                     throw new Error("Unsupported event type");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,7 +4,7 @@ export interface Webhook {
     eventMessageTimestamp: string;
     eventType: string;
     eventVersion: string;
-    payload?: ChatMessage | KickFollower | LivestreamStatusUpdated;
+    payload?: ChatMessage | KickFollower | LivestreamStatusUpdated | ModerationBannedEvent;
 }
 
 export interface KickBadge {
@@ -84,4 +84,17 @@ export interface CategoryInfo {
     id: number;
     name: string;
     thumbnail: string;
+}
+
+export interface ModerationBannedMetadata {
+    reason: string;
+    createdAt: Date;
+    expiresAt?: Date; // null for permanent bans
+}
+
+export interface ModerationBannedEvent {
+    broadcaster: KickUser;
+    moderator: KickUser;
+    bannedUser: KickUser;
+    metadata: ModerationBannedMetadata;
 }

--- a/src/variables/banDuration.ts
+++ b/src/variables/banDuration.ts
@@ -1,0 +1,26 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../constants';
+
+const triggers: Effects.TriggersObject = {};
+triggers["event"] = [`${IntegrationConstants.INTEGRATION_ID}:banned`];
+triggers["manual"] = true;
+
+export const kickBanDuration: ReplaceVariable = {
+    definition: {
+        handle: "kickBanDuration",
+        description: "The duration of the ban imposed on the user in seconds (-1 = permanent).",
+        triggers: triggers,
+        possibleDataOutput: ["number"]
+    },
+    evaluator: (trigger) => {
+        const expiresAt = trigger.metadata.eventData?.expiresAt;
+        if (!expiresAt || !(expiresAt instanceof Date)) {
+            return -1; // Permanent ban
+        }
+
+        const now = new Date();
+        const duration = expiresAt.getTime() - now.getTime();
+        return Math.max(0, Math.floor(duration / 1000));
+    }
+};

--- a/src/variables/mod-reason.ts
+++ b/src/variables/mod-reason.ts
@@ -1,0 +1,19 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../constants';
+
+const triggers: Effects.TriggersObject = {};
+triggers["event"] = [`${IntegrationConstants.INTEGRATION_ID}:banned`];
+triggers["manual"] = true;
+
+export const kickModReason: ReplaceVariable = {
+    definition: {
+        handle: "kickModReason",
+        description: "The reason given by the moderator for the action (ban).",
+        triggers: triggers,
+        possibleDataOutput: ["text"]
+    },
+    evaluator: (trigger) => {
+        return trigger.metadata.eventData?.modReason || "";
+    }
+};

--- a/src/variables/moderator.ts
+++ b/src/variables/moderator.ts
@@ -1,0 +1,19 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../constants';
+
+const triggers: Effects.TriggersObject = {};
+triggers["event"] = [`${IntegrationConstants.INTEGRATION_ID}:banned`];
+triggers["manual"] = true;
+
+export const kickModerator: ReplaceVariable = {
+    definition: {
+        handle: "kickModerator",
+        description: "The username of the moderator that performed the action (ban).",
+        triggers: triggers,
+        possibleDataOutput: ["text"]
+    },
+    evaluator: (trigger) => {
+        return trigger.metadata.eventData?.moderatorDisplayName || "";
+    }
+};


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds a "viewer banned" event for Kick and variables `$kickModerator`, `$kickModReason`, and `$kickBanDuration` to handlers for that event.

Note: there is no "unbanned" event because the Kick webhook API does not support that.

### Motivation
This is supported by the Kick webhook API and is useful.

### Testing
Banned a test user, confirming that this showed in the activity feed and that an effect exercising these variables was triggered.
