### PR TITLE
Properly report username of someone who chatted and then followed

### DIFF
--- a/src/events/chat-message-sent.ts
+++ b/src/events/chat-message-sent.ts
@@ -36,7 +36,7 @@ export async function handleChatMessageSentEvent(payload: ChatMessage): Promise<
     }
 
     // Increment message count for user
-    const viewer = await integration.kick.userManager.getViewerById(payload.sender.userId);
+    const viewer = await integration.kick.userManager.getOrCreateViewer(payload.sender);
     await integration.kick.userManager.countChatMessage(viewer._id, 1);
 
     // Command checking.

--- a/src/events/follower.ts
+++ b/src/events/follower.ts
@@ -4,7 +4,7 @@ import { KickFollower } from "../shared/types";
 
 export async function handleFollowerEvent(payload: KickFollower): Promise<void> {
     // Create the user if they don't exist
-    const viewer = await integration.kick.userManager.getViewer(payload.follower);
+    const viewer = await integration.kick.userManager.getOrCreateViewer(payload.follower);
 
     // Trigger the follow event
     const { eventManager } = firebot.modules;


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Update the user creation code in the chat handler so that it passes a full user to the mechanism that counts chat messages. If the first interaction of the user was chatting, the back end stored the user's username and display name as their user ID. If they then followed, it would report their username as their user ID.

### Motivation
It was weird that `#########` instead of their actual name got acknowledged for a follow...

### Testing
Tested chat -> follow and follow -> chat to confirm that everything was correct.
