### PR TITLE
Persist Firebot user data in its own user DB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "firebot-mage-kick-integration",
-    "version": "0.0.1",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "firebot-mage-kick-integration",
-            "version": "0.0.1",
+            "version": "0.2.0",
             "license": "GNU3",
             "dependencies": {
+                "@seald-io/nedb": "^4.1.2",
                 "node-cache": "^5.1.2",
                 "node-json-db": "^1.6.0",
                 "pusher-js": "^8.4.0"
@@ -1619,6 +1620,22 @@
                 "url": "https://opencollective.com/pkgr"
             }
         },
+        "node_modules/@seald-io/binary-search-tree": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@seald-io/binary-search-tree/-/binary-search-tree-1.0.3.tgz",
+            "integrity": "sha512-qv3jnwoakeax2razYaMsGI/luWdliBLHTdC6jU55hQt1hcFqzauH/HsBollQ7IR4ySTtYhT+xyHoijpA16C+tA=="
+        },
+        "node_modules/@seald-io/nedb": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@seald-io/nedb/-/nedb-4.1.2.tgz",
+            "integrity": "sha512-bDr6TqjBVS2rDyYM9CPxAnotj5FuNL9NF8o7h7YyFXM7yruqT4ddr+PkSb2mJvvw991bqdftazkEo38gykvaww==",
+            "license": "MIT",
+            "dependencies": {
+                "@seald-io/binary-search-tree": "^1.0.3",
+                "localforage": "^1.10.0",
+                "util": "^0.12.5"
+            }
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.34.37",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
@@ -2923,6 +2940,21 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/babel-jest": {
             "version": "30.0.4",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.0.4.tgz",
@@ -3113,6 +3145,53 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.0",
+                "es-define-property": "^1.0.0",
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -3449,6 +3528,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/detect-newline": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3457,6 +3553,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/eastasianwidth": {
@@ -3546,12 +3656,42 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/es-module-lexer": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
             "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/escalade": {
             "version": "3.2.0",
@@ -4045,6 +4185,21 @@
             "license": "ISC",
             "peer": true
         },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/foreground-child": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4088,7 +4243,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4114,6 +4268,30 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4122,6 +4300,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -4193,6 +4384,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4217,11 +4420,49 @@
                 "node": ">=8"
             }
         },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -4257,6 +4498,12 @@
             "engines": {
                 "node": ">= 4"
             }
+        },
+        "node_modules/immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.1",
@@ -4322,7 +4569,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/interpret": {
@@ -4335,12 +4581,40 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/is-arguments": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+            "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
@@ -4388,6 +4662,24 @@
                 "node": ">=6"
             }
         },
+        "node_modules/is-generator-function": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+            "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "get-proto": "^1.0.0",
+                "has-tostringtag": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4424,6 +4716,24 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-regex": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4435,6 +4745,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "license": "MIT",
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/isexe": {
@@ -5373,6 +5698,15 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/lie": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+            "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+            "license": "MIT",
+            "dependencies": {
+                "immediate": "~3.0.5"
+            }
+        },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -5388,6 +5722,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.11.5"
+            }
+        },
+        "node_modules/localforage": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+            "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lie": "3.1.1"
             }
         },
         "node_modules/locate-path": {
@@ -5463,6 +5806,15 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tmpl": "1.0.5"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/merge-stream": {
@@ -5994,6 +6346,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6262,6 +6623,23 @@
             ],
             "license": "MIT"
         },
