### PR TITLE
Add channel point redemptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Currently supported:
   - Restrictions for commands generally work
   - A custom restriction is shipped with this integration (trigger platform)
 - Events
+  - Channel points redeemed
   - Chat message
   - Follow
   - Stream started
@@ -43,6 +44,7 @@ Currently supported:
   - Chat message (Platform aware)
   - Set stream game
   - Set stream title
+  - Trigger Custom Channel Reward Handler
 - Variables
   - `$kickCategory` (`$kickCategory`) for your channel or another channel
   - `$kickCategoryId` (`$kickGameId`) for your channel or another channel
@@ -51,6 +53,9 @@ Currently supported:
   - `$kickCurrentViewerCount` for your channel or another channel
   - `$kickModerator` (for bans)
   - `$kickModReason` (for bans)
+  - `$kickRewardId` (for redeems)
+  - `$kickRewardMessage` (for redeems)
+  - `$kickRewardName` (for redeems)
   - `$kickStreamer`
   - `$kickStreamerId`
   - `$kickStreamIsLive` for your channel or another channel
@@ -65,7 +70,6 @@ Things that are not supported now but should be possible:
 - Event for livestream metadata updated (i.e. game or title change)
 - Events for unban and untimeout
 - Ban user, unban user, time out user, un-time out user actions
-- Channel point redeems (TBD)
 - Some chat roles
 
 Limitations due to Kick:
@@ -75,6 +79,8 @@ Limitations due to Kick:
 - Kick user profile images are broken. This is because the Kick API returns URLs that cannot be accessed from anywhere other than the kick.com website. (Kick needs to fix this. Once they do, this integration can work properly.)
 
 - Kick does not have an API endpoint to get the current viewer list or any other similar functionality to determine when users are present in your stream. That means there can be no accural of currency or tracking of watch time for Kick users.
+
+- Kick channel point redeems cannot be created, deleted, approved, or rejected via the API. Therefore, it's not possible to have Firebot approve or reject awards via its API, to push existing custom rewards to Kick, or the like. In addition, Kick channel point redeems cannot be disabled or paused at all.
 
 Limitations due to Firebot:
 
@@ -86,7 +92,7 @@ Limitations due to Firebot:
 
 - Actions on chat feed messages (e.g. delete, ban user, etc.) will either do nothing or possibly error out when used on Kick messages. These are hard-coded within Firebot to assume the user or message is on the Purple site.
 
