### PR TITLE
Properly parse a pusher chat message with no metadata

### DIFF
--- a/src/internal/pusher/__tests__/pusher.test.ts
+++ b/src/internal/pusher/__tests__/pusher.test.ts
@@ -174,6 +174,41 @@ describe('KickPusher.parseChatMessageEvent', () => {
         expect(result.createdAt).toBeInstanceOf(Date);
         expect(result.createdAt.toISOString()).toBe('2025-08-20T07:07:44.000Z');
     });
+
+    it('parses a message with no metadata', () => {
+        const jsonInput = `{"id":"59778b1e-9c4d-42e3-a1c7-8cf6de3eee79","chatroom_id":2346570,"content":"Message sent as bot","type":"message","created_at":"2025-08-21T07:20:31+00:00","sender":{"id":72805522,"username":"thestaticmagetest","slug":"thestaticmagetest","identity":{"color":"#31D6C2","badges":[]}}}`;
+
+        const result = (pusher as any).parseChatMessageEvent(JSON.parse(jsonInput));
+
+        expect(result).toEqual({
+            messageId: '59778b1e-9c4d-42e3-a1c7-8cf6de3eee79',
+            broadcaster: {
+                userId: '123',
+                username: 'broadcasterUser',
+                displayName: 'broadcasterUser',
+                profilePicture: 'pic_url',
+                isVerified: false,
+                channelSlug: 'broadcasterUser'
+            },
+            sender: {
+                userId: '72805522',
+                username: 'thestaticmagetest',
+                displayName: 'thestaticmagetest',
+                profilePicture: '',
+                isVerified: false,
+                channelSlug: 'thestaticmagetest',
+                identity: {
+                    usernameColor: '#31D6C2',
+                    badges: []
+                }
+            },
+            content: 'Message sent as bot',
+            createdAt: new Date('2025-08-21T07:20:31.000Z'),
+            repliesTo: undefined
+        });
+        expect(result.createdAt).toBeInstanceOf(Date);
+        expect(result.createdAt.toISOString()).toBe('2025-08-21T07:20:31.000Z');
+    });
 });
 
 describe('KickPusher.parseRewardRedeemedEvent', () => {

--- a/src/internal/pusher/chatmessageevent.d.ts
+++ b/src/internal/pusher/chatmessageevent.d.ts
@@ -13,9 +13,9 @@ interface ChatMessageEvent {
             badges: InboundBadge[];
         };
     };
-    metadata: {
+    metadata?: {
         original_sender: InboundOriginalSender;
-        original_message: InboundOriginalMessage;
+        original_message?: InboundOriginalMessage;
         message_ref: string;
     };
 }

--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -136,7 +136,7 @@ export class KickPusher {
             },
             content: d.content,
             createdAt: parseDate(d.created_at),
-            repliesTo: d.metadata.original_message && d.metadata.original_sender ? {
+            repliesTo: d.metadata && d.metadata.original_message && d.metadata.original_sender ? {
                 messageId: d.metadata.original_message.id,
                 content: d.metadata.original_message.content,
                 sender: {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Received chat messages from pusher that had no metadata section, which was breaking the parsing. This fixes it.

### Motivation
These were programmatically posted messages. Even though the pusher payloads are inconsistent, we want it all to work.

### Testing
Tested with both typed messages and generated messages.
