### PR TITLE
Add event for incoming hosts (raids)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Currently supported:
   - Channel points redeemed
   - Chat message
   - Follow
+  - Host (raid)
   - Stream started
   - Stream ended
   - Viewer arrived
@@ -55,7 +56,9 @@ Currently supported:
   - Viewer timed out
 - Filters:
   - Platform
+  - Viewer count (hosts)
 - Variables:
+  - `$hostViewerCount` (also returns viewer count for Twitch raids)
   - `$kickCategory` (`$kickCategory`) for your channel or another channel
   - `$kickCategoryId` (`$kickGameId`) for your channel or another channel
   - `$kickCategoryImageUrl` for your channel or another channel
@@ -75,6 +78,7 @@ Currently supported:
   - `$kickUptime` for your channel or another channel
   - `$kickUserDisplayName`
   - `$platform`
+  - `$platformAwareUserDisplayName`
 
 Planned but not yet supported:
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -113,11 +113,17 @@ Here's how to do it:
 
         - Are you using the default "Chat" effect built into Firebot to send a response? This will always send the message to Twitch, even if you're trying to reply to a message posted on Kick! (You probably need to convert this to the "Chat (Platform Aware)" effect distributed with this integration.)
 
-        - Are you using `$userDisplayName[$username]`? The `$userDisplayName` variable only queries Twitch users, so if it's a Kick user, you'll get `[Error]`. (You should use `$platformAwareUserDisplayName[$username]` from this integration instead as it'll work for either.)
-
         - Are you adding or removing VIP or moderator status from a user, banning a user, timing out a user, etc., as a result of an event? If the event comes in via Kick, this may have unexpected results when the API calls are sent to Twitch because the User IDs will be different.
 
         - Are you using the "Chat Message" event to route messages to a chat overlay, such as with the [Mage Onscreen Chat](https://github.com/TheStaticMage/firebot-mage-onscreen-chat) overlay? If so, you might be running afoul of the Twitch terms of service by merging chat messages from multiple platforms on your stream.
+
+        :warning: **CAUTION**: If you intend to have a combined event handler, be sure that you have thoroughly reviewed the variables being used. Here is a partial list of common gotchas:
+
+        - The `$chatMessage` variable only works for Twitch chat messages. Use `$kickChatMessage` for Kick chat messages.
+
+        - The `$raidViewerCount` variable only works for Twitch raids, so if you are handling a Kick host, this will evaluate to 0. (You can use `$hostViewerCount` for either platform instead.)
+
+        - The `$userDisplayName` variable only queries Twitch users, so if it's a Kick user, you'll get `[Error]`. (You can use `$platformAwareUserDisplayName[$username]` for either platform instead.)
 
         Note: Triggering the equivalent Firebot Twitch events is _in addition to_ triggering the Kick events supplied by this integration. (The Kick variants of these events will always be triggered, whether or not you have the box checked to trigger the equivalent Twitch event.)
 

--- a/src/__tests__/dummy.test.ts
+++ b/src/__tests__/dummy.test.ts
@@ -1,5 +1,0 @@
-import { expect, test } from '@jest/globals';
-
-test('dummy test (always passes)', () => {
-    expect(true).toBe(true);
-});

--- a/src/__tests__/host.test.ts
+++ b/src/__tests__/host.test.ts
@@ -1,0 +1,132 @@
+export const triggerEventMock = jest.fn();
+
+export const userManagerMock = {
+    getViewerById: jest.fn(),
+    createNewViewer: jest.fn()
+};
+
+jest.mock('../integration', () => ({
+    integration: {
+        getSettings: () => null,
+        kick: {
+            userManager: userManagerMock
+        }
+    }
+}));
+
+jest.mock('../main', () => ({
+    firebot: {
+        modules: {
+            eventManager: {
+                triggerEvent: triggerEventMock
+            }
+        }
+    },
+    logger: {
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn()
+    }
+}));
+
+import { KickPusher } from '../internal/pusher/pusher';
+import { IntegrationConstants } from '../constants';
+import { FirebotViewer } from '@crowbartools/firebot-custom-scripts-types/types/modules/viewer-database';
+
+describe('e2e stream hosted', () => {
+    let pusher: KickPusher;
+
+    beforeEach(() => {
+        pusher = new KickPusher();
+        jest.clearAllMocks();
+    });
+
+    const jsonInput = `{"message":{"id":"d251ef14-5f5c-4593-8f7d-f5cc0aa52571","numberOfViewers":32,"optionalMessage":"","createdAt":"2025-08-20T20:26:31.231698Z"},"user":{"id":1234567,"username":"Kicker","isSuperAdmin":false,"verified":{"id":12345,"channel_id":7654321,"created_at":"2025-05-12T14:00:00.000000Z","updated_at":"2025-05-12T14:00:00.000000Z"}}}`;
+    const payload = JSON.parse(jsonInput);
+    const event = 'App\\Events\\StreamHostedEvent';
+    const expectedMetadata = {
+        userId: 'k1234567',
+        username: 'Kicker@kick',
+        userDisplayName: 'Kicker',
+        viewerCount: 32,
+        platform: 'kick'
+    };
+    const firebotViewer: FirebotViewer = {
+        _id: 'k1234567',
+        username: 'Kicker@kick',
+        displayName: 'Kicker',
+        profilePicUrl: '',
+        twitch: false,
+        twitchRoles: [],
+        online: false,
+        onlineAt: 0,
+        lastSeen: 0,
+        joinDate: 0,
+        minutesInChannel: 0,
+        chatMessages: 0,
+        disableAutoStatAccrual: true,
+        disableActiveUserList: true,
+        disableViewerList: true,
+        metadata: {},
+        currency: {},
+        ranks: {}
+    };
+
+    describe('twitch forwarding enabled', () => {
+        describe('viewer database had user', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({ triggerTwitchEvents: { raid: true } });
+                (userManagerMock.getViewerById).mockReturnValueOnce(firebotViewer);
+            });
+
+            it('triggers all expected events', async () => {
+                await expect((pusher as any).dispatchChatroomEvent(event, payload)).resolves.not.toThrow();
+                expect(userManagerMock.createNewViewer).not.toHaveBeenCalled();
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "raid", expectedMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "raid", expectedMetadata);
+            });
+        });
+
+        describe('viewer database created user', () => {
+            beforeEach(() => {
+                (userManagerMock.createNewViewer).mockReturnValueOnce(firebotViewer);
+            });
+
+            it('triggers all expected events', async () => {
+                await expect((pusher as any).dispatchChatroomEvent(event, payload)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "raid", expectedMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "raid", expectedMetadata);
+            });
+        });
+
+        describe('viewer database failed', () => {
+            it('triggers all expected events', async () => {
+                await expect((pusher as any).dispatchChatroomEvent(event, payload)).resolves.not.toThrow();
+                expect(userManagerMock.getViewerById).toHaveBeenCalledWith("k1234567");
+                expect(userManagerMock.createNewViewer).toHaveBeenCalledWith({"channelSlug": "", "displayName": "Kicker", "isVerified": true, "profilePicture": "", "userId": "1234567", "username": "Kicker"}, [], true);
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "raid", expectedMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "raid", expectedMetadata);
+            });
+        });
+    });
+
+    describe('twitch forwarding disabled', () => {
+        beforeEach(() => {
+            const integration = require('../integration').integration;
+            integration.getSettings = () => ({ triggerTwitchEvents: { raid: false } });
+            (userManagerMock.getViewerById).mockReturnValueOnce(firebotViewer);
+        });
+
+        it('triggers all expected events', async () => {
+            await expect((pusher as any).dispatchChatroomEvent(event, payload)).resolves.not.toThrow();
+            expect(userManagerMock.createNewViewer).not.toHaveBeenCalled();
+            expect(triggerEventMock).toHaveBeenCalledTimes(1);
+            expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "raid", expectedMetadata);
+        });
+    });
+});

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -1,4 +1,5 @@
 import { EventSource } from '@crowbartools/firebot-custom-scripts-types/types/modules/event-manager';
