### PR TITLE
Ban user from chat feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Currently supported:
 
 - Chat integration:
   - Kick messages appear in Firebot's chat feed (Dashboard), displaying Kick usernames and supporting emotes.
+  - Ban user from the context menu in the chat feed.
 - Commands:
   - Standard commands mostly work, including restriction logic (with a custom Platform restriction).
 - Conditions:
@@ -79,14 +80,16 @@ Planned but not yet supported:
 
 - Subscription-related events (renewals, gifts, first time subs)
 - Live stream metadata updates (e.g., game/title change)
-- Unban or untimeout events
-- Actions such as ban/unban, time out/un-time out
+- Events when a user is unbanned or untimed-out
+- Effects to ban, unban, timeout, and untimeout users
 - Chat roles
+- Chat as a separate user account
 
 Limitations due to Kick:
 
 - Many user actions (e.g., custom rewards, raids, unbans) don't trigger webhooks. Some are only available via "pusher" WebSocket. Others are not provided at all. The integration can only support events that Kick provides.
 - Kick delivers profile image URLs that only resolve from kick.com, so these images may not display correctly elsewhere.
+- Kick's public API is lacking basic chat management options (e.g. delete message, clear chat), so we cannot implement these in Firebot's chat feed.
 - There is currently no API for fetching the viewer list, which prevents watch-time tracking and currency accrual.
 - Channel point redeems on Kick cannot be managed via API (creation, approval, rejection), nor can they be disabled or paused. This means that Firebot cannot control them.
 - Configuration of the "pusher" websocket requires your channel ID and chatroom ID, which are different from your user ID. The process to determine these can be tedious. Thankfully, you'll only need to do this once.
@@ -94,7 +97,6 @@ Limitations due to Kick:
 Limitations due to Firebot:
 
 - Firebot's viewer database uses Twitch user IDs as primary keys and assumes every user is from Twitch. This rigid design prevents full platform independence.
-- Chat feed actions in the dashboard (like delete message or ban user) assume Twitch context and may error out or do nothing for Kick messages or users.
 - Rate limiting (cooldowns) for commands and redeems doesn't work natively. Consider using the [Firebot Rate Limiter](https://github.com/TheStaticMage/firebot-rate-limiter) if needed.
 - Many built-in Firebot variables and effects are hard-coded to be available only to specific Twitch events. Therefore, this integration introduces Kick-specific variables like `$kickModerator`. Alternatively, you can trigger equivalent Twitch events if your effects are platform-aware.
 - Kick authorization flow is clunky. Thankfully, you'll only need to authorize once.

--- a/src/internal/http.ts
+++ b/src/internal/http.ts
@@ -43,8 +43,8 @@ export async function httpCallWithTimeout(
             signal: AbortSignal.any(signals)
         };
 
