### PR TITLE
Granular forwarding to Twitch events

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -99,9 +99,31 @@ Here's how to do it:
         >
         > Yes, you are free to use tools that are for your personal use. The prohibition on third-party tools only applies to content presented to viewers either on or off Twitch.
 
+    - **Trigger Twitch Events**
+
+        In short: with great power comes great responsibility. **If you do not know exactly what you are doing, or you are not careful about validating your effect lists for both platforms, then you should NOT use these options!**
+
+        Checking any of these boxes will trigger the Firebot Twitch event corresponding to the Kick event. For example, if you check the box for "Chat Message" in this section, then whenever a message is posted in your Kick chat, both the "Chat Message (Kick)" and the "Chat Message (Twitch)" events will be triggered in Firebot. You could then put all of the logic in the "Chat Message (Twitch)" event and not need to duplicate all of that logic in the "Chat Message (Kick)" event.
+
+        This can help reduce the amount of repetitive code if you are doing the same things in your Kick and Twitch handlers. In addition, you can check the `$platform` variable in any conditional effects: it will always be set to `kick` for events originating from Kick.
+
+        Note that another way to do this is to define a preset effect list. For example, you could add a preset effect list for "Handle Chat Message" and call that preset effect list from both the "Chat Message (Kick)" and the "Chat Message (Twitch)" events. If you set things up that way, then you do not need to check the boxes in this section.
+
+        :warning: **CAUTION**: If you intend to have a combined event handler, be sure that you have thoroughly reviewed the effects it triggers. For example:
+
+          - Are you using the default "Chat" effect built into Firebot to send a response? This will always send the message to Twitch, even to reply to a message posted on Kick! (You probably need to convert this to the "Chat (Platform Aware)" effect distributed with this integration.)
+
+          - Are you using the "Chat Message" event to route messages to a chat overlay, such as with the [Mage Onscreen Chat](https://github.com/TheStaticMage/firebot-mage-onscreen-chat) overlay? If so, you might be running afoul of the Twitch terms of service by merging chat messages from multiple platforms on your stream.
+
+          - Are you adding or removing VIP or moderator status from a user, banning a user, timing out a user, etc., as a result of an event? If the event comes in via Kick, this may have unexpected results when the API calls are sent to Twitch because the User IDs will be different.
+
+        Note: Triggering the equivalent Firebot Twitch events is _in addition to_ triggering the Kick events supplied by this integration. (The Kick variants of these events will always be triggered, whether or not you have the box checked to trigger the equivalent Twitch event.)
+
     - **Logging Settings**
 
         If you are developing or troubleshooting the integration, enabling additional logging events may help.
+
+        These messages are logged at the "debug" level. For this to be useful, you also need to have debug logging enabled in the global settings for Firebot (Settings &lt; Advanced &lt; Enable Debug Mode and then restart Firebot).
 
     - **Advanced Settings**
 

--- a/src/conditions/__tests__/platform.test.ts
+++ b/src/conditions/__tests__/platform.test.ts
@@ -1,0 +1,74 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { platformCondition } from '../platform';
+
+describe('platformCondition.predicate', () => {
+    const baseTrigger: Effects.Trigger = {
+        type: 'event',
+        metadata: {
+            username: '',
+            eventData: {},
+            platform: undefined,
+            chatMessage: undefined
+        }
+    };
+
+    const kickTrigger: Effects.Trigger = {
+        ...baseTrigger,
+        metadata: {
+            ...baseTrigger.metadata,
+            platform: 'kick'
+        }
+    };
+
+    const twitchTrigger: Effects.Trigger = {
+        ...baseTrigger,
+        metadata: {
+            ...baseTrigger.metadata,
+            platform: 'twitch'
+        }
+    };
+
+    it('resolves true when comparison is "is" and platform matches', () => {
+        expect(platformCondition.predicate({ type: "is", comparisonType: "is", leftSideValue: "", rightSideValue: "kick" }, kickTrigger)).toBe(true);
+    });
+
+    it('resolves true when comparison is "is" and platform does not match', () => {
+        expect(platformCondition.predicate({ type: "is", comparisonType: "is", leftSideValue: "", rightSideValue: "kick" }, twitchTrigger)).toBe(false);
+    });
+
+    it('resolves true when comparison is "is" and platform is "any" and currentPlatform is kick', async () => {
+        expect(platformCondition.predicate({ type: "is", comparisonType: "is", leftSideValue: "", rightSideValue: "any" }, kickTrigger)).toBe(true);
+    });
+
+    it('resolves true when comparison is "is" and platform is "any" and currentPlatform is twitch', async () => {
+        expect(platformCondition.predicate({ type: "is", comparisonType: "is", leftSideValue: "", rightSideValue: "any" }, twitchTrigger)).toBe(true);
+    });
+
+    it('resolves true when comparison is "is" and platform is "any" and currentPlatform is unknown', async () => {
+        expect(platformCondition.predicate({ type: "is", comparisonType: "is", leftSideValue: "", rightSideValue: "any" }, baseTrigger)).toBe(false);
+    });
+
+    it('resolves true when comparison is "isNot" and platform is "unknown" and currentPlatform is not unknown', async () => {
+        expect(platformCondition.predicate({ type: "isNot", comparisonType: "isNot", leftSideValue: "", rightSideValue: "unknown" }, kickTrigger)).toBe(true);
+    });
+
+    it('resolves true when comparison is "isNot" and platform is "any" and currentPlatform is unknown', async () => {
+        expect(platformCondition.predicate({ type: "isNot", comparisonType: "isNot", leftSideValue: "", rightSideValue: "any" }, baseTrigger)).toBe(true);
+    });
+
+    it('resolves false when comparison is "isNot" and platform is "any" and currentPlatform is kick', async () => {
+        expect(platformCondition.predicate({ type: "isNot", comparisonType: "isNot", leftSideValue: "", rightSideValue: "any" }, kickTrigger)).toBe(false);
+    });
+
+    it('resolves false when comparison is "isNot" and platform is "any" and currentPlatform is twitch', async () => {
+        expect(platformCondition.predicate({ type: "isNot", comparisonType: "isNot", leftSideValue: "", rightSideValue: "any" }, twitchTrigger)).toBe(false);
+    });
+
+    it('resolves true when comparison is "isNot" and platform does not match', async () => {
+        expect(platformCondition.predicate({ type: "isNot", comparisonType: "isNot", leftSideValue: "", rightSideValue: "twitch" }, kickTrigger)).toBe(true);
+    });
+
+    it('resolves false when comparison is "isNot" and platform matches', async () => {
+        expect(platformCondition.predicate({ type: "isNot", comparisonType: "isNot", leftSideValue: "", rightSideValue: "twitch" }, twitchTrigger)).toBe(false);
+    });
+});

--- a/src/conditions/platform.ts
+++ b/src/conditions/platform.ts
@@ -1,0 +1,52 @@
+import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
+import { ConditionType, PresetValue } from "@crowbartools/firebot-custom-scripts-types/types/modules/condition-manager";
+import { IntegrationConstants } from "../constants";
+import { platformVariable } from "../variables/platform";
+
+const triggers: Effects.TriggersObject = {
+    "channel_reward": true,
+    "command": true,
+    "event": true,
+    "preset": true,
+    "manual": true
+};
+
+export const platformCondition: ConditionType<any, any, any> = {
+    id: `${IntegrationConstants.INTEGRATION_ID}:platform`,
+    name: "Platform",
+    description: "Condition based on the platform in the trigger metadata",
+    triggers: triggers,
+    comparisonTypes: ["is", "isNot"],
+    leftSideValueType: "none",
+    rightSideValueType: "preset",
+    getRightSidePresetValues(): PresetValue[] {
+        return [
+            { value: "kick", display: "Kick" },
+            { value: "twitch", display: "Twitch" },
+            { value: "any", display: "Either Kick or Twitch" }
+        ];
+    },
+    predicate: (conditionSettings, trigger) => {
+        const { comparisonType, rightSideValue } = conditionSettings;
+        const platform = platformVariable.evaluator(trigger);
+        const match = checkMatch(platform, rightSideValue);
+        switch (comparisonType) {
+            case "is":
+                return match;
+            case "isNot":
+                return !match;
+            default:
+                return false;
+        }
+    }
+};
+
+function checkMatch(platform: string, rightSideValue: string | number): boolean {
+    if (platform === "unknown") {
+        return false;
+    }
+    if (rightSideValue === "any") {
+        return platform === "kick" || platform === "twitch";
+    }
+    return platform === rightSideValue;
+}

--- a/src/events/follower.ts
+++ b/src/events/follower.ts
@@ -1,3 +1,4 @@
+import { IntegrationConstants } from "../constants";
 import { integration } from "../integration";
 import { firebot } from "../main";
 import { KickFollower } from "../shared/types";
@@ -8,12 +9,17 @@ export async function handleFollowerEvent(payload: KickFollower): Promise<void> 
 
     // Trigger the follow event
     const { eventManager } = firebot.modules;
-    for (const source of integration.getEventSources()) {
-        eventManager.triggerEvent(source, "follow", {
-            username: viewer.username,
-            userId: viewer._id,
-            userDisplayName: viewer.displayName,
-            profilePicture: viewer.profilePicUrl
-        });
+    const metadata = {
+        username: viewer.username,
+        userId: viewer._id,
+        userDisplayName: viewer.displayName,
+        profilePicture: viewer.profilePicUrl,
+        platform: "kick"
+    };
+    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "follow", metadata);
+
+    // Trigger the Twitch follow event if enabled via the integration settings
+    if (integration.getSettings().triggerTwitchEvents.follower) {
+        eventManager.triggerEvent("twitch", "follow", metadata);
     }
 }