+import { unkickifyUsername } from "./internal/util";
 
 export const eventSource: EventSource = {
     id: "mage-kick-integration",
@@ -188,6 +189,27 @@ export const eventSource: EventSource = {
                 username: "firebot",
                 userDisplayName: "Firebot",
                 userId: ""
+            }
+        },
+        {
+            id: "raid",
+            name: "Incoming Host (Kick)",
+            description: "When someone else hosts (raids) your channel on Kick",
+            cached: true,
+            cacheMetaKey: "username",
+            manualMetadata: {
+                username: "firebot@kick",
+                userDisplayName: "Firebot",
+                userId: "k1234567",
+                viewerCount: 42
+            },
+            activityFeed: {
+                icon: "fad fa-inbox-in",
+                getMessage: (eventData) => {
+                    const username = typeof eventData.username === "string" ? unkickifyUsername(eventData.username) : "Unknown User";
+                    const userDisplayName = typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : username;
+                    return `**${userDisplayName}** hosted on Kick with **${eventData.viewerCount}** viewer(s)`;
+                }
             }
         }
     ]

--- a/src/events/stream-hosted-event.ts
+++ b/src/events/stream-hosted-event.ts
@@ -1,0 +1,35 @@
+import { IntegrationConstants } from "../constants";
+import { integration } from "../integration";
+import { kickifyUserId, kickifyUsername, unkickifyUsername } from "../internal/util";
+import { firebot, logger } from "../main";
+import { StreamHostedEvent } from "../shared/types";
+
+export async function handleStreamHostedEvent(payload: StreamHostedEvent): Promise<void> {
+    const userId = kickifyUserId(payload.user.userId.toString());
+    const username = kickifyUsername(payload.user.username);
+
+    // Create the user if they don't exist
+    let viewer = await integration.kick.userManager.getViewerById(userId);
+    if (!viewer) {
+        viewer = await integration.kick.userManager.createNewViewer(payload.user, [], true);
+        if (!viewer) {
+            logger.warn(`Failed to create new viewer for userId=${userId}`);
+        }
+    }
+
+    // Trigger the follow event
+    const { eventManager } = firebot.modules;
+    const metadata = {
+        username: username,
+        userId: userId,
+        userDisplayName: viewer && viewer.displayName ? viewer.displayName : unkickifyUsername(username),
+        viewerCount: payload.numberOfViewers,
+        platform: "kick"
+    };
+    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "raid", metadata);
+
+    // Trigger the Twitch raid event if enabled via the integration settings
+    if (integration.getSettings().triggerTwitchEvents.raid) {
+        eventManager.triggerEvent("twitch", "raid", metadata);
+    }
+}