+        "node_modules/safe-regex-test": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "is-regex": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/schema-utils": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
@@ -6340,6 +6718,23 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/shallow-clone": {
@@ -7108,6 +7503,19 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/util": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "which-typed-array": "^1.1.2"
+            }
+        },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -7330,6 +7738,27 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/wildcard": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "webpack-cli": "^6.0.1"
     },
     "dependencies": {
+        "@seald-io/nedb": "^4.1.2",
         "node-cache": "^5.1.2",
         "node-json-db": "^1.6.0",
         "pusher-js": "^8.4.0"

--- a/src/events/follower.ts
+++ b/src/events/follower.ts
@@ -1,11 +1,18 @@
 import { IntegrationConstants } from "../constants";
 import { integration } from "../integration";
-import { firebot } from "../main";
+import { firebot, logger } from "../main";
 import { KickFollower } from "../shared/types";
 
 export async function handleFollowerEvent(payload: KickFollower): Promise<void> {
     // Create the user if they don't exist
-    const viewer = await integration.kick.userManager.getOrCreateViewer(payload.follower);
+    let viewer = await integration.kick.userManager.getViewerById(payload.follower.userId);
+    if (!viewer) {
+        viewer = await integration.kick.userManager.createNewViewer(payload.follower, [], true);
+        if (!viewer) {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] Failed to create new viewer for userId=${payload.follower.userId}`);
+            return;
+        }
+    }
 
     // Trigger the follow event
     const { eventManager } = firebot.modules;

--- a/src/internal/channel-manager.ts
+++ b/src/internal/channel-manager.ts
@@ -1,4 +1,4 @@
-import * as NodeCache from 'node-cache';
+import NodeCache from 'node-cache';
 import { IntegrationConstants } from "../constants";
 import { firebot, logger } from "../main";
 import { CategoryInfo, Channel } from "../shared/types";

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -28,7 +28,7 @@ export class Kick {
         this.apiAborter = new AbortController();
 
         try {
-            this.broadcaster = await this.userManager.getBasicKickUser();
+            this.broadcaster = await this.userManager.lookupUserById();
         } catch (error) {
             logger.error(`[${IntegrationConstants.INTEGRATION_ID}] Failed to get broadcaster ID: ${error}`);
             this.disconnect();
@@ -44,6 +44,7 @@ export class Kick {
         }
 
         this.channelManager.start();
+        await this.userManager.connectViewerDatabase();
         logger.info(`[${IntegrationConstants.INTEGRATION_ID}] Kick API integration connected.`);
     }
 
@@ -51,6 +52,7 @@ export class Kick {
         logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Kick API integration disconnecting...`);
         this.apiAborter.abort();
         this.channelManager.stop();
+        this.userManager.disconnectViewerDatabase();
         logger.info(`[${IntegrationConstants.INTEGRATION_ID}] Kick API integration disconnected.`);
     }
 

--- a/src/internal/user-manager.ts
+++ b/src/internal/user-manager.ts
@@ -1,25 +1,170 @@
 import { FirebotViewer } from "@crowbartools/firebot-custom-scripts-types/types/modules/viewer-database";
+import Datastore from "@seald-io/nedb";
 import { IntegrationConstants } from "../constants";
 import { integration } from "../integration";
-import { firebot, logger } from "../main";
+import { logger } from "../main";
 import { BasicKickUser, KickUser } from "../shared/types";
+import { getDataFilePath } from "../util/datafile";
 import { Kick } from "./kick";
-import { kickifyUserId, kickifyUsername, unkickifyUsername } from "./util";
+import { kickifyUserId, kickifyUsername, unkickifyUserId, unkickifyUsername } from "./util";
 import { parseBasicKickUser } from "./webhook-handler/webhook-handler";
 
 export class KickUserManager {
     private kick: Kick;
-    private _users = new Map<string, FirebotViewer>();
+    private _db: Datastore | null = null;
+    private _dbCompactionInterval = 30000;
+    private _dbPath = "";
 
     constructor(kick: Kick) {
         this.kick = kick;
     }
 
-    async getBasicKickUser(userId = 0): Promise<BasicKickUser> {
+    isViewerDBOn(): boolean {
+        return !integration.areDangerousOpsEnabled();
+    }
+
+    async connectViewerDatabase(): Promise<void> {
+        if (this.isViewerDBOn() !== true) {
+            return;
+        }
+
+        this._dbPath = getDataFilePath("kick-users.db");
+
+        logger.info(`[${IntegrationConstants.INTEGRATION_ID}] Trying to connect to Kick viewer database...`);
+        try {
+            this._db = new Datastore({ filename: this._dbPath });
+            await this._db.loadDatabaseAsync();
+        } catch (error) {
+            if (error && typeof error === "object" && "message" in error) {
+                logger.error(`[${IntegrationConstants.INTEGRATION_ID}] ViewerDB: Error Loading Database: ${(error as { message: string }).message}`);
+            } else {
+                logger.error(`[${IntegrationConstants.INTEGRATION_ID}] ViewerDB: Error Loading Database: ${String(error)}`);
+            }
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] ViewerDB: Failed Database Path: ${this._dbPath}`);
+            return;
+        }
+
+        // Setup our automatic compaction interval to shrink filesize.
+        this._db.setAutocompactionInterval(this._dbCompactionInterval);
+        setInterval(() => {
+            logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] ViewerDB: Compaction should be happening now. Compaction Interval: ${this._dbCompactionInterval}`);
+        }, this._dbCompactionInterval);
+
+        logger.info(`[${IntegrationConstants.INTEGRATION_ID}] ViewerDB: Viewer Database Loaded: ${this._dbPath}`);
+    }
+
+    disconnectViewerDatabase(): void {
+        this._db = null;
+        logger.info(`[${IntegrationConstants.INTEGRATION_ID}] ViewerDB: Database disconnected.`);
+    }
+
+    async createNewViewer(kickUser: KickUser, roles: string[] = [], isOnline = false): Promise<FirebotViewer | undefined> {
+        if (this.isViewerDBOn() !== true) {
+            // TODO: Redirect this call to "real" user DB
+            throw new Error("This is unavailable because 'allow dangerous operations' is enabled.");
+        }
+        if (!this._db) {
+            return;
+        }
+
+        const firebotViewer: FirebotViewer = {
+            _id: unkickifyUsername(kickUser.userId.toString()),
+            username: unkickifyUsername(kickUser.username),
+            displayName: kickUser.displayName || unkickifyUsername(kickUser.username),
+            profilePicUrl: kickUser.profilePicture || "",
+            twitch: false,
+            twitchRoles: roles, // Preserving this naming for now for consistency
+            online: isOnline,
+            onlineAt: isOnline ? Date.now() : 0,
+            lastSeen: Date.now(),
+            joinDate: Date.now(),
+            minutesInChannel: 0,
+            chatMessages: 0,
+            disableAutoStatAccrual: false,
+            disableActiveUserList: true, // Because this doesn't work
+            disableViewerList: true, // Because this doesn't work
+            metadata: {},
+            currency: {},
+            ranks: {}
+        };
+
+        try {
+            await this._db.insertAsync(firebotViewer);
+        } catch (error) {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] ViewerDB: Error Creating Viewer: ${String(error)}`);
+        }
+
+        firebotViewer._id = kickifyUserId(firebotViewer._id);
+        firebotViewer.username = kickifyUsername(firebotViewer.username);
+        return firebotViewer;
+    }
+
+    async getViewerById(id: string): Promise<FirebotViewer | undefined> {
+        if (this.isViewerDBOn() !== true) {
+            // TODO: Redirect this call to "real" user DB
+            throw new Error("This is unavailable because 'allow dangerous operations' is enabled.");
+        }
+        if (!this._db) {
+            return;
+        }
+
+        try {
+            const viewer = await this._db.findOneAsync<FirebotViewer>({ _id: id });
+            if (viewer) {
+                viewer._id = kickifyUserId(viewer._id);
+                viewer.username = kickifyUsername(viewer.username);
+            }
+            return viewer;
+        } catch (error) {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] ViewerDB: Error Finding Viewer by ID: id=${id}, error=${String(error)}`);
+            return undefined;
+        }
+    }
+
+    async getViewerByUsername(username: string): Promise<FirebotViewer | undefined> {
+        if (this.isViewerDBOn() !== true) {
+            // TODO: Redirect this call to "real" user DB
+            throw new Error("This is unavailable because 'allow dangerous operations' is enabled.");
+        }
+        if (!this._db) {
+            return;
+        }
+
+        try {
+            const searchTerm = new RegExp(`^${unkickifyUsername(username)}$`, 'i');
+            const viewer = await this._db.findOneAsync<FirebotViewer>({ username: { $regex: searchTerm }, twitch: false });
+            if (viewer) {
+                viewer._id = kickifyUserId(viewer._id);
+                viewer.username = kickifyUsername(viewer.username);
+            }
+            return viewer;
+        } catch (error) {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] ViewerDB: Error Finding Viewer by Username: username=${username}, error=${String(error)}`);
+            return undefined;
+        }
+    }
+
+    private static userIdToCleanString(userId: string | number = ""): string {
+        if (typeof userId === "number") {
+            return userId > 0 ? userId.toString() : "";
+        }
+
+        const unkickifiedUserId = unkickifyUserId(userId);
+        if (unkickifiedUserId.trim() !== "") {
+            if (!/^\d+$/.test(unkickifiedUserId)) {
+                throw new Error("userId string must be numeric.");
+            }
+            return unkickifiedUserId;
+        }
+        return "";
+    }
+
+    async lookupUserById(userId: string | number = ""): Promise<BasicKickUser> {
         return new Promise((resolve, reject) => {
             const formVariables = new URLSearchParams();
-            if (userId > 0) {
-                formVariables.append("id", userId.toString());
+            const unkickifiedUserId = KickUserManager.userIdToCleanString(userId);
+            if (unkickifiedUserId !== "") {
+                formVariables.append("id", unkickifiedUserId);
             }
 
             const uri = `/public/v1/users${formVariables.toString().length > 0 ? `?${formVariables.toString()}` : ''}`;
@@ -45,110 +190,29 @@ export class KickUserManager {
         });
     }
 
-    private async getViewerInternal(viewerRequest: KickUser, createMissing = false): Promise<FirebotViewer | undefined> {
-        const userId = kickifyUserId(viewerRequest.userId);
-        const username = kickifyUsername(viewerRequest.username);
-
-        if (integration.areDangerousOpsEnabled()) {
-            const { viewerDatabase } = firebot.modules;
-            let viewer = await viewerDatabase.getViewerById(userId);
-            if (viewer) {
-                return viewer;
-            }
-            if (!createMissing) {
-                return;
-            }
-
-            // CAUTION: This creates viewers in the database. The IDs will not
-            // overlap because we hard-code the userId to start with "k" and add
-            // "@kick" to the username. However, Firebot still assumes that all
-            // users are Twitch users, and there are various places in the code that
-            // will break if it comes upon this user.
-            viewer = await viewerDatabase.createNewViewer(
-                userId,
-                username,
-                viewerRequest.displayName || viewerRequest.username,
-                viewerRequest.profilePicture || "",
-                [],
-                true
-            );
-            logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Created new user: id=${userId}, username=${username}`);
-            return viewer;
+    async incrementDbField(userId: string, fieldName: string): Promise<void> {
+        if (this.isViewerDBOn() !== true) {
+            // TODO: Redirect this call to "real" user DB
+            throw new Error("This is unavailable because 'allow dangerous operations' is enabled.");
         }
-
-        const userInMap = this._users.get(userId);
-        if (userInMap) {
-            return userInMap;
-        }
-        if (!createMissing) {
+        if (!this._db) {
             return;
         }
 
-        const fakeViewer: FirebotViewer = {
-            _id: userId,
-            username: username,
-            displayName: viewerRequest.displayName || unkickifyUsername(viewerRequest.username),
-            profilePicUrl: viewerRequest.profilePicture || "",
-            twitch: false,
-            twitchRoles: [],
-            online: false,
-            onlineAt: 0,
-            lastSeen: 0,
-            joinDate: 0,
-            minutesInChannel: 0,
-            chatMessages: 0,
-            disableAutoStatAccrual: false,
-            disableActiveUserList: false,
-            disableViewerList: false,
-            metadata: {},
-            currency: {},
-            ranks: {}
-        };
-        this._users.set(userId, fakeViewer);
-        return fakeViewer;
-    }
+        try {
+            const updateDoc: Record<string, number> = {};
+            updateDoc[fieldName] = 1;
 
-    async getOrCreateViewer(kickUser: KickUser): Promise<FirebotViewer> {
-        const viewer = await this.getViewerInternal(kickUser, true);
-        if (viewer) {
-            return viewer;
-        }
-        throw new Error(`Failed to create viewer for Kick user: ${kickUser.userId}`);
-    }
+            const { affectedDocuments } = await this._db.updateAsync({ _id: unkickifyUserId(userId), disableAutoStatAccrual: { $ne: true } }, { $inc: updateDoc }, { returnUpdatedDocs: true });
 
-    async getViewerById(userId: string): Promise<FirebotViewer | undefined> {
-        const minimalKickUser: KickUser = {
-            userId: kickifyUserId(userId),
-            username: "",
-            displayName: "",
-            profilePicture: "",
-            isVerified: false,
-            channelSlug: ""
-        };
-        return await this.getViewerInternal(minimalKickUser, false);
-    }
-
-    async countChatMessage(rawViewerId: string, increment = 1): Promise<void> {
-        const userId = kickifyUserId(rawViewerId);
-
-        if (integration.areDangerousOpsEnabled()) {
-            const { viewerDatabase } = firebot.modules;
-            const viewer = await viewerDatabase.getViewerById(userId);
-            if (viewer) {
-                await viewerDatabase.updateViewerDataField(userId, "chatMessages", (viewer.chatMessages ?? 0) + increment);
-                return;
+            if (affectedDocuments != null) {
+                logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] Incremented DB field '${fieldName}' for user ${userId}. New value: ${(affectedDocuments as any)[fieldName]}`);
+            } else {
+                logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] Failed to increment DB field '${fieldName}' for user ${userId}. No documents were affected.`);
             }
-            logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] Unable to count chat message for viewer ${userId} - viewer not found.`);
+        } catch (error) {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] Error incrementing DB field '${fieldName}' for user ${userId}: ${String(error)}`);
             return;
         }
-
-        const userInMap = this._users.get(userId);
-        if (userInMap) {
-            userInMap.chatMessages = (userInMap.chatMessages ?? 0) + increment;
-            this._users.set(userId, userInMap);
-            return;
-        }
-
-        logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] Unable to count chat message for viewer ${userId} - viewer not found in map.`);
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
         "experimentalDecorators": true,
         "downlevelIteration": true,
         "strict": true,
-        "strictNullChecks": true
+        "strictNullChecks": true,
+        "esModuleInterop": true
     },
     "include": ["./src/**/*"]
 }


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This follows the same structure as the built-in Firebot user database and persists the Kick user information to a file. Therefore, chat count should be persistent across restarts. In the future, as the assumptions of Firebot allow, other information could be made more persistent in this user database.

Note: This also removes the portions of the code for the "dangerous" operations that wrote directly to the main Firebot database. Nobody should be doing that anyway, and this might be removed at some future point.

### Motivation
This allows the chat counter to be updated and is the foundation for other persistence in the future.

### Testing
Did some operations that create and update the user (chatting, following). Confirmed proper writing of the user database file.