--- a/src/events/livestream-status-updated.ts
+++ b/src/events/livestream-status-updated.ts
@@ -1,5 +1,6 @@
+import { IntegrationConstants } from "../constants";
 import { integration } from "../integration";
-import { kickifyUserId, kickifyUsername } from "../internal/util";
+import { kickifyUserId, kickifyUsername, unkickifyUsername } from "../internal/util";
 import { firebot } from "../main";
 import { LivestreamStatusUpdated } from "../shared/types";
 
@@ -23,12 +24,16 @@ function triggerStreamOnline(
     userDisplayName: string
 ) {
     const { eventManager } = firebot.modules;
-    for (const source of integration.getEventSources()) {
-        eventManager.triggerEvent(source, "stream-online", {
-            username: `${username}@kick`,
-            userId: `k${userId}`,
-            userDisplayName
-        });
+    const metadata = {
+        username: kickifyUsername(username),
+        userId: kickifyUserId(userId),
+        userDisplayName: userDisplayName || unkickifyUsername(username),
+        platform: "kick"
+    };
+    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "stream-online", metadata);
+
+    if (integration.getSettings().triggerTwitchEvents.streamOnline) {
+        eventManager.triggerEvent("twitch", "stream-online", metadata);
     }
 }
 
@@ -38,11 +43,15 @@ function triggerStreamOffline(
     userDisplayName: string
 ) {
     const { eventManager } = firebot.modules;
-    for (const source of integration.getEventSources()) {
-        eventManager.triggerEvent(source, "stream-offline", {
-            username: `${username}@kick`,
-            userId: `k${userId}`,
-            userDisplayName
-        });
+    const metadata = {
+        username: kickifyUsername(username),
+        userId: kickifyUserId(userId),
+        userDisplayName: userDisplayName || unkickifyUsername(username),
+        platform: "kick"
+    };
+    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "stream-offline", metadata);
+
+    if (integration.getSettings().triggerTwitchEvents.streamOffline) {
+        eventManager.triggerEvent("twitch", "stream-offline", metadata);
     }
 }