--- a/src/filters/host-viewer-count.ts
+++ b/src/filters/host-viewer-count.ts
@@ -1,0 +1,69 @@
+import { EventFilter } from "@crowbartools/firebot-custom-scripts-types/types/modules/event-filter-manager";
+import { IntegrationConstants } from "../constants";
+import { logger } from "../main";
+
+enum ComparisonType {
+    IS = "is",
+    IS_NOT = "is not",
+    LESS_THAN = "less than",
+    LESS_THAN_OR_EQUAL_TO = "less than or equal to",
+    GREATER_THAN = "greater than",
+    GREATER_THAN_OR_EQUAL_TO = "greater than or equal to"
+}
+
+export const hostViewerCountFilter: EventFilter = {
+    id: `${IntegrationConstants.INTEGRATION_ID}:host-viewer-count`,
+    name: "Host Viewer Count",
+    description: "Filter by how many viewers have been brought by the host.",
+    events: [
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "raid" }
+    ],
+    comparisonTypes: [
+        ComparisonType.IS,
+        ComparisonType.IS_NOT,
+        ComparisonType.LESS_THAN,
+        ComparisonType.LESS_THAN_OR_EQUAL_TO,
+        ComparisonType.GREATER_THAN,
+        ComparisonType.GREATER_THAN_OR_EQUAL_TO
+    ],
+    valueType: "number",
+    predicate: async (
+        filterSettings,
+        eventData: {
+            eventMeta: {
+                viewerCount?: number;
+            }
+        }
+    ): Promise<boolean> => {
+        const { comparisonType, value } = filterSettings;
+        const viewerCount = eventData.eventMeta.viewerCount || 0;
+        return compareValue(comparisonType as ComparisonType, value, viewerCount);
+    }
+};
+
+function compareValue(
+    comparisonType: ComparisonType,
+    expectedValue: unknown,
+    actualValue: unknown
+): boolean {
+    logger.debug(`Comparing values: type=${comparisonType}, expected='${expectedValue}', actual='${actualValue}'`);
+    const expectedNum = Number(expectedValue);
+    const actualNum = Number(actualValue);
+
+    switch (comparisonType) {
+        case ComparisonType.IS:
+            return actualNum === expectedNum;
+        case ComparisonType.IS_NOT:
+            return actualNum !== expectedNum;
+        case ComparisonType.LESS_THAN:
+            return actualNum < expectedNum;
+        case ComparisonType.LESS_THAN_OR_EQUAL_TO:
+            return actualNum <= expectedNum;
+        case ComparisonType.GREATER_THAN:
+            return actualNum > expectedNum;
+        case ComparisonType.GREATER_THAN_OR_EQUAL_TO:
+            return actualNum >= expectedNum;
+        default:
+            return false;
+    }
+}

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -8,6 +8,7 @@ import { streamGameEffect } from "./effects/stream-game";
 import { streamTitleEffect } from "./effects/stream-title";
 import { triggerCustomChannelRewardEffect } from "./effects/trigger-custom-channel-reward";
 import { eventSource } from './event-source';