-        if (method !== "GET" && method !== "HEAD" && method !== "DELETE") {
-            // Only include body for methods that require it
+        if (body !== '' || method !== "GET" && method !== "HEAD" && method !== "DELETE") {
+            // Only include body for methods that require it, or when it is defined
             fetchOptions['body'] = body;
         }
 

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -4,6 +4,7 @@ import { logger } from "../main";
 import { BasicKickUser } from "../shared/types";
 import { KickChannelManager } from "./channel-manager";
 import { httpCallWithTimeout } from "./http";
+import { KickUserApi } from "./user-api";
 import { KickUserManager } from "./user-manager";
 import { ChatManager } from "./chat-manager";
 
@@ -13,11 +14,13 @@ export class Kick {
     broadcaster: BasicKickUser | null = null;
     channelManager: KickChannelManager;
     chatManager: ChatManager;
+    userApi: KickUserApi;
     userManager: KickUserManager;
 
     constructor() {
         this.channelManager = new KickChannelManager(this);
         this.chatManager = new ChatManager(this);
+        this.userApi = new KickUserApi(this);
         this.userManager = new KickUserManager(this);
     }
 
@@ -44,6 +47,7 @@ export class Kick {
         }
 
         this.channelManager.start();
+        this.userApi.start();
         await this.userManager.connectViewerDatabase();
         logger.info(`[${IntegrationConstants.INTEGRATION_ID}] Kick API integration connected.`);
     }
@@ -53,6 +57,7 @@ export class Kick {
         this.deleteExistingSubscriptions();
         this.apiAborter.abort();
         this.channelManager.stop();
+        this.userApi.stop();
         this.userManager.disconnectViewerDatabase();
         logger.info(`[${IntegrationConstants.INTEGRATION_ID}] Kick API integration disconnected.`);
     }

--- a/src/internal/user-api.ts
+++ b/src/internal/user-api.ts
@@ -1,0 +1,97 @@
+import { Kick } from "./kick";
+import { firebot, logger } from "../main";
+import { IntegrationConstants } from "../constants";
+import { unkickifyUsername } from "./util";
+import { KickUserManager } from "./user-manager";
+
+interface UserBanRequest {
+    username: string;
+    shouldBeBanned: boolean;
+}
+
+export class KickUserApi {
+    private kick: Kick;
+
+    constructor(kick: Kick) {
+        this.kick = kick;
+    }
+
+    start(): void {
+        // Listen to user ban request from the UI
+        const { frontendCommunicator } = firebot.modules;
+        frontendCommunicator.onAsync("update-user-banned-status", async (data: UserBanRequest) => {
+            await this.banUserByUsername(data.username, 0, data.shouldBeBanned, 'Banned via Firebot');
+        });
+    }
+
+    stop(): void {
+        // Can't stop listening to frontend communicator events
+        logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] User API stopped.`);
+    }
+
+    async banUserByUsername(username: string, duration: number, shouldBeBanned: boolean, reason = ''): Promise<boolean> {
+        if (username.trim() === '') {
+            logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] banUserByUsername: No username provided.`);
+            return false;
+        }
+
+        if (unkickifyUsername(username) === username) {
+            logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] banUserByUsername: Username provided that does not seem to be a kick user (${username}).`);
+            return false;
+        }
+
+        const user = await this.kick.userManager.getViewerByUsername(username);
+        if (!user) {
+            logger.warn(`[${IntegrationConstants.INTEGRATION_ID}] banUserByUsername: User not found (${username}).`);
+            return false;
+        }
+
+        try {
+            await this.banUnbanUser(user._id, duration, shouldBeBanned, reason);
+            return true;
+        } catch (error) {
+            logger.error(`[${IntegrationConstants.INTEGRATION_ID}] Error occurred while banning/unbanning user (${user.username}): ${error}`);
+            return false;
+        }
+    }
+
+    private async banUnbanUser(userId: number | string, duration: number, shouldBeBanned: boolean, reason = ''): Promise<void> {
+        const broadcasterUserId = this.kick.broadcaster?.userId || 0;
+        if (!broadcasterUserId) {
+            throw new Error("banUser: Broadcaster user ID not available.");
+        }
+
+        const realUserId = KickUserManager.userIdToCleanNumber(userId);
+        if (!realUserId) {
+            throw new Error("banUser: Invalid user ID provided.");
+        }
+
+        if (realUserId === broadcasterUserId) {
+            throw new Error("banUser: Cannot ban broadcaster.");
+        }
+
+        const payload: Record<string, any> = {
+            // eslint-disable-next-line camelcase
+            broadcaster_user_id: broadcasterUserId,
+            // eslint-disable-next-line camelcase
+            user_id: realUserId
+        };
+        if (shouldBeBanned) {
+            const operation = duration > 0 ? "timeout" : "ban";
+            if (duration > 0) {
+                payload.duration = duration;
+            }
+            if (reason) {
+                payload.reason = reason;
+            }
+
+            logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] banUser: Sending ${operation} request: ${JSON.stringify(payload)}`);
+            await this.kick.httpCallWithTimeout('/public/v1/moderation/bans', "POST", JSON.stringify(payload));
+            logger.info(`[${IntegrationConstants.INTEGRATION_ID}] banUser: User ${operation} successful (userId=${realUserId}, duration=${duration}).`);
+        } else {
+            logger.debug(`[${IntegrationConstants.INTEGRATION_ID}] banUser: Sending unban request: ${JSON.stringify(payload)}`);
+            await this.kick.httpCallWithTimeout('/public/v1/moderation/bans', "DELETE", JSON.stringify(payload));
+            logger.info(`[${IntegrationConstants.INTEGRATION_ID}] banUser: User unban successful (userId=${realUserId}).`);
+        }
+    }
+}

--- a/src/internal/user-manager.ts
+++ b/src/internal/user-manager.ts
@@ -68,7 +68,7 @@ export class KickUserManager {
         }
 
         const firebotViewer: FirebotViewer = {
-            _id: unkickifyUsername(kickUser.userId.toString()),
+            _id: unkickifyUserId(kickUser.userId.toString()),
             username: unkickifyUsername(kickUser.username),
             displayName: kickUser.displayName || unkickifyUsername(kickUser.username),
             profilePicUrl: kickUser.profilePicture || "",
@@ -144,7 +144,12 @@ export class KickUserManager {
         }
     }
 
-    private static userIdToCleanString(userId: string | number = ""): string {
+    static userIdToCleanNumber(userId: string | number = ""): number {
+        const cleanedId = KickUserManager.userIdToCleanString(userId);
+        return cleanedId !== "" ? Number(cleanedId) : 0;
+    }
+
+    static userIdToCleanString(userId: string | number = ""): string {
         if (typeof userId === "number") {
             return userId > 0 ? userId.toString() : "";
         }


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This makes the "Ban" action in the chat feed work correctly.

Limitations/caveats:
- This still triggers the Twitch handler too, which sends a user lookup request to Twitch for "username@kick" (which obviously fails and goes no further).
- Unban is not implemented, because the user does not show up as banned in the chat interface.
- This doesn't update roles in the user database or in any other way record locally that the user is banned.

### Motivation
Mostly due to bots... even though this feature only partially works, the part that works is valuable.

### Testing
Tested to confirm that when I ban a user via chat:
- The banned user event fires
- The user actually gets banned on Kick
- The user's messages get deleted from the chat feed