--- a/src/filters/__tests__/platform.test.ts
+++ b/src/filters/__tests__/platform.test.ts
@@ -1,0 +1,45 @@
+
+import { IntegrationConstants } from '../../constants';
+import { platformFilter } from '../platform';
+
+describe('platformFilter.predicate', () => {
+    it('returns true when platform matches and comparisonType is "is"', () => {
+        const filterSettings = { comparisonType: 'is', value: 'kick' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {}
+        };
+        expect(platformFilter.predicate(filterSettings, eventData)).toBe(true);
+    });
+
+    it('returns false when platform does not match and comparisonType is "is"', () => {
+        const filterSettings = { comparisonType: 'is', value: 'twitch' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {}
+        };
+        expect(platformFilter.predicate(filterSettings, eventData)).toBe(false);
+    });
+
+    it('returns true when platform does not match and comparisonType is "is not"', () => {
+        const filterSettings = { comparisonType: 'is not', value: 'twitch' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {}
+        };
+        expect(platformFilter.predicate(filterSettings, eventData)).toBe(true);
+    });
+
+    it('returns false when platform matches and comparisonType is "is not"', () => {
+        const filterSettings = { comparisonType: 'is not', value: 'kick' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {}
+        };
+        expect(platformFilter.predicate(filterSettings, eventData)).toBe(false);
+    });
+});

