### PR TITLE
Add platformAwareUserDisplayName variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ node_modules/
 
 # Go stuff
 /server/app
+
+# Coverage
+/coverage/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "explicit"
+    }
+}

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -111,11 +111,13 @@ Here's how to do it:
 
         :warning: **CAUTION**: If you intend to have a combined event handler, be sure that you have thoroughly reviewed the effects it triggers. For example:
 
-        - Are you using the default "Chat" effect built into Firebot to send a response? This will always send the message to Twitch, even to reply to a message posted on Kick! (You probably need to convert this to the "Chat (Platform Aware)" effect distributed with this integration.)
+        - Are you using the default "Chat" effect built into Firebot to send a response? This will always send the message to Twitch, even if you're trying to reply to a message posted on Kick! (You probably need to convert this to the "Chat (Platform Aware)" effect distributed with this integration.)
 
-        - Are you using the "Chat Message" event to route messages to a chat overlay, such as with the [Mage Onscreen Chat](https://github.com/TheStaticMage/firebot-mage-onscreen-chat) overlay? If so, you might be running afoul of the Twitch terms of service by merging chat messages from multiple platforms on your stream.
+        - Are you using `$userDisplayName[$username]`? The `$userDisplayName` variable only queries Twitch users, so if it's a Kick user, you'll get `[Error]`. (You should use `$platformAwareUserDisplayName[$username]` from this integration instead as it'll work for either.)
 
         - Are you adding or removing VIP or moderator status from a user, banning a user, timing out a user, etc., as a result of an event? If the event comes in via Kick, this may have unexpected results when the API calls are sent to Twitch because the User IDs will be different.
+
+        - Are you using the "Chat Message" event to route messages to a chat overlay, such as with the [Mage Onscreen Chat](https://github.com/TheStaticMage/firebot-mage-onscreen-chat) overlay? If so, you might be running afoul of the Twitch terms of service by merging chat messages from multiple platforms on your stream.
 
         Note: Triggering the equivalent Firebot Twitch events is _in addition to_ triggering the Kick events supplied by this integration. (The Kick variants of these events will always be triggered, whether or not you have the box checked to trigger the equivalent Twitch event.)
 

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -36,6 +36,7 @@ import { kickStreamerIdVariable } from "./variables/streamer-id";
 import { kickTimeoutDurationVariable } from "./variables/timeout-duration";
 import { kickUptimeVariable } from "./variables/uptime";
 import { kickUserDisplayNameVariable } from "./variables/user-display-name";
+import { platformAwareUserDisplayNameVariable } from "./variables/platform-aware-user-display-name";
 
 const pusherAppKey = "32cbd69e4b950bf97679";
 
@@ -210,6 +211,7 @@ export class KickIntegration extends EventEmitter {
 
         // User variables
         replaceVariableManager.registerReplaceVariable(kickUserDisplayNameVariable);
+        replaceVariableManager.registerReplaceVariable(platformAwareUserDisplayNameVariable.replaceVariable);
 
         // Ban and timeout variables
         replaceVariableManager.registerReplaceVariable(kickModReason);

--- a/src/variables/__tests__/platform-aware-user-display-name.test.ts
+++ b/src/variables/__tests__/platform-aware-user-display-name.test.ts
@@ -1,0 +1,411 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { platformAwareUserDisplayNameVariable, PlatformAwareUserDisplayNameVariable } from '../platform-aware-user-display-name';
+import { IntegrationConstants } from '../../constants';
+
+describe('platformAwareUserDisplayName.evaluate', () => {
+    const baseTrigger: Effects.Trigger = {
+        type: 'event',
+        metadata: {
+            username: '',
+            eventSource: { id: '', name: '' },
+            eventData: {},
+            platform: undefined,
+            chatMessage: undefined
+        }
+    };
+
+    describe('platform=kick (by username)', () => {
+        it('resolves to Kick based on the username', async () => {
+            const trigger = {
+                ...baseTrigger,
+                metadata: {
+                    ...baseTrigger.metadata,
+                    eventSource: { id: 'something', name: 'something' },
+                    chatMessage: { displayName: 'KickUser' },
+                    username: ''
+                }
+            };
+            const mockKickUserManager = {
+                getViewerByUsername: jest.fn().mockResolvedValue({ displayName: 'KickViewerName' })
+            };
+            const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+            const result = await obj.evaluate(trigger, 'kickuser@kick');
+            expect(result).toBe('KickViewerName');
+        });
+    });
+
+    describe('platform=kick', () => {
+        describe('username undefined', () => {
+            it('extracts the username from eventData', async() => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        eventData: { username: 'kickuser@kick' },
+                        chatMessage: {},
+                        username: ''
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn((username) => {
+                        if (username !== 'kickuser@kick') {
+                            throw new Error(`Unexpected username: ${username}`);
+                        }
+                        return Promise.resolve({ displayName: 'KickViewerName' });
+                    })
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger);
+                expect(result).toBe('KickViewerName');
+            });
+
+            it('extracts the username from chatMessage', async() => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        chatMessage: { username: 'kickuser@kick' },
+                        username: ''
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn((username) => {
+                        if (username !== 'kickuser@kick') {
+                            throw new Error(`Unexpected username: ${username}`);
+                        }
+                        return Promise.resolve({ displayName: 'KickViewerName' });
+                    })
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger);
+                expect(result).toBe('KickViewerName');
+            });
+
+            it('extracts the username from metadata', async() => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        chatMessage: {},
+                        username: 'kickuser@kick'
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn((username) => {
+                        if (username !== 'kickuser@kick') {
+                            throw new Error(`Unexpected username: ${username}`);
+                        }
+                        return Promise.resolve({ displayName: 'KickViewerName' });
+                    })
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger);
+                expect(result).toBe('KickViewerName');
+            });
+
+            it('fails with no username extraction', async() => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        chatMessage: {},
+                        username: ''
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn((username) => {
+                        throw new Error(`Should not be called, but was called with '${username}'`);
+                    })
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger);
+                expect(result).toBe('[No username available]');
+            });
+        });
+
+        describe('username defined', () => {
+            it('prefers the data in the user database', async () => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        chatMessage: { displayName: 'KickUser' },
+                        username: ''
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn().mockResolvedValue({ displayName: 'KickViewerName' })
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger, 'kickuser');
+                expect(result).toBe('KickViewerName');
+            });
+
+            it('uses data from the chat message metadata', async () => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        chatMessage: { displayName: 'KickUser' },
+                        username: ''
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn()
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger, 'kickuser');
+                expect(result).toBe('KickUser');
+            });
+
+            it('returns Kick display name from eventData.userDisplayName', async () => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        eventData: { userDisplayName: 'KickEventUser' },
+                        chatMessage: undefined,
+                        username: ''
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn()
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger, 'kickuser');
+                expect(result).toBe('KickEventUser');
+            });
+
+            it('returns Kick display name from metadata.userDisplayName', async () => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        userDisplayName: 'MetaKickUser',
+                        chatMessage: undefined,
+                        username: ''
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn()
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger, 'kickuser');
+                expect(result).toBe('MetaKickUser');
+            });
+
+            it('returns Kick viewer displayName from KickUserManager if username is provided', async () => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        chatMessage: undefined,
+                        username: 'kickuser'
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn().mockResolvedValue({ displayName: 'KickViewerName' })
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger, 'kickuser');
+                expect(result).toBe('KickViewerName');
+            });
+
+            it('returns unkickified username if KickUserManager returns null', async () => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        chatMessage: undefined,
+                        username: 'kickuser'
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn().mockResolvedValue(null)
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger, 'kickuser');
+                expect(result).toBe('kickuser');
+            });
+
+            it('returns "[No username available]" if no username or displayName is present', async () => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        chatMessage: undefined,
+                        username: ''
+                    }
+                };
+                const result = await platformAwareUserDisplayNameVariable.evaluate(trigger, null);
+                expect(result).toBe('[No username available]');
+            });
+
+            it('returns displayName for unkickified username if username is kickified', async () => {
+                const trigger = {
+                    ...baseTrigger,
+                    metadata: {
+                        ...baseTrigger.metadata,
+                        eventSource: { id: IntegrationConstants.INTEGRATION_ID, name: 'kick-event' },
+                        chatMessage: undefined,
+                        username: 'kick_user'
+                    }
+                };
+                const mockKickUserManager = {
+                    getViewerByUsername: jest.fn().mockResolvedValue({ displayName: 'KickifiedUser' })
+                };
+                const obj = new PlatformAwareUserDisplayNameVariable(null, null, mockKickUserManager as any);
+                const result = await obj.evaluate(trigger, 'kick_user');
+                expect(result).toBe('KickifiedUser');
+            });
+        });
+    });
+
+    describe('platform=twitch', () => {
+        it('returns Twitch display name from chatMessage.displayName', async () => {
+            const trigger = {
+                ...baseTrigger,
+                metadata: {
+                    ...baseTrigger.metadata,
+                    eventSource: { id: 'twitch', name: 'twitch-event' },
+                    chatMessage: { displayName: 'TwitchUser' },
+                    username: ''
+                }
+            };
+            const result = await platformAwareUserDisplayNameVariable.evaluate(trigger, null);
+            expect(result).toBe('TwitchUser');
+        });
+
+        it('returns username if chatMessage.displayName is not present', async () => {
+            const trigger = {
+                ...baseTrigger,
+                metadata: {
+                    ...baseTrigger.metadata,
+                    eventSource: { id: 'twitch', name: 'twitch' },
+                    chatMessage: { displayName: undefined },
+                    username: 'FallbackUser'
+                }
+            };
+            const mockTwitchApi = {
+                getDisplayName: jest.fn(),
+                getClient: jest.fn(),
+                channels: {},
+                channelRewards: {},
+                users: {}
+                // Add any other required properties/methods if needed
+            };
+            const mockViewerDatabase = {
+                getViewerByUsername: jest.fn().mockResolvedValue({ displayName: 'FallbackUser' })
+            };
+            const obj = new PlatformAwareUserDisplayNameVariable(mockTwitchApi as any, mockViewerDatabase as any);
+            const result = await obj.evaluate(trigger, null);
+            expect(result).toBe('FallbackUser');
+        });
+
+        it('prefers the viewer database entry', async () => {
+            const trigger = {
+                ...baseTrigger,
+                metadata: {
+                    ...baseTrigger.metadata,
+                    eventSource: { id: 'twitch', name: 'twitch' },
+                    chatMessage: { displayName: undefined },
+                    username: 'theusername'
+                }
+            };
+            const mockTwitchApi = {
+                getDisplayName: jest.fn(),
+                getClient: jest.fn(),
+                channels: {},
+                channelRewards: {},
+                users: {}
+                // Add any other required properties/methods if needed
+            };
+            const mockViewerDatabase = {
+                getViewerByUsername: jest.fn().mockResolvedValue({ displayName: 'TheUserName' })
+            };
+            const obj = new PlatformAwareUserDisplayNameVariable(mockTwitchApi as any, mockViewerDatabase as any);
+            const result = await obj.evaluate(trigger, null);
+            expect(result).toBe('TheUserName');
+        });
+
+        it('falls back to the Twitch API', async () => {
+            const trigger = {
+                ...baseTrigger,
+                metadata: {
+                    ...baseTrigger.metadata,
+                    eventSource: { id: 'twitch', name: 'twitch' },
+                    chatMessage: { displayName: undefined },
+                    username: 'theusername'
+                }
+            };
+            const mockTwitchApi = {
+                getDisplayName: jest.fn(),
+                getClient: jest.fn(),
+                channels: {},
+                channelRewards: {},
+                users: {
+                    getUserByName: jest.fn().mockResolvedValue({ displayName: 'TheUserName' })
+                }
+            };
+            const mockViewerDatabase = {
+                getViewerByUsername: jest.fn()
+            };
+            const obj = new PlatformAwareUserDisplayNameVariable(mockTwitchApi as any, mockViewerDatabase as any);
+            const result = await obj.evaluate(trigger, null);
+            expect(result).toBe('TheUserName');
+        });
+
+        it('returns an error if the username could not be found', async () => {
+            const trigger = {
+                ...baseTrigger,
+                metadata: {
+                    ...baseTrigger.metadata,
+                    eventSource: { id: 'twitch', name: 'twitch' },
+                    chatMessage: { displayName: undefined },
+                    username: ''
+                }
+            };
+
+            const mockTwitchApi = {
+                getDisplayName: jest.fn(),
+                getClient: jest.fn(),
+                channels: {},
+                channelRewards: {},
+                users: {
+                    getUserByName: jest.fn()
+                }
+            };
+            const mockViewerDatabase = {
+                getViewerByUsername: jest.fn()
+            };
+            const obj = new PlatformAwareUserDisplayNameVariable(mockTwitchApi as any, mockViewerDatabase as any);
+            const result = await obj.evaluate(trigger, 'ExplicitUser');
+            expect(result).toBe('[No user found]');
+        });
+
+        it('returns appropriate string if no display name or username is available', async () => {
+            const trigger = {
+                ...baseTrigger,
+                metadata: {
+                    ...baseTrigger.metadata,
+                    eventSource: { id: 'twitch', name: 'twitch' },
+                    chatMessage: { displayName: undefined },
+                    username: ''
+                }
+            };
+            const result = await platformAwareUserDisplayNameVariable.evaluate(trigger, null);
+            expect(result).toBe("[No username available]");
+        });
+    });
+});

