### PR TITLE
Add preliminary support for pusher

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Seriously though:
 
 - By default, this integration does not store user data between sessions (e.g. currency, chat message counts). If you enable the "dangerous" option to store Kick users in the user database, this will almost certainly not be compatible with Firebot's eventual implementation of multi-platform support. At best this data will not be importable -- at worst, it will do enough damage that you won't be able to upgrade at all.
 
-- The current state of Kick's public API is ... incomplete (and that's putting it charitably). Their public API supports [only a small set of events](https://docs.kick.com/events/event-types) and is missing basic functionality. Some bots that integrate Kick now rely on their "private API" or websocket implementation "pusher" -- these work by pretending they are legitimate web browsers to sneak around Kick's web application firewall. I do not intend to use these "private" APIs in this project.
+- The current state of Kick's public API is ... incomplete (and that's putting it charitably). Their public API supports [only a small set of events](https://docs.kick.com/events/event-types) and is missing basic functionality. Some bots that integrate Kick now rely on a "private API" that only work by pretending they are legitimate web browsers to sneak around Kick's web application firewall. I do not intend to use these "private" APIs in this project.
 
-- This requires an [external server](/server) because Kick sends webhooks to a server on the internet. It does not support websockets like the Purple site does, which is necessary to let your Firebot instance connect to receive events. I have written a server and provide instructions to deploy my "webhook proxy" on Render.
+- This currently requires an [external server](/server) to receive webhooks that must be sent to a server on the internet. I have written a server and provide instructions to deploy my "webhook proxy" on Render. This server also supports more seamless authentication for the public API. (I may make this optional in the future by allowing each user to register their own Kick app and providing the client ID and secret in the configuration.)
 
 ## Introduction
 
@@ -105,7 +105,7 @@ As for support, there is none. In fact, you are risking current and future stabi
 
 ## Contributions
 
-I will not accept contributions that add functionality via Kick's "private API" or "pusher". I am the guy that wants to eat dinner at a steakhouse, finds the restaurant's online reservation system to be broken, and orders pizza instead out of principle. Kick is inexplicably making scant investments in their developer community despite being in catch-up mode. I would rather advise you to continue streaming on the Purple site than to help enable Kick's lack of investment via fragile workarounds.
+I will not accept contributions that add functionality via Kick's "private API". I am the guy that wants to eat dinner at a steakhouse, finds the restaurant's online reservation system to be broken, and orders pizza instead out of principle. Kick is inexplicably making scant investments in their developer community despite being in catch-up mode. I would rather advise you to continue streaming on the Purple site than to help enable Kick's lack of investment via fragile workarounds.
 
 I am also not interested in contributions that require modifications to Firebot that have not been accepted by their developers. I run Firebot on the [v5 branch](https://github.com/crowbartools/Firebot/tree/v5) so anything that is merged there, or in a Dev-approved pull request, is fair game.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,15 @@
             "version": "0.0.1",
             "license": "GNU3",
             "dependencies": {
-                "node-cache": "^5.1.2"
+                "node-cache": "^5.1.2",
+                "pusher-js": "^8.4.0"
             },
             "devDependencies": {
                 "@crowbartools/firebot-custom-scripts-types": "github:TheStaticMage/firebot-custom-scripts-types#running",
                 "@eslint/js": "^9.28.0",
                 "@stylistic/eslint-plugin": "^4.4.1",
                 "@types/jest": "^30.0.0",
+                "@types/ws": "^8.18.1",
                 "jest": "^30.0.4",
                 "terser-webpack-plugin": "^5.3.10",
                 "ts-jest": "^29.4.0",
@@ -1991,6 +1993,16 @@
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/yargs": {
             "version": "17.0.33",
@@ -6038,6 +6050,15 @@
             ],
             "license": "MIT"
         },
+        "node_modules/pusher-js": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.4.0.tgz",
+            "integrity": "sha512-wp3HqIIUc1GRyu1XrP6m2dgyE9MoCsXVsWNlohj0rjSkLf+a0jLvEyVubdg58oMk7bhjBWnFClgp8jfAa6Ak4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "tweetnacl": "^1.0.3"
+            }
+        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6911,6 +6932,12 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
             "license": "0BSD"
+        },
+        "node_modules/tweetnacl": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+            "license": "Unlicense"
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "webpack-cli": "^6.0.1"
     },
     "dependencies": {
-        "node-cache": "^5.1.2"
+        "node-cache": "^5.1.2",
+        "pusher-js": "^8.4.0"
     }
 }

--- a/src/internal/pusher/chatmessageevent.d.ts
+++ b/src/internal/pusher/chatmessageevent.d.ts
@@ -1,0 +1,25 @@
+interface ChatMessageEvent {
+    id: string;
+    chatroom_id: number;
+    content: string;
+    type: string;
+    created_at: string;
+    sender: {
+        id: number;
+        username: string;
+        slug: string;
+        identity: {
+            color: string;
+            badges: InboundBadge[];
+        };
+    };
+    metadata: {
+        message_ref: string;
+    };
+}
+
+interface InboundBadge {
+    text: string;
+    type: string;
+    count?: number;
+}