+import { hostViewerCountFilter } from "./filters/host-viewer-count";
 import { platformFilter } from "./filters/platform";
 import { rewardTitleFilter } from "./filters/reward-title";
 import { AuthManager } from "./internal/auth";
@@ -23,6 +24,7 @@ import { kickCategoryImageUrlVariable } from "./variables/category-image-url";
 import { kickChannelIdVariable } from "./variables/channel-id";
 import { kickChatMessageVariable } from "./variables/chat-message";
 import { kickCurrentViewerCountVariable } from "./variables/current-viewer-count";
+import { hostViewerCount } from "./variables/host-viewer-count";
 import { kickModReason } from "./variables/mod-reason";
 import { kickModerator } from "./variables/moderator";
 import { platformVariable } from "./variables/platform";
@@ -58,6 +60,7 @@ type IntegrationParameters = {
     triggerTwitchEvents: {
         chatMessage: boolean;
         follower: boolean;
+        raid: boolean;
         streamOnline: boolean;
         streamOffline: boolean;
         viewerArrived: boolean;
@@ -125,6 +128,7 @@ export class KickIntegration extends EventEmitter {
         triggerTwitchEvents: {
             chatMessage: false,
             follower: false,
+            raid: false,
             streamOffline: false,
             streamOnline: false,
             viewerArrived: false,
@@ -181,6 +185,7 @@ export class KickIntegration extends EventEmitter {
         eventManager.registerEventSource(eventSource);
 
         const { eventFilterManager } = firebot.modules;
+        eventFilterManager.registerFilter(hostViewerCountFilter);
         eventFilterManager.registerFilter(platformFilter);
         eventFilterManager.registerFilter(rewardTitleFilter);
 
@@ -202,6 +207,7 @@ export class KickIntegration extends EventEmitter {
         replaceVariableManager.registerReplaceVariable(kickStreamerVariable);
 
         // Stream variables
+        replaceVariableManager.registerReplaceVariable(hostViewerCount);
         replaceVariableManager.registerReplaceVariable(kickCurrentViewerCountVariable);
         replaceVariableManager.registerReplaceVariable(kickStreamIsLiveVariable);
         replaceVariableManager.registerReplaceVariable(kickStreamTitleVariable);

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -109,40 +109,47 @@ export const definition: IntegrationDefinition = {
                     default: false,
                     sortRank: 2
                 },
+                raid: {
+                    title: "Host (Raid)",
+                    tip: "Trigger the 'Twitch:Raid' event when someone hosts (raids) your stream on Kick",
+                    type: "boolean",
+                    default: false,
+                    sortRank: 3
+                },
                 streamOffline: {
                     title: "Stream Ended",
                     tip: "Trigger the 'Twitch:Stream Ended' event when the Kick stream goes offline",
                     type: "boolean",
                     default: false,
-                    sortRank: 3
+                    sortRank: 4
                 },
                 streamOnline: {
                     title: "Stream Started",
                     tip: "Trigger the 'Twitch:Stream Started' event when the Kick stream goes online",
                     type: "boolean",
                     default: false,
-                    sortRank: 4
+                    sortRank: 5
                 },
                 viewerArrived: {
                     title: "Viewer Arrived",
                     tip: "Trigger the 'Twitch:Viewer Arrived' event when a viewer arrives on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 5
+                    sortRank: 6
                 },
                 viewerBanned: {
                     title: "Viewer Banned",
                     tip: "Trigger the 'Twitch:Viewer Banned' event when a viewer is banned on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 6
+                    sortRank: 7
                 },
                 viewerTimeout: {
                     title: "Viewer Timeout",
                     tip: "Trigger the 'Twitch:Viewer Timeout' event when a viewer is timed out on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 7
+                    sortRank: 8
                 }
             }
         },

--- a/src/internal/pusher/__tests__/pusher.test.ts
+++ b/src/internal/pusher/__tests__/pusher.test.ts
@@ -197,3 +197,30 @@ describe('KickPusher.parseRewardRedeemedEvent', () => {
         });
     });
 });