-- Cooldowns on commands do not work because Firebot does not expose the "cooldown manager" to scripts.
+- Cooldowns do not work because Firebot does not expose the "cooldown manager" to scripts. This means there are no cooldowns on channel point redeems, commands, etc. (You could use my [Firebot rate limiter](https://github.com/TheStaticMage/firebot-rate-limiter) instead.)
 
 - Effects and variables defined by Firebot that pertain to events from the Purple site are often hard-coded for only those events. This means, for example, that the `$moderator` variable is not available to the Kick integration, even though the event metadata is the same. For this reason, this integration adds variables like `$kickModerator`. However, you'll need to have separate handlers for all of these.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "GNU3",
             "dependencies": {
                 "node-cache": "^5.1.2",
+                "node-json-db": "^1.6.0",
                 "pusher-js": "^8.4.0"
             },
             "devDependencies": {
@@ -17,7 +18,6 @@
                 "@eslint/js": "^9.28.0",
                 "@stylistic/eslint-plugin": "^4.4.1",
                 "@types/jest": "^30.0.0",
-                "@types/ws": "^8.18.1",
                 "jest": "^30.0.4",
                 "terser-webpack-plugin": "^5.3.10",
                 "ts-jest": "^29.4.0",
@@ -1993,16 +1993,6 @@
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/ws": {
-            "version": "8.18.1",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/yargs": {
             "version": "17.0.33",
@@ -5578,6 +5568,18 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
+        "node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "license": "MIT",
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/moment": {
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -5664,6 +5666,15 @@
             "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/node-json-db": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/node-json-db/-/node-json-db-1.6.0.tgz",
+            "integrity": "sha512-Cpvuqejlx354aH5d1uqK9KB0/LOKslnexqgOrhgCqcvvzJ0I2hrAEA7eIct6hRqS9gxnuge+eXqd++za87tchA==",
+            "license": "MIT",
+            "dependencies": {
+                "mkdirp": "~1.0.4"
+            }
         },
         "node_modules/node-releases": {
             "version": "2.0.19",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     },
     "dependencies": {
         "node-cache": "^5.1.2",
+        "node-json-db": "^1.6.0",
         "pusher-js": "^8.4.0"
     }
 }

--- a/src/effects/trigger-custom-channel-reward.ts
+++ b/src/effects/trigger-custom-channel-reward.ts
@@ -1,0 +1,231 @@
+import { Firebot } from "@crowbartools/firebot-custom-scripts-types";
+import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
+import { RestrictionData } from "@crowbartools/firebot-custom-scripts-types/types/modules/command-manager";
+import { IntegrationConstants } from "../constants";
+import { firebot } from "../main";
+import { kickifyUserId, kickifyUsername } from "../internal/util";
+import { JsonDB } from "node-json-db";
+import { logger } from "../main";
+declare const SCRIPTS_DIR: string; // Hack to get profile directory
+
+type triggerCustomChannelRewardParams = {
+    channelRewardId: string;
+    selectionMode: 'select' | 'title';
+}
+
+interface ImageSet {
+    url1x: string;
+    url2x: string;
+    url4x: string;
+}
+
+interface CustomReward {
+    broadcasterId: string;
+    broadcasterLogin: string;
+    broadcasterName: string;
+    id: string;
+    title: string;
+    prompt: string;
+    cost: number;
+    image?: ImageSet;
+    defaultImage: ImageSet;
+    backgroundColor: string;
+    isEnabled: boolean;
+    isUserInputRequired: boolean;
+    maxPerStreamSetting: {
+        isEnabled: boolean;
+        maxPerStream: number;
+    };
+    maxPerUserPerStreamSetting: {
+        isEnabled: boolean;
+        maxPerUserPerStream: number;
+    };
+    globalCooldownSetting: {
+        isEnabled: boolean;
+        globalCooldownSeconds: number;
+    };
+    isPaused: boolean;
+    isInStock: boolean;
+    shouldRedemptionsSkipRequestQueue: boolean;
+    redemptionsRedeemedCurrentStream?: number;
+    cooldownExpiresAt?: Date;
+}
+
+type SavedChannelReward = {
+    id: string,
+    twitchData: CustomReward,
+    manageable: boolean,
+    effects?: Effects.EffectList,
+    effectsFulfilled?: Effects.EffectList,
+    effectsCanceled?: Effects.EffectList,
+    restrictionData?: RestrictionData,
+    autoApproveRedemptions?: boolean,
+};
+
+type RewardRedemptionMetadata = {
+    username: string,
+    userId: string,
+    userDisplayName: string,
+    messageText: string,
+    redemptionId: string,
+    rewardId: string,
+    rewardImage: string,
+    rewardName: string,
+    rewardCost: number,
+};
+
+export const triggerCustomChannelRewardEffect: Firebot.EffectType<triggerCustomChannelRewardParams> = {
+    definition: {
+        id: `${IntegrationConstants.INTEGRATION_ID}:trigger-custom-channel-reward`,
+        name: "Trigger Custom Channel Reward Handler",
+        description: "Trigger the effects of a custom channel reward as if the user had redeemed it on Twitch. (Caution: No cooldowns are enforced!)",
+        icon: "fad fa-comment-lines",
+        categories: ["common"]
+    },
+    optionsTemplate: `
+        <eos-container>
+            <p class="muted">This will trigger the effects of a custom channel reward as if the user had redeemed it on Twitch. No cooldowns are enforced, so use with caution!</p>
+        </eos-container>
+        <eos-container header="Channel Reward" pad-top="true">
+            <firebot-radios options="targetOptions" model="effect.selectionMode" />
+
+            <firebot-searchable-select
+                ng-model="effect.channelRewardId"
+                items="manageableRewards"
+                placeholder="Select or search for a channel reward..."
+                ng-if="effect.selectionMode === 'select'"
+            />
+        </eos-container>
+    `,
+    optionsController: ($scope, channelRewardsService: any) => {
+        if (!$scope.effect) {
+            $scope.effect = {
+                channelRewardId: "",
+                selectionMode: 'select'
+            };
+        }
+
+        if ($scope.effect.selectionMode === undefined) {
+            $scope.effect.selectionMode = 'select';
+        }
+
+        $scope.targetOptions = {
+            title: "Match Reward Title",
+            select: "Select a channel reward"
+        };
+
+        $scope.manageableRewards = channelRewardsService
+            .channelRewards.filter((r: SavedChannelReward) => r.manageable)
+            .map((r: SavedChannelReward) => ({ id: r.twitchData.id, name: r.twitchData.title }));
+    },
+    optionsValidator: (effect) => {
+        const errors = [];
+        if (effect.selectionMode === 'select') {
+            if (!effect.channelRewardId || effect.channelRewardId === "") {
+                errors.push("Channel Reward ID is required when using 'Select' mode.");
+            }
+        } else if (effect.selectionMode !== 'title') {
+            errors.push("Invalid selection mode. Must be 'select' or 'title'.");
+        }
+        return errors;
+    },
+    onTriggerEvent: async ({ effect, trigger }) => {
+        const { effectRunner, JsonDb, path, restrictionManager } = firebot.modules;
+
+        // This is terrible and I'm sorry. Firebot doesn't expose the channel
+        // reward manager to scripts.
+        const jsonDb = JsonDb as JsonDB;
+        if (!jsonDb) {
+            throw new Error("JsonDB module is not available.");
+        }
+
+        const customRewardsDbPath = path.join(SCRIPTS_DIR, '..', 'channel-rewards.json');
+        let channelRewardsData: Record<string, SavedChannelReward> = {};
+        try {
+            const db = new JsonDB(customRewardsDbPath, false, false);
+            db.load();
+            channelRewardsData = db.getData("/") || {};
+        } catch (error) {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] Error loading JsonDB at ${customRewardsDbPath}. Cannot trigger custom channel reward effects.`, error);
+            return false;
+        }
+
+        const rewards = Object.values(channelRewardsData);
+        let channelReward: SavedChannelReward | undefined;
+        const rewardTitle = typeof trigger.metadata.eventData?.rewardName === "string" ? trigger.metadata.eventData.rewardName : "";
+
+        if (effect.selectionMode === 'select') {
+            channelReward = rewards.find((r: SavedChannelReward) => r.id === effect.channelRewardId);
+        } else if (effect.selectionMode === 'title') {
+            channelReward = rewards.find((r: SavedChannelReward) => r.twitchData.title.toLowerCase() === rewardTitle.toLowerCase());
+        }
+
+        if (!channelReward) {
+            logger.error(`Channel reward with ID ${effect.channelRewardId} or title ${rewardTitle} not found.`);
+            return false;
+        }
+
+        if (!channelReward.effects) {
+            logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] Channel reward ${channelReward.twitchData.title} has no effects to trigger.`);
+            return true;
+        }
+
+        const metadata: RewardRedemptionMetadata = {
+            username: kickifyUsername(trigger.metadata.username),
+            userId: kickifyUserId(
+                typeof trigger.metadata.eventData?.userId === "string" || typeof trigger.metadata.eventData?.userId === "number"
+                    ? trigger.metadata.eventData.userId
+                    : ""
+            ),
+            userDisplayName: typeof trigger.metadata.eventData?.userDisplayName === "string"
+                ? trigger.metadata.eventData.userDisplayName
+                : trigger.metadata.username,
+            messageText: typeof trigger.metadata.eventData?.messageText === "string"
+                ? trigger.metadata.eventData.messageText
+                : "",
+            redemptionId: typeof trigger.metadata.eventData?.redemptionId === "string"
+                ? trigger.metadata.eventData.redemptionId
+                : crypto.randomUUID(), // Generate a unique ID if not provided
+            rewardId: channelReward.id,
+            rewardImage: channelReward.twitchData.image?.url1x || channelReward.twitchData.defaultImage.url1x,
+            rewardName: channelReward.twitchData.title,
+            rewardCost: channelReward.twitchData.cost || 0
+        };
+
+        const restrictionData = channelReward.restrictionData;
+        if (restrictionData) {
+            try {
+                await restrictionManager.runRestrictionPredicates(trigger, restrictionData, false);
+                logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Restrictions passed for user ${metadata.username} (${metadata.userId}) on reward ${channelReward.twitchData.title}`);
+            } catch (restrictionReason) {
+                let reason;
+                if (Array.isArray(restrictionReason)) {
+                    reason = restrictionReason.join(", ");
+                } else {
+                    reason = restrictionReason;
+                }
+                logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] Restrictions failed for user ${metadata.username} (${metadata.userId}) on reward ${channelReward.twitchData.title}: ${reason}`);
+                return false;
+            }
+        }
+
+        const processEffectsRequest = {
+            trigger: {
+                type: trigger.type,
+                metadata: metadata
+            },
+            effects: channelReward.effects || []
+        };
+
+        try {
+            await effectRunner.processEffects(processEffectsRequest);
+        } catch (reason) {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] Error when running effects for ${metadata.redemptionId}: ${reason}`);
+            return false;
+        }
+
+        // If we reach here, it means the effects were successfully triggered.
+        logger.info(`[${IntegrationConstants.INTEGRATION_ID}] Successfully triggered effects for channel reward ${channelReward.twitchData.title} (ID: ${channelReward.id}) for user ${metadata.username} (${metadata.userId})`);
+        return true;
+    }
+};

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -152,6 +152,32 @@ export const eventSource: EventSource = {
                     return message;
                 }
             }
+        },
+        {
+            id: "channel-reward-redemption",
+            name: "Channel Reward Redemption (Kick)",
+            description: "When someone redeems a channel reward on Kick",
+            cached: false,
+            manualMetadata: {
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
+                rewardName: "Test Reward",
+                messageText: "Test message"
+            },
+            activityFeed: {
+                icon: "fad fa-circle",
+                getMessage: (eventData) => {
+                    const username = typeof eventData.username === "string" ? eventData.username : "";
+                    const userDisplayName = typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : "";
+                    const showUserIdName = username.toLowerCase() !== userDisplayName.toLowerCase();
+                    return `**${userDisplayName}${
+                        showUserIdName ? ` (${username})` : ""
+                    }** redeemed **${eventData.rewardName}**${
+                        typeof eventData.messageText === "string" && eventData.messageText.length > 0 ? `: *${eventData.messageText}*` : ""
+                    }`;
+                }
+            }
         }
     ]
 };

--- a/src/events/reward-redeemed-event.ts
+++ b/src/events/reward-redeemed-event.ts
@@ -1,0 +1,45 @@
+import * as crypto from 'crypto';
+import { IntegrationConstants } from "../constants";
+import { kickifyUserId, kickifyUsername } from "../internal/util";
+import { firebot } from "../main";
+import { RewardRedeemedEvent } from "../shared/types";
+
+export async function handleRewardRedeemedEvent(payload: RewardRedeemedEvent): Promise<void> {
+    const redemptionId = crypto.randomUUID(); // Generate a unique ID for the redemption
+    const rewardId = crypto.createHash('sha256').update(payload.rewardTitle).digest('hex');
+
+    const { frontendCommunicator } = firebot.modules;
+    frontendCommunicator.send("twitch:chat:rewardredemption", {
+        id: redemptionId,
+        queued: false,
+        messageText: payload.userInput,
+        user: {
+            id: kickifyUserId(payload.userId),
+            username: kickifyUsername(payload.username),
+            displayName: payload.username
+        },
+        reward: {
+            id: rewardId, // Simulate a reward ID based on the title
+            name: payload.rewardTitle,
+            cost: 0, // Cost is not provided in the event
+            imageUrl: "" // Image URL is not provided in the event
+        }
+    });
+
+    // This event is so different from Twitch's reward redeemed event that we
+    // cannot use the same function.
+    const { eventManager } = firebot.modules;
+    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "channel-reward-redemption", {
+        username: kickifyUsername(payload.username),
+        userId: kickifyUserId(payload.userId),
+        userDisplayName: payload.username,
+        messageText: payload.userInput,
+        args: (payload.userInput || "").split(" "),
+        rewardId: rewardId,
+        rewardImage: "",
+        rewardName: payload.rewardTitle,
+        rewardDescription: payload.rewardTitle, // No description provided
+        rewardCost: 0, // No cost provided
+        rewardBackgroundColor: payload.rewardBackgroundColor || "#FFFFFF" // Default to white if not provided
+    });
+}

--- a/src/filters/reward-title.ts
+++ b/src/filters/reward-title.ts
@@ -1,0 +1,98 @@
+import { EventFilter } from "@crowbartools/firebot-custom-scripts-types/types/modules/event-filter-manager";
+import { IntegrationConstants } from "../constants";
+import { logger } from "../main";
+
+enum ComparisonType {
+    IS = "is",
+    IS_NOT = "is not",
+    CONTAINS = "contains",
+    DOESNT_CONTAIN = "doesn't contain",
+    DOESNT_STARTS_WITH = "doesn't start with",
+    STARTS_WITH = "starts with",
+    DOESNT_END_WITH = "doesn't end with",
+    ENDS_WITH = "ends with",
+    MATCHES_REGEX_CS = "matches regex (case-sensitive)",
+    DOESNT_MATCH_REGEX_CS = "doesn't match regex (case-sensitive)",
+    MATCHES_REGEX = "matches regex",
+    DOESNT_MATCH_REGEX = "doesn't match regex"
+}
+
+export const rewardTitleFilter: EventFilter = {
+    id: `${IntegrationConstants.INTEGRATION_ID}:reward-title`,
+    name: "Reward Title",
+    description: "Checks if the reward title equals or matches the provided value. Comparisons are case-insensitive.",
+    events: [
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "channel-reward-redemption" }
+    ],
+    comparisonTypes: [
+        ComparisonType.IS,
+        ComparisonType.IS_NOT,
+        ComparisonType.CONTAINS,
+        ComparisonType.DOESNT_CONTAIN,
+        ComparisonType.STARTS_WITH,
+        ComparisonType.DOESNT_STARTS_WITH,
+        ComparisonType.ENDS_WITH,
+        ComparisonType.DOESNT_END_WITH,
+        ComparisonType.MATCHES_REGEX_CS,
+        ComparisonType.DOESNT_MATCH_REGEX_CS,
+        ComparisonType.MATCHES_REGEX,
+        ComparisonType.DOESNT_MATCH_REGEX
+    ],
+    valueType: "text",
+    predicate: async (
+        filterSettings,
+        eventData: {
+            eventMeta: {
+                rewardName?: string;
+            }
+        }
+    ): Promise<boolean> => {
+        const { comparisonType, value } = filterSettings;
+        const rewardName = eventData.eventMeta.rewardName || "";
+        return compareValue(comparisonType as ComparisonType, value, rewardName);
+    }
+};
+
+function compareValue(
+    comparisonType: ComparisonType,
+    expectedValue: unknown,
+    actualValue: unknown
+): boolean {
+    logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Comparing values: type=${comparisonType}, expected='${expectedValue}', actual='${actualValue}'`);
+    switch (comparisonType) {
+        case ComparisonType.IS:
+            return actualValue === expectedValue;
+        case ComparisonType.IS_NOT:
+            return actualValue !== expectedValue;
+        case ComparisonType.CONTAINS:
+            return actualValue?.toString().includes(expectedValue?.toString() ?? "") || false;
+        case ComparisonType.DOESNT_CONTAIN:
+            return !actualValue?.toString().includes(expectedValue?.toString() ?? "");
+        case ComparisonType.STARTS_WITH:
+            return actualValue?.toString().startsWith(expectedValue?.toString() ?? "") || false;
+        case ComparisonType.DOESNT_STARTS_WITH:
+            return !actualValue?.toString().startsWith(expectedValue?.toString() ?? "");
+        case ComparisonType.ENDS_WITH:
+            return actualValue?.toString().endsWith(expectedValue?.toString() ?? "") || false;
+        case ComparisonType.DOESNT_END_WITH:
+            return !actualValue?.toString().endsWith(expectedValue?.toString() ?? "");
+        case ComparisonType.MATCHES_REGEX: {
+            const regex = new RegExp(expectedValue?.toString() ?? "", "gi");
+            return regex.test(actualValue?.toString() ?? "");
+        }
+        case ComparisonType.DOESNT_MATCH_REGEX: {
+            const regex = new RegExp(expectedValue?.toString() ?? "", "gi");
+            return !regex.test(actualValue?.toString() ?? "");
+        }
+        case ComparisonType.MATCHES_REGEX_CS: {
+            const regex = new RegExp(expectedValue?.toString() ?? "", "g");
+            return regex.test(actualValue?.toString() ?? "");
+        }
+        case ComparisonType.DOESNT_MATCH_REGEX_CS: {
+            const regex = new RegExp(expectedValue?.toString() ?? "", "g");
+            return !regex.test(actualValue?.toString() ?? "");
+        }
+        default:
+            return false;
+    }
+}

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -5,7 +5,9 @@ import { chatEffect } from "./effects/chat";
 import { chatPlatformEffect } from "./effects/chat-platform";
 import { streamGameEffect } from "./effects/stream-game";
 import { streamTitleEffect } from "./effects/stream-title";