--- a/src/variables/platform-aware-user-display-name.ts
+++ b/src/variables/platform-aware-user-display-name.ts
@@ -1,0 +1,174 @@
+import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { unkickifyUsername } from "../internal/util";
+import { integration } from "../integration";
+import { firebot, logger } from "../main";
+import { platformVariable } from "./platform";
+import { TwitchApi } from "@crowbartools/firebot-custom-scripts-types/types/modules/twitch-api";
+import { ViewerDatabase } from "@crowbartools/firebot-custom-scripts-types/types/modules/viewer-database";
+import { KickUserManager } from "../internal/user-manager";
+
+export class PlatformAwareUserDisplayNameVariable {
+    replaceVariable: ReplaceVariable = {
+        definition: {
+            handle: "platformAwareUserDisplayName",
+            description: "Outputs the formatted display name from the associated event/command/redeem. Works for both Twitch and Kick. Use this instead of $userDisplayName.",
+            examples: [
+                {
+                    usage: "platformAwareUserDisplayName",
+                    description: "The formatted name of the user who triggered the event/command/redeem."
+                },
+                {
+                    usage: "platformAwareUserDisplayName[username]",
+                    description: "The formatted display name for the provided username."
+                }
+            ],
+            categories: ["common"],
+            possibleDataOutput: ["text"]
+        },
+        evaluator: async (trigger: Effects.Trigger, username: string | null = null) => {
+            return await this.evaluate(trigger, username);
+        }
+    };
+
+    private _kickUserManager: KickUserManager | null;
+    private _twitchApi: TwitchApi | null;
+    private _viewerDatabase: ViewerDatabase | null;
+
+    constructor(injectTwitchApi: TwitchApi | null = null, injectViewerDatabase: ViewerDatabase | null = null, injectKickUserManager: KickUserManager | null = null) {
+        this._twitchApi = injectTwitchApi;
+        this._viewerDatabase = injectViewerDatabase;
+        this._kickUserManager = injectKickUserManager;
+    }
+
+    async evaluate(trigger: Effects.Trigger, username: string | null = null): Promise<string> {
+        // This uses the Twitch logic unless the event is demonstrably from
+        // Kick, for maximum compatibility.
+        const platform = this.getPlatform(trigger);
+        if (platform === "kick" || (username && unkickifyUsername(username) !== username)) {
+            return this.evaluateForKick(trigger, username);
+        }
+        return this.evaluateForTwitch(trigger, username);
+    }
+
+    private fallbackUserDisplayName(trigger: Effects.Trigger): string | null {
+        if (typeof trigger.metadata?.eventData?.userDisplayName === 'string' && trigger.metadata?.eventData?.userDisplayName.trim() !== "") {
+            return trigger.metadata.eventData.userDisplayName;
+        }
+
+        if (typeof trigger.metadata?.chatMessage?.displayName === 'string' && trigger.metadata?.chatMessage?.displayName.trim() !== "") {
+            return trigger.metadata.chatMessage.displayName;
+        }
+
+        if (typeof trigger.metadata?.userDisplayName === 'string' && trigger.metadata?.userDisplayName.trim() !== "") {
+            return trigger.metadata.userDisplayName;
+        }
+
+        return null;
+    }
+
+    private fallbackUsername(trigger: Effects.Trigger): string | null {
+        if (typeof trigger.metadata?.eventData?.username === 'string' && trigger.metadata?.eventData?.username.trim() !== "") {
+            return trigger.metadata.eventData.username;
+        }
+
+        if (typeof trigger.metadata?.chatMessage?.username === 'string' && trigger.metadata?.chatMessage?.username.trim() !== "") {
+            return trigger.metadata.chatMessage.username;
+        }
+
+        if (typeof trigger.metadata?.username === 'string' && trigger.metadata?.username.trim() !== "") {
+            return trigger.metadata.username;
+        }
+
+        return null;
+    }
+
+    private async evaluateForKick(trigger: Effects.Trigger, username: string | null): Promise<string> {
+        if (username == null) {
+            const realUsername = this.fallbackUsername(trigger);
+            if (!realUsername) {
+                return "[No username available]";
+            }
+            username = realUsername;
+        }
+
+        const viewer = await this.getKickUserManager().getViewerByUsername(username);
+        if (viewer != null && viewer.displayName) {
+            return viewer.displayName;
+        }
+
+        const fallback = this.fallbackUserDisplayName(trigger);
+        if (fallback) {
+            return fallback;
+        }
+
+        return unkickifyUsername(username); // Fallback to the username if no display name is found
+    }
+
+    private async evaluateForTwitch(trigger: Effects.Trigger, username: string | null): Promise<string> {
+        // Re-implements the logic from Firebot's `userDisplayName` variable
+        // implementation. I don't particularly like parts of this
+        // implementation, like not referencing the display name metadata if the
+        // username does not resolve, but we are keeping things consistent for
+        // now.
+        if (username == null) {
+            const fallback = this.fallbackUserDisplayName(trigger);
+            if (fallback) {
+                return fallback;
+            }
+
+            const realUsername = this.fallbackUsername(trigger);
+            if (!realUsername) {
+                return "[No username available]";
+            }
+            username = realUsername;
+        }
+
+        const viewer = await this.getViewerDatabase().getViewerByUsername(username);
+        if (viewer != null) {
+            return viewer.displayName;
+        }
+
+        try {
+            const user = await this.getTwitchApi().users.getUserByName(username);
+            if (user != null) {
+                return user.displayName;
+            }
+            return "[No user found]";
+        } catch (error) {
+            logger.debug(`Unable to find user with name "${username}"`, error);
+            return "[Error]";
+        }
+    }
+
+    private getPlatform(trigger: Effects.Trigger): string {
+        return platformVariable.evaluator(trigger);
+    }
+
+    private getKickUserManager(): KickUserManager {
+        if (this._kickUserManager) {
+            return this._kickUserManager;
+        }
+        return integration.kick.userManager;
+    }
+
+    private getTwitchApi(): TwitchApi {
+        if (this._twitchApi) {
+            return this._twitchApi;
+        }
+
+        const { twitchApi } = firebot.modules;
+        return twitchApi;
+    }
+
+    private getViewerDatabase(): ViewerDatabase {
+        if (this._viewerDatabase) {
+            return this._viewerDatabase;
+        }
+
+        const { viewerDatabase } = firebot.modules;
+        return viewerDatabase;
+    }
+}
+
+export const platformAwareUserDisplayNameVariable = new PlatformAwareUserDisplayNameVariable();


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This adds `$platformAwareUserDisplayName` as a variable. It works just like `$userDisplayName` except that it is available for both Kick and Twitch users. It should be safe to replace all calls to `$userDisplayName` with calls to this variable and it should just work transparently to the user.

### Motivation
If an effect calls `$userDisplayName[$username]` this will resolve to `[Error]` if given a Kick user.

### Testing
Unit tests cover the majority of this. I also did a global search and replace from userDisplayName to platformAwareUserDisplayName in my Firebot config and did some testing. YOLO!