+
+describe('KickPusher.parseStreamHostedEvent', () => {
+    let pusher: KickPusher;
+
+    beforeEach(() => {
+        pusher = new KickPusher();
+        jest.clearAllMocks();
+    });
+
+    it('parses a StreamHostedEvent payload', () => {
+        const jsonInput = `{"message":{"id":"d251ef14-5f5c-4593-8f7d-f5cc0aa52571","numberOfViewers":32,"optionalMessage":"","createdAt":"2025-08-20T20:26:31.231698Z"},"user":{"id":1234567,"username":"Kicker","isSuperAdmin":false,"verified":{"id":12345,"channel_id":7654321,"created_at":"2025-05-12T14:00:00.000000Z","updated_at":"2025-05-12T14:00:00.000000Z"}}}`;
+        const result = (pusher as any).parseStreamHostedEvent(JSON.parse(jsonInput));
+        expect(result).toEqual({
+            user: {
+                userId: "1234567",
+                username: "Kicker",
+                displayName: "Kicker",
+                profilePicture: "",
+                isVerified: true,
+                channelSlug: ""
+            },
+            numberOfViewers: 32,
+            optionalMessage: "",
+            createdAt: new Date("2025-08-20T20:26:31.231698Z")
+        });
+    });
+});

--- a/src/internal/pusher/hostedevent.d.ts
+++ b/src/internal/pusher/hostedevent.d.ts
@@ -1,0 +1,19 @@
+interface InboundStreamHostedEvent {
+    message: {
+        id: string;
+        numberOfViewers: number;
+        optionalMessage: string;
+        createdAt: string;
+    };
+    user: {
+        id: number;
+        username: string;
+        isSuperAdmin: boolean;
+        verified?: {
+            id: number;
+            channel_id: number;
+            created_at: string;
+            updated_at: string;
+        };
+    };
+}

--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -1,8 +1,9 @@
 import { handleChatMessageSentEvent } from "../../events/chat-message-sent";
 import { handleRewardRedeemedEvent } from "../../events/reward-redeemed-event";
+import { handleStreamHostedEvent } from "../../events/stream-hosted-event";
 import { integration } from "../../integration";
 import { logger } from "../../main";
-import { ChatMessage, KickUser, RewardRedeemedEvent } from "../../shared/types";
+import { ChatMessage, KickUser, RewardRedeemedEvent, StreamHostedEvent } from "../../shared/types";
 import { parseDate } from "../util";
 
 const Pusher = require('pusher-js');
