### PR TITLE
Fix send as reply for kick platform-aware chat

### DIFF
--- a/src/effects/__tests__/chat-platform.test.ts
+++ b/src/effects/__tests__/chat-platform.test.ts
@@ -69,7 +69,7 @@ describe('chatPlatformEffect.onTriggerEvent', () => {
 
     it('sends to Kick with reply id for command', async () => {
         jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('kick');
-        const effect: chatPlatformEffectParams = { message: 'hi', chatterKick: 'Bot', chatterTwitch: 'Bot', sendAsReply: true, copyMessageKick: true, defaultSendKick: true };
+        const effect: chatPlatformEffectParams = { message: 'hi', chatterKick: 'Bot', chatterTwitch: 'Bot', sendAsReplyKick: true, copyMessageKick: true, defaultSendKick: true };
         const trigger: Effects.Trigger = { type: 'command', metadata: { chatMessage: { id: 'msg123' }, eventSource: { id: 'kick' }} } as any;
         await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
         expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('hi', 'Bot', 'msg123');
@@ -77,7 +77,7 @@ describe('chatPlatformEffect.onTriggerEvent', () => {
 
     it('sends to Kick with reply id for event', async () => {
         jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('kick');
-        const effect: chatPlatformEffectParams = { message: 'yo', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendAsReply: true, copyMessageKick: true, defaultSendKick: true };
+        const effect: chatPlatformEffectParams = { message: 'yo', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendAsReplyKick: true, copyMessageKick: true, defaultSendKick: true };
         const trigger: Effects.Trigger = { type: 'event', metadata: { eventData: { chatMessage: { id: 'evt456' } }, eventSource: { id: 'kick' }} } as any;
         await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
         expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('yo', 'Streamer', 'evt456');

--- a/src/effects/chat-platform.ts
+++ b/src/effects/chat-platform.ts
@@ -138,7 +138,7 @@ export const chatPlatformEffect: Firebot.EffectType<chatPlatformEffectParams> = 
     optionsController: ($scope) => {
         if (!$scope.effect) {
             $scope.effect = {
-                chatterKick: "Streamer",
+                chatterKick: "Bot",
                 chatterTwitch: "Bot",
                 copyMessageKick: true,
                 defaultSendKick: false,
@@ -214,7 +214,7 @@ export const chatPlatformEffect: Firebot.EffectType<chatPlatformEffectParams> = 
                 logger.debug("Skipping sending message to Kick as per effect settings.");
             } else {
                 let messageId = undefined;
-                if (effect.sendAsReply && platform === 'kick') {
+                if (effect.sendAsReplyKick && platform === 'kick') {
                     if (trigger.type === "command") {
                         messageId = trigger.metadata.chatMessage.id;
                     } else if (trigger.type === "event") {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
The platform aware chat effect was incorrectly using the "send as reply" setting configured for Twitch when deciding if the Kick message would be sent as a reply. Now this will respect the actual "send as reply" as configured for Kick.

### Motivation
<!-- Please describe WHY you are making this change. This may include links to GitHub issues if relevant. -->

### Testing
Updated the tests and tested on my instance.