+import { triggerCustomChannelRewardEffect } from "./effects/trigger-custom-channel-reward";
 import { eventSource } from './event-source';
+import { rewardTitleFilter } from "./filters/reward-title";
 import { AuthManager } from "./internal/auth";
 import { Kick } from "./internal/kick";
 import { Poller } from "./internal/poll";
@@ -13,7 +15,6 @@ import { KickPusher } from "./internal/pusher/pusher";
 import { firebot, logger } from "./main";
 import { platformRestriction } from "./restrictions/platform";
 import { getDataFilePath } from "./util/datafile";
-import { kickTimeoutDurationVariable } from "./variables/timeout-duration";
 import { kickCategoryVariable } from "./variables/category";
 import { kickCategoryIdVariable } from "./variables/category-id";
 import { kickCategoryImageUrlVariable } from "./variables/category-image-url";
@@ -22,10 +23,14 @@ import { kickChatMessageVariable } from "./variables/chat-message";
 import { kickCurrentViewerCountVariable } from "./variables/current-viewer-count";
 import { kickModReason } from "./variables/mod-reason";
 import { kickModerator } from "./variables/moderator";
+import { kickRewardIdVariable } from "./variables/reward-id";
+import { kickRewardMessageVariable } from "./variables/reward-message";
+import { kickRewardNameVariable } from "./variables/reward-name";
 import { kickStreamIsLiveVariable } from "./variables/stream-is-live";
 import { kickStreamTitleVariable } from "./variables/stream-title";
 import { kickStreamerVariable } from "./variables/streamer";
 import { kickStreamerIdVariable } from "./variables/streamer-id";
