### PR TITLE
Support local app with no webhook proxy

### DIFF
--- a/src/internal/http.ts
+++ b/src/internal/http.ts
@@ -27,7 +27,11 @@ export async function httpCallWithTimeout(
             headers["Authorization"] = `Bearer ${authToken}`;
         }
         if (body) {
-            headers["Content-Type"] = "application/json";
+            if (/^[^=]+=[^=]+(&[^=]+=[^=]+)*$/.test(body)) {
+                headers["Content-Type"] = "application/x-www-form-urlencoded";
+            } else {
+                headers["Content-Type"] = "application/json";
+            }
         }
         headers["Accept"] = "application/json";
 

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -60,6 +60,11 @@ export class Kick {
     }
 
     async subscribeToEvents(): Promise<void> {
+        if (!integration.getSettings().webhookProxy.webhookProxyUrl) {
+            logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Webhook proxy URL not set, skipping event subscription.`);
+            return;
+        }
+
         const payload = {
             events: [
                 {
@@ -96,7 +101,7 @@ export class Kick {
 
     async httpCallWithTimeout(uri: string, method: string, body = '', signal: AbortSignal | null = null, timeout = 10000): Promise<any> {
         const requestId = crypto.randomUUID();
-        if (integration.getSettings().advanced.logApiResponses) {
+        if (integration.getSettings().logging.logApiResponses) {
             logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] [${requestId}] Making API call to ${uri} with method ${method} and body: ${JSON.stringify(body)}`);
         }
 
@@ -110,12 +115,12 @@ export class Kick {
                 timeout
             );
 
-            if (integration.getSettings().advanced.logApiResponses) {
+            if (integration.getSettings().logging.logApiResponses) {
                 logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] [${requestId}] API call to ${uri} successful. Response: ${JSON.stringify(response)}`);
             }
             return response;
         } catch (error) {
-            if (integration.getSettings().advanced.logApiResponses) {
+            if (integration.getSettings().logging.logApiResponses) {
                 logger.error(`[${IntegrationConstants.INTEGRATION_ID}] [${requestId}] API call to ${uri} failed: ${error}`);
             }
             throw error;

--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -16,19 +16,19 @@ export class KickPusher {
         if (!pusherAppKey) {
             logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] Pusher cannot connect: App Key is missing.`);
             this.pusher = null;
-            return;
+            throw new Error("Pusher App Key is required");
         }
 
         if (!channelId && !chatroomId) {
             logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] Pusher will not connect: No subscriptions available (Channel ID and Chatroom ID are both missing).`);
             this.pusher = null;
-            return;
+            throw new Error("Pusher Channel ID and Chatroom ID are required");
         }
 
         logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Pusher connecting (app key: ${pusherAppKey}...`);
 
         Pusher.log = (message: any) => {
-            if (integration.getSettings().advanced.logWebsocketEvents) {
+            if (integration.getSettings().logging.logWebsocketEvents) {
                 logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Pusher log: ${message}`);
             }
         };

--- a/src/internal/webhook-handler/webhook-handler.ts
+++ b/src/internal/webhook-handler/webhook-handler.ts
@@ -9,7 +9,7 @@ import { BasicKickUser, Channel, ChatMessage, KickFollower, KickUser, Livestream
 import { parseDate } from "../util";
 
 export async function handleWebhook(webhook: InboundWebhook): Promise<void> {
-    if (integration.getSettings().advanced.logWebhooks) {
+    if (integration.getSettings().logging.logWebhooks) {
         logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Received webhook: ${JSON.stringify(webhook)}`);
     }
 


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Allows the user to set up a Kick app and supply the client ID and secret, and thus avoid needing a webhook proxy. This also moves around some of the settings a bit.

### Motivation
This should make the setup a bit easier for users who do not need the full event set provided by the webhook proxy.

### Testing
Authenticated myself with a local app and via webhook proxy, both work.