@@ -94,6 +95,9 @@ export class KickPusher {
                 case 'App\\Events\\ChatMessageEvent':
                     await handleChatMessageSentEvent(this.parseChatMessageEvent(data));
                     break;
+                case 'App\\Events\\StreamHostedEvent':
+                    await handleStreamHostedEvent(this.parseStreamHostedEvent(data));
+                    break;
                 case 'RewardRedeemedEvent':
                     await handleRewardRedeemedEvent(this.parseRewardRedeemedEvent(data));
                     break;
@@ -156,6 +160,23 @@ export class KickPusher {
             username: d.username,
             userInput: d.user_input,
             rewardBackgroundColor: d.reward_background_color
+        };
+    }
+
+    private parseStreamHostedEvent(data: any): StreamHostedEvent {
+        const d = data as InboundStreamHostedEvent;
+        return {
+            user: {
+                userId: d.user.id.toString(),
+                username: d.user.username,
+                displayName: d.user.username,
+                profilePicture: '', // Not provided in event
+                isVerified: d.user.verified ? true : false,
+                channelSlug: '' // Not provided in event
+            },
+            numberOfViewers: d.message.numberOfViewers,
+            optionalMessage: d.message.optionalMessage,
+            createdAt: parseDate(d.message.createdAt)
         };
     }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -108,3 +108,10 @@ export interface RewardRedeemedEvent {
     userInput: string;
     rewardBackgroundColor: string;
 }
+
+export interface StreamHostedEvent {
+    user: KickUser;
+    numberOfViewers: number;
+    optionalMessage: string;
+    createdAt: Date | undefined;
+}

--- a/src/variables/__tests__/platform.test.ts
+++ b/src/variables/__tests__/platform.test.ts
@@ -196,9 +196,14 @@ describe('platformVariable.evaluator', () => {
         expect(platformVariable.evaluator(trigger)).toBe('unknown');
     });
 
-    it('returns "manual" if trigger type is manual', () => {
-        const trigger = { type: 'manual', metadata: { eventData: undefined, platform: undefined, eventSource: undefined, chatMessage: undefined } } as any;
-        expect(platformVariable.evaluator(trigger)).toBe('manual');
+    it('returns kick for Kick events manually triggered', () => {
+        const trigger = { type: 'manual', metadata: { eventData: undefined, platform: undefined, eventSource: { id: IntegrationConstants.INTEGRATION_ID }, chatMessage: undefined } } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('kick');
+    });
+
+    it('returns twitch for Twitch events manually triggered', () => {
+        const trigger = { type: 'manual', metadata: { eventData: undefined, platform: undefined, eventSource: { id: 'twitch' }, chatMessage: undefined } } as any;
+        expect(platformVariable.evaluator(trigger)).toBe('twitch');
     });
 
     it('returns "unknown" if trigger type is not event or manual', () => {

--- a/src/variables/host-viewer-count.ts
+++ b/src/variables/host-viewer-count.ts
@@ -1,0 +1,22 @@
+import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+
+export const hostViewerCount: ReplaceVariable = {
+    definition: {
+        handle: "hostViewerCount",
+        description: "Outputs the number of viewers in the Kick host or the Twitch raid.",
+        triggers: {
+            "manual": true,
+            "event": [
+                "mage-kick-integration:raid",
+                "twitch:raid",
+                "twitch:raid-sent-off"
+            ]
+        },
+        categories: ["common"],
+        possibleDataOutput: ["number"]
+    },
+    evaluator: (trigger: Effects.Trigger) => {
+        return trigger.metadata.eventData?.viewerCount || 0;
+    }
+};

--- a/src/variables/platform.ts
+++ b/src/variables/platform.ts
@@ -16,9 +16,14 @@ export const platformVariable: ReplaceVariable = {
         }
     },
     evaluator: (trigger) => {
-        // Manual trigger returns "manual"
+        // Manual trigger prefers the event source regardless of metadata
         if (trigger.type === "manual") {
-            return debugPlatform("manual", "trigger.type", trigger);
+            switch (trigger.metadata.eventSource?.id) {
+                case IntegrationConstants.INTEGRATION_ID:
+                    return debugPlatform("kick", "metadata.eventSource.id (manual)", trigger);
+                case "twitch":
+                    return debugPlatform("twitch", "metadata.eventSource.id (manual)", trigger);
+            }
         }
 
         // See if the platform is explicitly set in the metadata


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This adds an event for incoming hosts (i.e. raids), a filter on viewer count for hosts, and `$hostViewerCount` for the viewer count. There is also an option to forward this event to the `Twitch:Raid` event.

`$hostViewerCount` works for Kick hosts and Twitch raids.

### Motivation
Another event we want to handle.

### Testing
I couldn't test this in real life, but I got a pusher payload from a streamer whose stream was hosted and incorporated that into an end-to-end test. So I hope this works but have not actually tested it on Kick.

The variable and filter were tested via simulated events.