+import { kickTimeoutDurationVariable } from "./variables/timeout-duration";
 import { kickUptimeVariable } from "./variables/uptime";
 import { kickUserDisplayNameVariable } from "./variables/user-display-name";
 
@@ -133,26 +138,49 @@ export class KickIntegration extends EventEmitter {
         effectManager.registerEffect(chatPlatformEffect);
         effectManager.registerEffect(streamGameEffect);
         effectManager.registerEffect(streamTitleEffect);
+        effectManager.registerEffect(triggerCustomChannelRewardEffect);
 
         const { eventManager } = firebot.modules;
         eventManager.registerEventSource(eventSource);
 
+        const { eventFilterManager } = firebot.modules;
+        eventFilterManager.registerFilter(rewardTitleFilter);
+
         const { replaceVariableManager } = firebot.modules;
+
+        // Category variables
         replaceVariableManager.registerReplaceVariable(kickCategoryIdVariable);
         replaceVariableManager.registerReplaceVariable(kickCategoryImageUrlVariable);
         replaceVariableManager.registerReplaceVariable(kickCategoryVariable);
+
+        // Channel variables
         replaceVariableManager.registerReplaceVariable(kickChannelIdVariable);
+
+        // Chat variables
         replaceVariableManager.registerReplaceVariable(kickChatMessageVariable);
-        replaceVariableManager.registerReplaceVariable(kickCurrentViewerCountVariable);
+
+        // Streamer variables
         replaceVariableManager.registerReplaceVariable(kickStreamerIdVariable);
         replaceVariableManager.registerReplaceVariable(kickStreamerVariable);
+
+        // Stream variables
+        replaceVariableManager.registerReplaceVariable(kickCurrentViewerCountVariable);
         replaceVariableManager.registerReplaceVariable(kickStreamIsLiveVariable);
         replaceVariableManager.registerReplaceVariable(kickStreamTitleVariable);
         replaceVariableManager.registerReplaceVariable(kickUptimeVariable);
+
+        // User variables
         replaceVariableManager.registerReplaceVariable(kickUserDisplayNameVariable);
-        replaceVariableManager.registerReplaceVariable(kickTimeoutDurationVariable);
+
+        // Ban and timeout variables
         replaceVariableManager.registerReplaceVariable(kickModReason);
         replaceVariableManager.registerReplaceVariable(kickModerator);
+        replaceVariableManager.registerReplaceVariable(kickTimeoutDurationVariable);
+
+        // Reward variables
+        replaceVariableManager.registerReplaceVariable(kickRewardIdVariable);
+        replaceVariableManager.registerReplaceVariable(kickRewardNameVariable);
+        replaceVariableManager.registerReplaceVariable(kickRewardMessageVariable);
 
         const { restrictionManager } = firebot.modules;
         restrictionManager.registerRestriction(platformRestriction);

--- a/src/internal/pusher/rewardredeemedevent.d.ts
+++ b/src/internal/pusher/rewardredeemedevent.d.ts
@@ -1,0 +1,8 @@
+interface RewardRedeemedEventData {
+    reward_title: string;
+    user_id: number;
+    channel_id: number;
+    username: string;
+    user_input: string;
+    reward_background_color: string;
+}

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -1,9 +1,9 @@
-export function kickifyUserId(userId: string): string {
-    return userId.startsWith("k") ? userId : `k${userId}`;
+export function kickifyUserId(userId: string | number): string {
+    return String(userId).startsWith("k") ? String(userId) : `k${userId}`;
 }
 
-export function unkickifyUserId(userId: string): string {
-    return userId.startsWith("k") ? userId.substring(1) : userId;
+export function unkickifyUserId(userId: string | number): string {
+    return String(userId).startsWith("k") ? String(userId).substring(1) : String(userId);
 }
 
 export function kickifyUsername(username: string): string {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -89,3 +89,12 @@ export interface ModerationBannedEvent {
     bannedUser: KickUser;
     metadata: ModerationBannedMetadata;
 }
+
+export interface RewardRedeemedEvent {
+    rewardTitle: string;
+    userId: number;
+    channelId: number;
+    username: string;
+    userInput: string;
+    rewardBackgroundColor: string;
+}

--- a/src/variables/reward-id.ts
+++ b/src/variables/reward-id.ts
@@ -1,0 +1,31 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../constants';
+import * as crypto from 'crypto';
+
+const triggers: Effects.TriggersObject = {};
+triggers["event"] = [`${IntegrationConstants.INTEGRATION_ID}:channel-reward-redemption`];
+triggers["manual"] = true;
+triggers["preset"] = true;
+
+export const kickRewardIdVariable : ReplaceVariable = {
+    definition: {
+        handle: "kickRewardId",
+        description: "The ID of the reward. Since Kick does not provide reward IDs, this is a hashed value of the reward title.",
+        categories: ["common"],
+        possibleDataOutput: ["text"]
+    },
+    evaluator: async (trigger) => {
+        if (trigger.metadata.eventData?.rewardId) {
+            return trigger.metadata.eventData.rewardId;
+        }
+
+        // If no reward ID is provided, we generate a hash based on the reward title.
+        if (typeof trigger.metadata.eventData?.rewardTitle === 'string' && trigger.metadata.eventData.rewardTitle.length > 0) {
+            return crypto.createHash('sha256').update(trigger.metadata.eventData.rewardTitle, 'utf8').digest('hex');
+        }
+
+        // If no reward title is available, return an empty string.
+        return "";
+    }
+};

--- a/src/variables/reward-message.ts
+++ b/src/variables/reward-message.ts
@@ -1,0 +1,19 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../constants';
+
+const triggers: Effects.TriggersObject = {};
+triggers["event"] = [`${IntegrationConstants.INTEGRATION_ID}:channel-reward-redemption`];
+triggers["manual"] = true;
+
+export const kickRewardMessageVariable : ReplaceVariable = {
+    definition: {
+        handle: "kickRewardMessage",
+        description: "The reward message text.",
+        categories: ["common"],
+        possibleDataOutput: ["text"]
+    },
+    evaluator: async (trigger) => {
+        return (trigger.metadata.eventData ? trigger.metadata.eventData.rewardMessage || trigger.metadata.messageText : "") || "";
+    }
+};

--- a/src/variables/reward-name.ts
+++ b/src/variables/reward-name.ts
@@ -1,0 +1,20 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../constants';
+
+const triggers: Effects.TriggersObject = {};
+triggers["event"] = [`${IntegrationConstants.INTEGRATION_ID}:channel-reward-redemption`];
+triggers["manual"] = true;
+triggers["preset"] = true;
+
+export const kickRewardNameVariable : ReplaceVariable = {
+    definition: {
+        handle: "kickRewardName",
+        description: "The name of the reward",
+        categories: ["common"],
+        possibleDataOutput: ["text"]
+    },
+    evaluator: async (trigger) => {
+        return trigger.metadata.eventData ? trigger.metadata.eventData.rewardName : trigger.metadata.rewardName;
+    }
+};


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This adds support for channel point redemptions.
- Event (Channel Reward Redemption)
- Effect (Trigger Custom Channel Reward Handler)
- Various variables

Note: The Kick event does not include metadata about how many channel points were redeemed. In addition, there are no API endpoints to approve/reject awards, and no support at all for disabling/pausing awards.

### Motivation
This allows Kick channel point rewards. And if there are already Twitch channel point rewards configured, they can be re-used.

### Testing
Verified by redeeming my own channel points.
