### PR TITLE
Channel Data Updated event

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Currently supported:
   - Restrictions for commands generally work
   - A custom restriction is shipped with this integration (trigger platform)
 - Events
+  - Channel data updated
   - Channel points redeemed
   - Chat message
   - Follow

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -178,6 +178,17 @@ export const eventSource: EventSource = {
                     }`;
                 }
             }
+        },
+        {
+            id: "channel-data-updated",
+            name: "Channel Data Updated (Kick)",
+            description: "When the channel data is updated on Kick (this happens periodically)",
+            cached: false,
+            manualMetadata: {
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: ""
+            }
         }
     ]
 };

--- a/src/internal/channel-manager.ts
+++ b/src/internal/channel-manager.ts
@@ -1,8 +1,9 @@
 import * as NodeCache from 'node-cache';
 import { IntegrationConstants } from "../constants";
-import { logger } from "../main";
+import { firebot, logger } from "../main";
 import { CategoryInfo, Channel } from "../shared/types";
 import { Kick } from "./kick";
+import { kickifyUserId, kickifyUsername, unkickifyUsername } from './util';
 import { parseChannel } from "./webhook-handler/webhook-handler";
 
 export class KickChannelManager {
@@ -60,25 +61,53 @@ export class KickChannelManager {
     }
 
     async getChannel(username: string | number = 0): Promise<Channel> {
+        let cacheKey = "";
+        let cacheValue: Channel | null | undefined = null;
+        if (typeof username === "number" || (typeof username === "string" && username.length > 0 && !isNaN(Number(username)))) {
+            const userId = Number(username);
+            if (userId === 0 || userId === this.kick.broadcaster?.userId) {
+                cacheKey = 'this_channel';
+                cacheValue = this.channel;
+            } else {
+                cacheKey = `b_${userId}`;
+                cacheValue = this.channelCache.get(cacheKey);
+            }
+        } else if (typeof username === "string") {
+            if (unkickifyUsername(username).length === 0 || unkickifyUsername(username).toLowerCase() === this.channel?.slug.toLowerCase()) {
+                cacheKey = 'this_channel';
+                cacheValue = this.channel;
+            } else {
+                cacheKey = `u_${username.toLowerCase()}`;
+                cacheValue = this.channelCache.get(cacheKey);
+            }
+        }
+        if (cacheValue) {
+            logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Returning cached channel for key=${cacheKey}, username='${username}'`);
+            return cacheValue;
+        }
+
+        logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Retrieving channel for username: '${username}'`);
+        try {
+            const response = await this.getChannelReal(username);
+            if (cacheKey === 'this_channel') {
+                this.channel = response;
+            } else {
+                this.channelCache.set(cacheKey, response);
+            }
+            return response;
+        } catch (error) {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] Error retrieving channel: ${error}`);
+            throw error;
+        }
+    }
+
+    private async getChannelReal(username: string | number = 0): Promise<Channel> {
         return new Promise((resolve, reject) => {
             const formVariables = new URLSearchParams();
-            let cacheKey = "";
-
             if (typeof username === "string" && username.length > 0) {
                 formVariables.append("slug", username);
-                cacheKey = `u_${username.toLowerCase()}`;
             } else if (typeof username === "number" && username > 0) {
                 formVariables.append("broadcaster_user_id", username.toString());
-                cacheKey = `b_${username.toString()}`;
-            }
-
-            if (cacheKey) {
-                const cachedChannel = this.channelCache.get(cacheKey);
-                if (cachedChannel) {
-                    logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Returning cached channel for key: ${cacheKey}`);
-                    resolve(cachedChannel as Channel);
-                    return;
-                }
             }
 
             const uri = `/public/v1/channels${formVariables.toString().length > 0 ? `?${formVariables.toString()}` : ''}`;
@@ -86,11 +115,6 @@ export class KickChannelManager {
                 .then((response) => {
                     logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Successfully retrieved channel status for ${username || '(you)'}`);
                     const channel = parseChannel(response);
-                    if (cacheKey) {
-                        this.channelCache.set(cacheKey, channel);
-                    } else {
-                        this.channel = channel;
-                    }
                     resolve(channel);
                 })
                 .catch((error) => {
@@ -100,9 +124,10 @@ export class KickChannelManager {
     }
 
     private refreshChannel(): void {
-        this.getChannel()
+        this.getChannelReal()
             .then((channelStatus: Channel) => {
                 this.channel = channelStatus;
+                this.triggerChannelDataUpdatedEvent();
                 logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Channel status updated: isLive=${channelStatus.stream.isLive}, title=${channelStatus.streamTitle || ''}, category=${channelStatus.category.id}, viewers=${channelStatus.stream.viewerCount}`);
             })
             .catch((error) => {
@@ -155,6 +180,7 @@ export class KickChannelManager {
         }
 
         logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Category updated to id=${categoryId} name=${this.channel.category.name}.`);
+        this.triggerChannelDataUpdatedEvent();
         return true;
     }
 
@@ -175,6 +201,7 @@ export class KickChannelManager {
         }
 
         this.channel.streamTitle = title;
+        this.triggerChannelDataUpdatedEvent();
         logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Title updated to "${title}".`);
         return true;
     }
@@ -191,7 +218,25 @@ export class KickChannelManager {
         }
 
         this.channel.stream.isLive = isLive;
+        this.triggerChannelDataUpdatedEvent();
         logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Live status updated to ${isLive}.`);
         return true;
+    }
+
+    private triggerChannelDataUpdatedEvent(): void {
+        if (!this.channel) {
+            return;
+        }
+        const { eventManager } = firebot.modules;
+        eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "channel-data-updated", {
+            username: kickifyUsername(this.kick.broadcaster?.name || ""),
+            userDisplayName: this.kick.broadcaster?.name || "",
+            userId: kickifyUserId(this.kick.broadcaster?.userId || ""),
+            isLive: this.channel.stream.isLive,
+            title: this.channel.streamTitle || "",
+            categoryId: this.channel.category.id,
+            categoryName: this.channel.category.name,
+            viewers: this.channel.stream.viewerCount || 0
+        });
     }
 }


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Event triggers when the channel data is updated, either periodically through polling or after refreshing due to an event. Also this has better caching behavior for custom variables that depend on channel details.

### Motivation
This could be used to export variables elsewhere. For example I send `$kickViewerCount` to Companion via HTTP.

### Testing
Added this event to my setup and sending Kick viewer count to Companion via HTTP.