--- a/src/filters/platform.ts
+++ b/src/filters/platform.ts
@@ -1,0 +1,68 @@
+import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
+import { EventData, EventFilter, FilterEvent, PresetValue } from "@crowbartools/firebot-custom-scripts-types/types/modules/event-filter-manager";
+import { IntegrationConstants } from "../constants";
+import { platformVariable } from "../variables/platform";
+
+// This can be useful if the user is forwarding Kick events to the corresponding
+// Twitch handlers. Otherwise it's kind of silly...
+//
+// We're only including the Twitch events that we might forward to. The Kick
+// version of the events only ever come from Kick anyway, so this filter would
+// be pointless to add to the Kick events.
+
+const events = [
+    "banned",
+    "chat-message",
+    "follow",
+    "stream-offline",
+    "stream-online",
+    "timeout",
+    "viewer-arrived"
+];
+
+const applicableTwitchEvents: FilterEvent[] = events.map(eventId => ({
+    eventSourceId: "twitch",
+    eventId
+}));
+
+export const platformFilter: EventFilter = {
+    id: `${IntegrationConstants.INTEGRATION_ID}:platform`,
+    name: "Platform",
+    description: "Checks the platform of the event.",
+    events: applicableTwitchEvents,
+    comparisonTypes: ["is", "is not"],
+    valueType: "preset",
+    presetValues(): PresetValue[] {
+        return [
+            { value: "kick", display: "Kick" },
+            { value: "twitch", display: "Twitch" }
+        ];
+    },
+    getSelectedValueDisplay: (filterSettings) => {
+        switch (filterSettings.value) {
+            case "kick":
+                return "Kick";
+            case "twitch":
+                return "Twitch";
+            default:
+                return `??? (${filterSettings.value})`;
+        }
+    },
+    predicate: (
+        filterSettings,
+        eventData: EventData
+    ): boolean => {
+        const { comparisonType, value } = filterSettings;
+        const trigger: Effects.Trigger = {
+            type: "event",
+            metadata: {
+                eventSource: { id: eventData.eventSourceId, name: eventData.eventSourceId },
+                eventData: eventData.eventMeta,
+                username: "" // We don't know it in the filter
+            }
+        };
+        const platform = platformVariable.evaluator(trigger);
+        return (comparisonType === "is" && platform === value) ||
+               (comparisonType === "is not" && platform !== value);
+    }
+};

--- a/src/internal/chat-manager.ts
+++ b/src/internal/chat-manager.ts
@@ -2,6 +2,7 @@ import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effect
 import { IntegrationConstants } from "../constants";
 import { logger } from "../main";
 import { Kick } from "./kick";