--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -1,0 +1,104 @@
+import { IntegrationConstants } from "../../constants";
+import { handleChatMessageSentEvent } from "../../events/chat-message-sent";
+import { integration } from "../../integration";
+import { logger } from "../../main";
+import { ChatMessage, KickUser } from "../../shared/types";
+import { parseDate } from "../util";
+
+const Pusher = require('pusher-js');
+
+export class KickPusher {
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+    private pusher: typeof Pusher | null = null;
+
+    connect(pusherAppKey: string, chatroomId: string): void {
+        if (!pusherAppKey || !chatroomId) {
+            logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] Pusher cannot connect: App Key or Chatroom ID is missing.`);
+            this.pusher = null;
+            return;
+        }
+
+        logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Pusher connecting (app key: ${pusherAppKey}, chatroom ID: ${chatroomId})...`);
+
+        Pusher.log = (message: any) => {
+            if (integration.getSettings().advanced.logWebsocketEvents) {
+                logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Pusher log: ${message}`);
+            }
+        };
+
+        this.pusher = new Pusher(pusherAppKey, { cluster: 'us2' });
+
+        this.pusher.connection.bind('error', (err: any) => {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] Pusher error: ${JSON.stringify(err)}`);
+            this.disconnect();
+        });
+
+        const channel = this.pusher.subscribe(`chatrooms.${chatroomId}.v2`);
+        channel.bind_global(async (event: string, data: any) => {
+            try {
+                await this.dispatchEvent(event, data);
+            } catch (error) {
+                logger.error(`[${IntegrationConstants.INTEGRATION_ID}] Pusher event dispatch error: event=${event}, error=${error}`);
+            }
+        });
+    }
+
+    disconnect(): void {
+        if (this.pusher) {
+            logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Pusher disconnecting...`);
+            this.pusher.disconnect();
+            this.pusher = null;
+            logger.info(`[${IntegrationConstants.INTEGRATION_ID}] Pusher disconnected.`);
+        }
+    }
+
+    private async dispatchEvent(event: string, data: any): Promise<void> {
+        switch (event) {
+            case 'App\\Events\\ChatMessageEvent':
+                await handleChatMessageSentEvent(this.parseChatMessageEvent(data));
+                break;
+            case 'pusher:subscription_succeeded':
+                logger.info(`[${IntegrationConstants.INTEGRATION_ID}] Pusher subscribed successfully.`);
+                break;
+            default:
+                throw new Error(`Unhandled event type: ${event}`);
+        }
+    }
+
+    private parseChatMessageEvent(data: any): ChatMessage {
+        const d = data as ChatMessageEvent;
+        return {
+            messageId: d.id,
+            broadcaster: this.getBroadcaster(),
+            sender: {
+                userId: d.sender.id.toString(),
+                username: d.sender.username,
+                displayName: d.sender.username,
+                profilePicture: '', // Not provided in event
+                isVerified: false, // Worth checking?
+                channelSlug: d.sender.slug,
+                identity: {
+                    usernameColor: d.sender.identity.color,
+                    badges: d.sender.identity.badges.map(b => ({
+                        text: b.text,
+                        type: b.type,
+                        count: b.count
+                    }))
+                }
+            },
+            content: d.content,
+            createdAt: parseDate(d.created_at)
+        };
+    }
+
+    private getBroadcaster(): KickUser {
+        return {
+            userId: integration.kick.broadcaster?.userId.toString() || '',
+            username: integration.kick.broadcaster?.name || '',
+            displayName: integration.kick.broadcaster?.name || '',
+            profilePicture: integration.kick.broadcaster?.profilePicture || '',
+            isVerified: false, // Worth checking?
+            channelSlug: integration.kick.broadcaster?.name || ''
+        };
+    }
+}

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -13,3 +13,16 @@ export function kickifyUsername(username: string): string {
 export function unkickifyUsername(username: string): string {
     return username.endsWith("@kick") ? username.substring(0, username.length - 5) : username;
 }
+
+export function parseDate(dateString: string | undefined): Date | undefined {
+    if (!dateString) {
+        return undefined;
+    }
+
+    if (dateString === "0001-01-01T00:00:00Z") {
+        return undefined;
+    }
+
+    const date = new Date(dateString);
+    return isNaN(date.getTime()) ? undefined : date;
+}

--- a/src/internal/webhook-handler/chat.d.ts
+++ b/src/internal/webhook-handler/chat.d.ts
@@ -1,6 +1,7 @@
 interface InboundBadge {
     text: string;
     type: string;
+    count?: number;
 }
 
 interface InboundChatMessage {

--- a/src/internal/webhook-handler/webhook-handler.ts
+++ b/src/internal/webhook-handler/webhook-handler.ts
@@ -6,6 +6,7 @@ import { handleModerationBannedEvent } from "../../events/moderation-banned";
 import { integration } from "../../integration";
 import { logger } from "../../main";
 import { BasicKickUser, Channel, ChatMessage, KickFollower, KickUser, LivestreamStatusUpdated, ModerationBannedEvent, ModerationBannedMetadata } from "../../shared/types";
+import { parseDate } from "../util";
 
 export async function handleWebhook(webhook: InboundWebhook): Promise<void> {
     if (integration.getSettings().advanced.logWebhooks) {
@@ -42,19 +43,6 @@ export async function handleWebhook(webhook: InboundWebhook): Promise<void> {
             throw new Error(`Unsupported event type: ${webhook.kick_event_type}`);
         }
     }
-}
-
-function parseDate(dateString: string | undefined): Date | undefined {
-    if (!dateString) {
-        return undefined;
-    }
-
-    if (dateString === "0001-01-01T00:00:00Z") {
-        return undefined;
-    }
-
-    const date = new Date(dateString);
-    return isNaN(date.getTime()) ? undefined : date;
 }
 
 export function parseKickUser(user: InboundKickUser): KickUser {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This adds preliminary support for the Kick websocket events that are sent via "pusher".

The chat event is implemented here. More to follow.

### Motivation
The Kick public API webhooks are very incomplete. Although the websockets are not officially supported for this sort of thing, many other bots are using them. Adding with the acknowledgement that this could just stop working (but if that happens, there will also be a lot of other angry developers).

### Testing
Tested with chat events on my channel.
