### PR TITLE
Add replies to Kick messages

### DIFF
--- a/src/effects/__tests__/chat-platform.test.ts
+++ b/src/effects/__tests__/chat-platform.test.ts
@@ -1,0 +1,170 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import * as ChatManagerModule from '../../internal/chat-manager';
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+
+type chatPlatformEffectParams = {
+    chatterKick: 'Streamer' | 'Bot';
+    chatterTwitch: 'Streamer' | 'Bot';
+    message: string;
+    messageKick?: string;
+    copyMessageKick?: boolean;
+    sendAsReply?: boolean;
+    sendAsReplyKick?: boolean;
+    skipKick?: boolean;
+    skipTwitch?: boolean;
+    alwaysSendKick?: boolean;
+    alwaysSendTwitch?: boolean;
+    defaultSendKick?: boolean;
+    defaultSendTwitch?: boolean;
+};
+
+const mockSendKickChatMessage = jest.fn().mockResolvedValue(undefined);
+const mockSendChatMessage = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../integration', () => {
+    return {
+        integration: {
+            kick: {
+                chatManager: {
+                    sendKickChatMessage: mockSendKickChatMessage
+                }
+            },
+            getModules: () => ({
+                twitchChat: {
+                    sendChatMessage: mockSendChatMessage
+                }
+            })
+        }
+    };
+});
+
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+    }
+}));
+
+describe('chatPlatformEffect.onTriggerEvent', () => {
+    let chatPlatformEffect: typeof import('../chat-platform').chatPlatformEffect;
+    let integration: typeof import('../../integration').integration;
+    beforeEach(() => {
+        jest.resetModules();
+        mockSendKickChatMessage.mockClear();
+        mockSendChatMessage.mockClear();
+        chatPlatformEffect = require('../chat-platform').chatPlatformEffect;
+        integration = require('../../integration').integration;
+        jest.restoreAllMocks();
+    });
+
+    it('sends to Kick with correct params (no reply)', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('kick');
+        const effect: chatPlatformEffectParams = { message: 'hello', chatterKick: 'Streamer', chatterTwitch: 'Bot', copyMessageKick: true, defaultSendKick: true };
+        const trigger: Effects.Trigger = { type: 'command', metadata: { eventSource: { id: 'kick' }} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('hello', 'Streamer', undefined);
+    });
+
+    it('sends to Kick with reply id for command', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('kick');
+        const effect: chatPlatformEffectParams = { message: 'hi', chatterKick: 'Bot', chatterTwitch: 'Bot', sendAsReply: true, copyMessageKick: true, defaultSendKick: true };
+        const trigger: Effects.Trigger = { type: 'command', metadata: { chatMessage: { id: 'msg123' }, eventSource: { id: 'kick' }} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('hi', 'Bot', 'msg123');
+    });
+
+    it('sends to Kick with reply id for event', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('kick');
+        const effect: chatPlatformEffectParams = { message: 'yo', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendAsReply: true, copyMessageKick: true, defaultSendKick: true };
+        const trigger: Effects.Trigger = { type: 'event', metadata: { eventData: { chatMessage: { id: 'evt456' } }, eventSource: { id: 'kick' }} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('yo', 'Streamer', 'evt456');
+    });
+
+    it('skips sending to Kick if skipKick is true', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('kick');
+        const effect: chatPlatformEffectParams = { message: 'skip', chatterKick: 'Streamer', chatterTwitch: 'Bot', skipKick: true, copyMessageKick: true };
+        const trigger: Effects.Trigger = { type: 'command', metadata: { eventSource: { id: 'kick' }} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends to Twitch with correct params (no reply)', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('twitch');
+        const effect: chatPlatformEffectParams = { message: 'tmsg', chatterKick: 'Streamer', chatterTwitch: 'Bot', alwaysSendTwitch: false };
+        const trigger: Effects.Trigger = { type: 'command', metadata: { eventSource: { id: 'twitch' }} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(mockSendChatMessage).toHaveBeenCalledWith('tmsg', '', 'bot', undefined);
+    });
+
+    it('sends to Twitch with reply id for command', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('twitch');
+        const effect: chatPlatformEffectParams = { message: 'tmsg2', chatterKick: 'Streamer', chatterTwitch: 'Streamer', alwaysSendTwitch: false, sendAsReply: true };
+        const trigger: Effects.Trigger = { type: 'command', metadata: { chatMessage: { id: 'tmsgid' }, eventSource: { id: 'twitch' }} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(mockSendChatMessage).toHaveBeenCalledWith('tmsg2', '', 'streamer', 'tmsgid');
+    });
+
+    it('sends to Twitch with reply id for event', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('twitch');
+        const effect: chatPlatformEffectParams = { message: 'tmsg2', chatterKick: 'Streamer', chatterTwitch: 'Streamer', alwaysSendTwitch: false, sendAsReply: true };
+        const trigger: Effects.Trigger = { type: 'event', metadata: { eventData: { chatMessage: { id: 'evt456' } }, eventSource: { id: 'twitch' }} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(mockSendChatMessage).toHaveBeenCalledWith('tmsg2', '', 'streamer', 'evt456');
+    });
+
+    it('skips sending to Twitch if skipTwitch is true', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('twitch');
+        const effect: chatPlatformEffectParams = { message: 'skipT', chatterKick: 'Streamer', chatterTwitch: 'Bot', alwaysSendTwitch: false, skipTwitch: true };
+        const trigger: Effects.Trigger = { type: 'command', metadata: { eventSource: { id: 'twitch' }} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(mockSendChatMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not send to either platform if platform cannot be determined', async() => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('');
+        const effect: chatPlatformEffectParams = { message: 'unknown', chatterKick: 'Streamer', chatterTwitch: 'Bot' };
+        const trigger: Effects.Trigger = { type: 'command', metadata: { eventSource: { id: 'unknown' }} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).not.toHaveBeenCalled();
+        expect(mockSendChatMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends to kick when trigger cannot be determined but default kick is enabled', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('');
+        const effect: chatPlatformEffectParams = { message: 'unknown', chatterKick: 'Streamer', chatterTwitch: 'Bot', defaultSendKick: true };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('unknown', 'Streamer', undefined);
+        expect(mockSendChatMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends to twitch when trigger cannot be determined but default twitch is enabled', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('');
+        const effect: chatPlatformEffectParams = { message: 'unknown', chatterKick: 'Streamer', chatterTwitch: 'Bot', defaultSendTwitch: true };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).not.toHaveBeenCalled();
+        expect(mockSendChatMessage).toHaveBeenCalledWith('unknown', '', 'bot', undefined);
+    });
+
+    it('sends to kick when alwaysSendKick is enabled', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('');
+        const effect: chatPlatformEffectParams = { message: 'unknown', chatterKick: 'Streamer', chatterTwitch: 'Bot', alwaysSendKick: true };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('unknown', 'Streamer', undefined);
+        expect(mockSendChatMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends to twitch when alwaysSendTwitch is enabled', async () => {
+        jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('');
+        const effect: chatPlatformEffectParams = { message: 'unknown', chatterKick: 'Streamer', chatterTwitch: 'Bot', alwaysSendTwitch: true };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+        await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).not.toHaveBeenCalled();
+        expect(mockSendChatMessage).toHaveBeenCalledWith('unknown', '', 'bot', undefined);
+    });
+});

--- a/src/effects/__tests__/chat.test.ts
+++ b/src/effects/__tests__/chat.test.ts
@@ -1,0 +1,50 @@
+import { chatEffect } from '../chat';
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+
+type chatEffectParams = {
+    chatter: 'Streamer' | 'Bot';
+    message: string;
+    sendAsReply: boolean;
+};
+
+jest.mock('../../integration', () => ({
+    integration: {
+        kick: {
+            chatManager: {
+                sendKickChatMessage: jest.fn().mockResolvedValue(undefined)
+            }
+        }
+    }
+}));
+
+const { integration } = require('../../integration');
+
+describe('chatEffect.onTriggerEvent', () => {
+    it('calls sendKickChatMessage with correct params (no reply)', async () => {
+        const effect: chatEffectParams = { message: 'hello', chatter: 'Streamer', sendAsReply: false };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+        await chatEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('hello', 'Streamer', undefined);
+    });
+
+    it('calls sendKickChatMessage with reply id for command', async () => {
+        const effect: chatEffectParams = { message: 'hi', chatter: 'Bot', sendAsReply: true };
+        const trigger: Effects.Trigger = { type: 'command', metadata: { chatMessage: { id: 'msg123' } } } as any;
+        await chatEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('hi', 'Bot', 'msg123');
+    });
+
+    it('calls sendKickChatMessage with reply id for event', async () => {
+        const effect: chatEffectParams = { message: 'yo', chatter: 'Streamer', sendAsReply: true };
+        const trigger: Effects.Trigger = { type: 'event', metadata: { eventData: { chatMessage: { id: 'evt456' } } } } as any;
+        await chatEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('yo', 'Streamer', 'evt456');
+    });
+
+    it('calls sendKickChatMessage with undefined if no id found for reply', async () => {
+        const effect: chatEffectParams = { message: 'test', chatter: 'Bot', sendAsReply: true };
+        const trigger: Effects.Trigger = { type: 'event', metadata: { eventData: {} } } as any;
+        await chatEffect.onTriggerEvent({ trigger, effect } as any);
+        expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('test', 'Bot', undefined);
+    });
+});

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -1,4 +1,4 @@
-import { IntegrationData } from "@crowbartools/firebot-custom-scripts-types";
+import { IntegrationData, ScriptModules } from "@crowbartools/firebot-custom-scripts-types";
 import { EventEmitter } from "events";
 import { platformCondition } from "./conditions/platform";
 import { IntegrationConstants } from "./constants";
@@ -362,6 +362,10 @@ export class KickIntegration extends EventEmitter {
 
     isChatFeedEnabled(): boolean {
         return this.settings.general.chatFeed;
+    }
+
+    getModules(): ScriptModules {
+        return firebot.modules;
     }
 
     getSettings(): IntegrationParameters {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds an option to send a message to Kick as a reply. This was added to both the Chat (Kick) and the Chat (Platform Aware) effects.

While writing tests for this, I discovered that the "default send to Twitch" and "default send to Kick" when the platform was unknown were broken, so these were fixed too.

### Motivation
Kick API supports replies, so we may as well give that option.

### Testing
Tests cover this code extensively and even caught a bug from when there were no tests. Additionally tested this for both Twitch and Kick on my setup.