+import { platformVariable } from "../variables/platform";
 
 export class ChatManager {
     private kick: Kick;
@@ -63,31 +64,12 @@ export class ChatManager {
         return true;
     }
 
-    static getPlatformFromTrigger(trigger: Effects.Trigger): "kick" | "twitch" | "" {
-        if (trigger.metadata.chatMessage?.userId && trigger.metadata.chatMessage.userId.startsWith("k")) {
-            return "kick";
+    static getPlatformFromTrigger(trigger: Effects.Trigger): string {
+        try {
+            return platformVariable.evaluator(trigger) || "unknown";
+        } catch (error) {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] Error determining platform from trigger: ${error}`);
+            return "unknown";
         }
-
-        if (trigger.metadata.chatMessage?.userId && /^\d+$/.test(trigger.metadata.chatMessage.userId)) {
-            return "twitch";
-        }
-
-        if (
-            trigger.metadata.eventData?.userId &&
-            typeof trigger.metadata.eventData.userId === "string" &&
-            trigger.metadata.eventData.userId.startsWith("k")
-        ) {
-            return "kick";
-        }
-
-        if (
-            trigger.metadata.eventData?.userId &&
-            typeof trigger.metadata.eventData.userId === "string" &&
-            /^\d+$/.test(trigger.metadata.eventData.userId)
-        ) {
-            return "twitch";
-        }
-
-        return "";
     }
 }

--- a/src/restrictions/__tests__/platform.test.ts
+++ b/src/restrictions/__tests__/platform.test.ts
@@ -1,0 +1,54 @@
+
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { platformRestriction } from '../platform';
+
+describe('platformRestriction.predicate', () => {
+    const baseTrigger: Effects.Trigger = {
+        type: 'event',
+        metadata: {
+            username: '',
+            eventData: {},
+            platform: undefined,
+            chatMessage: undefined
+        }
+    };
+
+    const kickTrigger: Effects.Trigger = {
+        ...baseTrigger,
+        metadata: {
+            ...baseTrigger.metadata,
+            platform: 'kick'
+        }
+    };
+
+    it('resolves true when comparison is "is" and platform matches', async () => {
+        await expect(platformRestriction.predicate(kickTrigger, { comparison: 'is', platform: 'kick' })).resolves.toBe(true);
+    });
+
+    it('resolves true when comparison is "is" and platform is "any" and currentPlatform is not unknown', async () => {
+        await expect(platformRestriction.predicate(kickTrigger, { comparison: 'is', platform: 'any' })).resolves.toBe(true);
+    });
+
+    it('resolves true when comparison is "is" and platform is "unknown" and currentPlatform is unknown', async () => {
+        const unknownTrigger: Effects.Trigger = { ...baseTrigger, metadata: { ...baseTrigger.metadata } };
+        await expect(platformRestriction.predicate(unknownTrigger, { comparison: 'is', platform: 'unknown' })).resolves.toBe(true);
+    });
+
+    it('resolves true when comparison is "isNot" and platform is "unknown" and currentPlatform is not unknown', async () => {
+        await expect(platformRestriction.predicate(kickTrigger, { comparison: 'isNot', platform: 'unknown' })).resolves.toBe(true);
+    });
+
+    it('resolves true when comparison is "isNot" and platform is "any" and currentPlatform is unknown', async () => {
+        const unknownTrigger: Effects.Trigger = { ...baseTrigger, metadata: { ...baseTrigger.metadata } };
+        await expect(platformRestriction.predicate(unknownTrigger, { comparison: 'isNot', platform: 'any' })).resolves.toBe(true);
+    });
+
+    it('resolves true when comparison is "isNot" and platform does not match', async () => {
+        await expect(platformRestriction.predicate(kickTrigger, { comparison: 'isNot', platform: 'twitch' })).resolves.toBe(true);
+    });
+
+    it('rejects when none of the conditions are met', async () => {
+        const twitchTrigger: Effects.Trigger = { ...baseTrigger, metadata: { ...baseTrigger.metadata, eventSource: { id: 'twitch', name: 'twitch' } } };
+        await expect(platformRestriction.predicate(twitchTrigger, { comparison: 'is', platform: 'kick' })).rejects.toThrow('Platform restriction failed');
+    });
+});

--- a/src/restrictions/platform.ts
+++ b/src/restrictions/platform.ts
@@ -1,6 +1,6 @@
 import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
 import { IntegrationConstants } from "../constants";
-import { ChatManager } from "../internal/chat-manager";
+import { platformVariable } from "../variables/platform";
 
 export const platformRestriction = {
     definition: {
@@ -72,20 +72,20 @@ export const platformRestriction = {
     },
     predicate: (triggerData: Effects.Trigger, { comparison, platform }: { comparison: string, platform: string }): Promise<boolean> => {
         return new Promise((resolve, reject) => {
-            const currentPlatform = ChatManager.getPlatformFromTrigger(triggerData);
+            const currentPlatform = platformVariable.evaluator(triggerData);
             if (comparison === "is" && currentPlatform === platform) {
                 resolve(true);
             }
-            if (comparison === "is" && currentPlatform !== "" && platform === "any") {
+            if (comparison === "is" && currentPlatform !== "unknown" && platform === "any") {
                 resolve(true);
             }
-            if (comparison === "is" && currentPlatform === "" && platform === "unknown") {
+            if (comparison === "is" && currentPlatform === "unknown" && platform === "unknown") {
                 resolve(true);
             }
-            if (comparison === "isNot" && currentPlatform !== "" && platform === "unknown") {
+            if (comparison === "isNot" && currentPlatform !== "unknown" && platform === "unknown") {
                 resolve(true);
             }
-            if (comparison === "isNot" && currentPlatform === "" && platform === "any") {
+            if (comparison === "isNot" && currentPlatform === "unknown" && platform === "any") {
                 resolve(true);
             }
             if (comparison === "isNot" && currentPlatform !== platform) {

--- a/src/variables/__tests__/platform.test.ts
+++ b/src/variables/__tests__/platform.test.ts
@@ -1,0 +1,184 @@
+import { platformVariable } from '../platform';
+import { IntegrationConstants } from '../../constants';
+
+describe('platformVariable.evaluator', () => {
+    it('returns platform from eventData.platform', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                eventData: { platform: 'customPlatform' },
+                platform: undefined,
+                eventSource: undefined,
+                chatMessage: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('customPlatform');
+    });
+
+    it('returns platform from metadata.platform', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                platform: 'metaPlatform',
+                eventData: undefined,
+                eventSource: undefined,
+                chatMessage: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('metaPlatform');
+    });
+
+    it('returns "kick" if eventSource.id matches INTEGRATION_ID', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                eventSource: { id: IntegrationConstants.INTEGRATION_ID },
+                eventData: undefined,
+                platform: undefined,
+                chatMessage: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('kick');
+    });
+
+    it('returns "twitch" if eventSource.id is "twitch"', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                eventSource: { id: 'twitch' },
+                eventData: undefined,
+                platform: undefined,
+                chatMessage: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('twitch');
+    });
+
+    it('returns "firebot" if eventSource.id is "firebot"', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                eventSource: { id: 'firebot' },
+                eventData: undefined,
+                platform: undefined,
+                chatMessage: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('firebot');
+    });
+
+    it('returns "kick" if chatMessage.userId starts with "k"', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                chatMessage: { userId: 'k123' },
+                eventData: undefined,
+                platform: undefined,
+                eventSource: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('kick');
+    });
+
+    it('returns "kick" if chatMessage.username ends with "@kick"', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                chatMessage: { username: 'user@kick' },
+                eventData: undefined,
+                platform: undefined,
+                eventSource: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('kick');
+    });
+
+    it('returns "twitch" if chatMessage has userId or username (not kick)', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                chatMessage: { userId: '123' },
+                eventData: undefined,
+                platform: undefined,
+                eventSource: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('twitch');
+
+        const trigger2 = {
+            type: 'event',
+            metadata: {
+                chatMessage: { username: 'user' },
+                eventData: undefined,
+                platform: undefined,
+                eventSource: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger2)).toBe('twitch');
+    });
+
+    it('returns "kick" if eventData.userId starts with "k"', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                eventData: { userId: 'k999' },
+                platform: undefined,
+                eventSource: undefined,
+                chatMessage: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('kick');
+    });
+
+    it('returns "kick" if eventData.username ends with "@kick"', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                eventData: { username: 'someone@kick' },
+                platform: undefined,
+                eventSource: undefined,
+                chatMessage: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('kick');
+    });
+
+    it('returns "twitch" if eventData has userId or username (not kick)', () => {
+        const trigger = {
+            type: 'event',
+            metadata: {
+                eventData: { userId: '123' },
+                platform: undefined,
+                eventSource: undefined,
+                chatMessage: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('twitch');
+
+        const trigger2 = {
+            type: 'event',
+            metadata: {
+                eventData: { username: 'someone' },
+                platform: undefined,
+                eventSource: undefined,
+                chatMessage: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger2)).toBe('twitch');
+    });
+
+    it('returns "unknown" if no platform can be determined', () => {
+        const trigger = { type: 'event', metadata: { eventData: undefined, platform: undefined, eventSource: undefined, chatMessage: undefined } } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('unknown');
+    });
+
+    it('returns "manual" if trigger type is manual', () => {
+        const trigger = { type: 'manual', metadata: { eventData: undefined, platform: undefined, eventSource: undefined, chatMessage: undefined } } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('manual');
+    });
+
+    it('returns "unknown" if trigger type is not event or manual', () => {
+        const trigger = { type: 'other', metadata: { eventData: undefined, platform: undefined, eventSource: undefined, chatMessage: undefined } } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('unknown');
+    });
+});

--- a/src/variables/platform.ts
+++ b/src/variables/platform.ts
@@ -1,0 +1,121 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../constants';
+import { logger } from "../main";
+
+export const platformVariable: ReplaceVariable = {
+    definition: {
+        handle: "platform",
+        aliases: ["platform"],
+        description: "Returns the platform on which the event was triggered (twitch, kick, firebot, etc.)",
+        categories: ["common"],
+        possibleDataOutput: ["text"],
+        triggers: {
+            event: true,
+            manual: true
+        }
+    },
+    evaluator: (trigger) => {
+        // Manual trigger returns "manual"
+        if (trigger.type === "manual") {
+            return debugPlatform("manual", "trigger.type", trigger);
+        }
+
+        // Something other than an event should not ever reach here, but would be unknown
+        if (trigger.type !== "event") {
+            return debugPlatform("unknown", "trigger.type", trigger);
+        }
+
+        // See if the platform is explicitly set in the metadata
+        if (typeof trigger.metadata.eventData?.platform === "string") {
+            return debugPlatform(trigger.metadata.eventData.platform, "metadata.eventData.platform", trigger);
+        }
+
+        if (typeof trigger.metadata.platform === "string") {
+            return debugPlatform(trigger.metadata.platform, "metadata.platform", trigger);
+        }
+
+        // If the event source is the Kick integration
+        if (trigger.metadata.eventSource?.id === IntegrationConstants.INTEGRATION_ID) {
+            return debugPlatform("kick", "metadata.eventSource.id", trigger);
+        }
+
+        // If there's a chat message, guess the platform from the user ID or username
+        if (trigger.metadata.chatMessage) {
+            const chatMessage = trigger.metadata.chatMessage;
+            if (chatMessage.userId && chatMessage.userId.startsWith("k")) {
+                return debugPlatform("kick", "metadata.chatMessage.userId", trigger);
+            }
+
+            if (chatMessage.username && chatMessage.username.endsWith("@kick")) {
+                return debugPlatform("kick", "metadata.chatMessage.username", trigger);
+            }
+
+            if (chatMessage.userId || chatMessage.username) {
+                return debugPlatform("twitch", "metadata.chatMessage.userId/username", trigger);
+            }
+        }
+
+        // If there's user information in the event, guess the platform from the user ID or username
+        if (trigger.metadata.eventData) {
+            const eventData = trigger.metadata.eventData;
+
+            if (typeof eventData.userId === "string" && eventData.userId.startsWith("k")) {
+                return debugPlatform("kick", "metadata.eventData.userId", trigger);
+            }
+
+            if (typeof eventData.username === "string" && eventData.username.endsWith("@kick")) {
+                return debugPlatform("kick", "metadata.eventData.username", trigger);
+            }
+
+            if (eventData.userId || eventData.username) {
+                return debugPlatform("twitch", "metadata.eventData.userId/username", trigger);
+            }
+        }
+
+        // Username in top level metadata
+        if (typeof trigger.metadata.username === 'string') {
+            if (trigger.metadata.username.endsWith('@kick')) {
+                return debugPlatform("kick", "metadata.username", trigger);
+            }
+            if (trigger.metadata.username !== '') {
+                return debugPlatform("twitch", "metadata.username", trigger);
+            }
+        }
+
+        // If the event source is reported, we'll return it.
+        if (typeof trigger.metadata.eventSource?.id === "string") {
+            return debugPlatform(trigger.metadata.eventSource.id, "metadata.eventSource.id", trigger);
+        }
+
+        // At this point we don't know
+        return "unknown";
+    }
+};
+
+function debugPlatform(result: string, reference: string, trigger: Effects.Trigger): string {
+    // Skip this in tests
+    if (process.env.NODE_ENV === "test") {
+        return result;
+    }
+
+    const interestingPartsOfTrigger = {
+        type: trigger.type,
+        metadata: {
+            platform: trigger.metadata.platform,
+            username: trigger.metadata.username,
+            eventSource: trigger.metadata.eventSource,
+            eventData: {
+                platform: trigger.metadata.eventData?.platform,
+                userId: trigger.metadata.eventData?.userId,
+                username: trigger.metadata.eventData?.username
+            },
+            chatMessage: {
+                userId: trigger.metadata.chatMessage?.userId,
+                username: trigger.metadata.chatMessage?.username
+            }
+        }
+    };
+    logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] platformVariable evaluated to "${result}" from "${reference}": trigger=${JSON.stringify(interestingPartsOfTrigger)}`);
+    return result;
+}


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This allows forwarding of Kick events to the corresponding Twitch events on a case-by-case basis. As part of this, a `$platform` variable, condition, filter, and restriction are all added to distinguish between where the event actually originated.

### Motivation
This allows configuration with less duplication.

### Testing
Unit tests for the new `$platform` variable, condition, filter, and restriction. Also tested several forwarded events on my implementation and things seemed to work as intended. I am personally forwarding just the follow event for now.
