### PR TITLE
Remove restriction on trigger type from platform variable

### DIFF
--- a/src/variables/__tests__/platform.test.ts
+++ b/src/variables/__tests__/platform.test.ts
@@ -167,6 +167,30 @@ describe('platformVariable.evaluator', () => {
         expect(platformVariable.evaluator(trigger2)).toBe('twitch');
     });
 
+    it('does not have the bug fixed in PR#21', () => {
+        const trigger = {
+            type: 'preset',
+            metadata: {
+                username: "thestaticmage",
+                eventSource: { id: "twitch", name: "Twitch" },
+                eventData: { userId: "123456789", username: "thestaticmage" },
+                chatMessage: {}
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('twitch');
+
+        const trigger2 = {
+            type: 'event',
+            metadata: {
+                eventData: { username: 'someone' },
+                platform: undefined,
+                eventSource: undefined,
+                chatMessage: undefined
+            }
+        } as any;
+        expect(platformVariable.evaluator(trigger2)).toBe('twitch');
+    });
+
     it('returns "unknown" if no platform can be determined', () => {
         const trigger = { type: 'event', metadata: { eventData: undefined, platform: undefined, eventSource: undefined, chatMessage: undefined } } as any;
         expect(platformVariable.evaluator(trigger)).toBe('unknown');

--- a/src/variables/platform.ts
+++ b/src/variables/platform.ts
@@ -21,11 +21,6 @@ export const platformVariable: ReplaceVariable = {
             return debugPlatform("manual", "trigger.type", trigger);
         }
 
-        // Something other than an event should not ever reach here, but would be unknown
-        if (trigger.type !== "event") {
-            return debugPlatform("unknown", "trigger.type", trigger);
-        }
-
         // See if the platform is explicitly set in the metadata
         if (typeof trigger.metadata.eventData?.platform === "string") {
             return debugPlatform(trigger.metadata.eventData.platform, "metadata.eventData.platform", trigger);


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Remove the restriction that the trigger type must be `event` from the `$platform` variable. This variable can be used in preset effect lists and other places, where the metadata will likely be the same. This can still return unknown if the determination is not possible from the metadata.

### Motivation
Supports this in preset effect lists.

### Testing
Tested with the platform-aware chat message effect in my channel and it works on both Twitch and Kick.
