### PR TITLE
Add optional second "bot" account to chat as

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This [Firebot](https://firebot.app) integration provides events and effects for 
 
 Currently supported:
 
+- Accounts:
+  - Chat as the streamer or as a separate bot account
 - Chat integration:
   - Kick messages appear in Firebot's chat feed (Dashboard), displaying Kick usernames and supporting emotes.
   - Ban user from the context menu in the chat feed.
@@ -87,7 +89,6 @@ Planned but not yet supported:
 - Events when a user is unbanned or untimed-out
 - Effects to ban, unban, timeout, and untimeout users
 - Chat roles
-- Chat as a separate user account
 
 Limitations due to Kick:
 
@@ -103,8 +104,6 @@ Limitations due to Firebot:
 - Firebot's viewer database uses Twitch user IDs as primary keys and assumes every user is from Twitch. This rigid design prevents full platform independence.
 - Rate limiting (cooldowns) for commands and redeems doesn't work natively. Consider using the [Firebot Rate Limiter](https://github.com/TheStaticMage/firebot-rate-limiter) if needed.
 - Many built-in Firebot variables and effects are hard-coded to be available only to specific Twitch events. Therefore, this integration introduces Kick-specific variables like `$kickModerator`. Alternatively, you can trigger equivalent Twitch events if your effects are platform-aware.
-- Kick authorization flow is clunky. Thankfully, you'll only need to authorize once.
-- Unlinking the integration causes Firebot to purge configuration data. Without relinking immediately, settings (like webhook URL, channel IDs, and other preferences) are lost.
 
 ## Installation
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -91,6 +91,10 @@ Here's how to do it:
 
       - **Client Secret**: Copy the client secret from the [Kick app](/doc/kick-app.md) that you created.  _Leave this setting blank if you are using a webhook proxy._
 
+    - **Accounts**
+
+      _We will come back very soon and authorize the accounts. Just skip this for now while you review the rest of the settings._
+
     - **General Settings**
 
       - **Chat Feed**: If checked (default), chat messages on Kick will be added to the Firebot chat feed, shown when you click on DASHBOARD in Firebot. Don't worry, this will not forward these messages to Twitch, add them to any on-screen chat overlay, etc. The [Twitch Simulcasting FAQ](https://help.twitch.tv/s/article/simulcasting-guidelines?language=en_US) explicitly notes that it's fine for you to use a tool that combines Twitch and Kick activity for your own use so long as you do not show it on stream:
@@ -139,32 +143,52 @@ Here's how to do it:
 
         THE DEVELOPER OF THIS INTEGRATION DOES NOT EVEN HAVE THESE ENABLED ON HIS OWN PRODUCTION FIREBOT INSTANCE!
 
-4. Click **Save** when you're done.
+4. Click **Save** when you're done. (Save your settings before you proceed to the authentication steps.)
 
-## Authentication
+## Authentication of Streamer
 
 You will authenticate to Kick using your browser, which will grant a token to the application. This uses a technology called [OAuth](https://docs.kick.com/getting-started/generating-tokens-oauth2-flow) which ensures that your Kick password is never needed by the Firebot integration.
 
-1. Navigate to Settings &gt; Integrations and look for the integration entitled **MageKickIntegration**.
+1. Log in to Kick as the streamer.
 
-2. If there is a button called **Unlink** next to that integration, you have already authenticated. If you want to re-authenticate, you can click this button to disconnect and unlink.
+2. Click the following link:
 
-3. Click the **Link** button.
+   [`http://localhost:7472/integrations/firebot-mage-kick-integration/link/streamer`](http://localhost:7472/integrations/firebot-mage-kick-integration/link/streamer)
 
-4. This will pop open an info box with a URL. You can copy and paste that URL to your browser. Or you can click here for the default URL:
+3. You will be redirected to a screen on Kick's website that prompts you to authorize the application. Click the **Allow Access** button.
 
-    [`http://localhost:7472/integrations/firebot-mage-kick-integration/link`](http://localhost:7472/integrations/firebot-mage-kick-integration/link)
+4. If everything works as it should, you should see this message in your browser after a few seconds:
 
-    _The integration author apologizes for the awkwardness of this flow. Firebot does not currently expose sufficient resources to script authors to create a dialog box with a clickable link._
-
-5. This will bring you to Kick's website. You may be prompted to log in if you have not already. The screen then prompts you to authorize the application. Click the **Allow Access** button.
-
-6. If everything works as it should, you should see this message in your browser after a few seconds:
-
-    > Kick integration connected successfully! You can close this tab.
+    > Kick integration authorized for streamer! You can close this tab.
 
     If you get that message, you can indeed close the tab.
 
-7. Back in Firebot, if the Info dialog with the URL is still open, you may close it.
+:bulb: You can re-authenticate at any time. The link to authenticate the streamer is also available under Settings &gt; Integrations &gt; **MageKickIntegration** &gt; Configure.
 
-:bulb: When you are done setting up the authentication or if you change any of the settings related to authentication (webhook proxy URL, client ID, client secret), you may need to connect. You can do this via the "Connections" which are accessed in the lower left corner of the Firebot application.
+## Authentication of Bot
+
+You may _optionally_ choose to have Firebot post chat messages as a separate Kick user, which we will call your "bot." (If you do not configure a separate bot user, chat messages will always be posted as the streamer.)
+
+1. Register a separate Kick account for your bot.
+
+2. Log in to Kick as the bot account. (We suggest using an incognito/private window so there is no confusion between your streamer account and bot account.)
+
+3. In Firebot, navigate to Settings &gt; Integrations &gt; **MageKickIntegration** and click the **Configure** button.
+
+4. Under the "Accounts" section, check the box for "Authorize Bot Account."
+
+5. Copy the link from the integration section into your (incognito) browser window, or just copy this link:
+
+   `http://localhost:7472/integrations/firebot-mage-kick-integration/link/bot`
+
+6. You will be redirected to a screen on Kick's website that prompts you to authorize the application. Click the **Allow Access** button.
+
+7. If everything works as it should, you should see this message in your browser after a few seconds:
+
+    > Kick integration authorized for bot! You can close this tab.
+
+    If you get that message, you can indeed close the tab.
+
+8. Be sure to save your integration settings in Firebot.
+
+:bulb: We suggest to make your bot a moderator so it can post URLs and bypass any other restrictions. (Note: this bot account does not attempt to take any "moderator" actions in the channel through Firebot.)

--- a/server/pkg/server/auth.go
+++ b/server/pkg/server/auth.go
@@ -180,7 +180,7 @@ func (s *Server) handleRefreshToken(ctx context.Context, w http.ResponseWriter, 
 	if result.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(result.Body)
 		s.log(ctx, r, "Refresh token request failed: status=%d, response=%s", result.StatusCode, body)
-		http.Error(w, fmt.Sprintf("Upstream refresh token request failed (%s)", requestId), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("Upstream refresh token request failed (%s)", requestId), result.StatusCode)
 		return
 	}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,12 +6,16 @@ export const IntegrationConstants = {
     KICK_API_SERVER: "https://api.kick.com",
     KICK_AUTH_SERVER: "https://id.kick.com",
     PUSHER_APP_KEY: "32cbd69e4b950bf97679",
-    SCOPES: [
+    STREAMER_SCOPES: [
         "user:read",
         "channel:read",
         "channel:write",
         "chat:write",
         "events:subscribe",
         "moderation:ban"
+    ],
+    BOT_SCOPES: [
+        "user:read",
+        "chat:write"
     ]
 } as const;

--- a/src/effects/chat-platform.ts
+++ b/src/effects/chat-platform.ts
@@ -179,7 +179,7 @@ export const chatPlatformEffect: Firebot.EffectType<chatPlatformEffectParams> = 
             $scope.effect.defaultSendTwitch = false;
         }
         if (!$scope.effect.chatterKick) {
-            $scope.effect.chatterKick = "Streamer";
+            $scope.effect.chatterKick = "Bot";
         }
         if (!$scope.effect.chatterTwitch) {
             $scope.effect.chatterTwitch = "Bot";

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -251,7 +251,7 @@ export class KickIntegration extends EventEmitter {
         if (!this.authManager.canConnect()) {
             const { frontendCommunicator } = firebot.modules;
             frontendCommunicator.send("error", `Kick Integration: You need to authorize the integration before you can use it. Do that in Settings > Integrations > ${IntegrationConstants.INTEGRATION_NAME}.`);
-            this.disconnect();
+            await this.disconnect();
             return;
         }
 
@@ -261,7 +261,7 @@ export class KickIntegration extends EventEmitter {
             logger.info("Kick authentication connected successfully.");
         } catch (error) {
             logger.error(`Failed to connect Kick authentication: ${error}`);
-            this.disconnect();
+            await this.disconnect();
             const { frontendCommunicator } = firebot.modules;
             frontendCommunicator.send("error", `Kick Integration: Failed to authenticate to Kick. You may need to re-authorize the integration. Do that in Settings > Integrations > ${IntegrationConstants.INTEGRATION_NAME}.`);
             return;
@@ -273,21 +273,21 @@ export class KickIntegration extends EventEmitter {
             logger.info("Kick API integration connected successfully.");
         } catch (error) {
             logger.error(`Failed to connect Kick API integration: ${error}`);
-            this.disconnect();
+            await this.disconnect();
             const { frontendCommunicator } = firebot.modules;
             frontendCommunicator.send("error", `Kick Integration: Failed to connect to the Kick API. You may need to re-authorize the integration. Do that in Settings > Integrations > ${IntegrationConstants.INTEGRATION_NAME}.`);
             return;
         }
 
         // Start the poller
-        this.poller.connect(this.proxyPollKey);
+        await this.poller.connect(this.proxyPollKey);
 
         // Websocket (pusher) connection setup
         try {
             this.pusher.connect(this.settings.connectivity.pusherAppKey, this.settings.connectivity.chatroomId, this.settings.connectivity.channelId);
         } catch (error) {
             logger.error(`Failed to connect Kick websocket (Pusher) integration: ${error}`);
-            this.disconnect();
+            await this.disconnect();
             const { frontendCommunicator } = firebot.modules;
             frontendCommunicator.send("error", `Kick Integration: Failed to connect to the Kick websocket (Pusher). You may need to reconfigure your channel and chatroom IDs in Settings > Integrations > ${IntegrationConstants.INTEGRATION_NAME}.`);
             return;
@@ -303,7 +303,7 @@ export class KickIntegration extends EventEmitter {
         this.connected = false;
         this.authManager.disconnect();
         await this.kick.disconnect();
-        this.poller.disconnect(this.proxyPollKey);
+        await this.poller.disconnect(this.proxyPollKey);
         this.pusher.disconnect();
         this.emit("disconnected", IntegrationConstants.INTEGRATION_ID);
         logger.info("Kick integration disconnected.");

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -9,7 +9,7 @@ export const definition: IntegrationDefinition = {
     description: IntegrationConstants.INTEGRATION_DESCRIPTION,
     connectionToggle: true,
     configurable: true,
-    linkType: "other", // Firebot doesn't support PKCE yet, so we use 'other' for now.
+    linkType: "none", // Firebot doesn't support PKCE yet, so we use 'none' for now.
     settingCategories: {
         connectivity: {
             title: "Connectivity Settings",
@@ -78,9 +78,29 @@ export const definition: IntegrationDefinition = {
                 }
             }
         },
+        accounts: {
+            title: "Accounts",
+            sortRank: 4,
+            settings: {
+                authorizeStreamerAccount: {
+                    title: "Authorize Streamer Account",
+                    tip: `Open this URL in a browser window to authorize the streamer account: http://localhost:7472/integrations/${IntegrationConstants.INTEGRATION_URI}/link/streamer`,
+                    type: "unknown",
+                    sortRank: 1
+                },
+                authorizeBotAccount: {
+                    title: "Authorize Bot Account",
+                    tip: `Open this URL in a browser window to authorize the bot account: http://localhost:7472/integrations/${IntegrationConstants.INTEGRATION_URI}/link/bot`,
+                    type: "boolean",
+                    description: "This is optional. You can register a separate account to chat in your stream.",
+                    default: false,
+                    sortRank: 2
+                }
+            }
+        },
         general: {
             title: "General Settings",
-            sortRank: 4,
+            sortRank: 5,
             settings: {
                 chatFeed: {
                     title: "Chat Feed",
@@ -93,7 +113,7 @@ export const definition: IntegrationDefinition = {
         },
         triggerTwitchEvents: {
             title: "Trigger Twitch Events",
-            sortRank: 5,
+            sortRank: 6,
             settings: {
                 chatMessage: {
                     title: "Chat Message",

--- a/src/internal/auth.ts
+++ b/src/internal/auth.ts
@@ -8,16 +8,25 @@ export class AuthManager {
     private authAborter = new AbortController();
     private authRenewer: NodeJS.Timeout | null = null;
     private codeChallenges: Record<string, string> = {};
+    private tokenRequests: Record<string, 'streamer' | 'bot'> = {};
     private authToken = "";
     private refreshToken = "";
     private tokenExpiresAt = 0;
+    private botAuthToken = "";
+    private botRefreshToken = "";
+    private botTokenExpiresAt = 0;
 
-    init(refreshToken: string) {
+    init(refreshToken: string, botRefreshToken: string) {
         this.refreshToken = refreshToken;
+        this.botRefreshToken = botRefreshToken;
     }
 
     canConnect(): boolean {
         return !!this.refreshToken;
+    }
+
+    isBotAuthorized(): boolean {
+        return !!this.botAuthToken;
     }
 
     async connect(): Promise<void> {
@@ -30,7 +39,7 @@ export class AuthManager {
         this.authAborter = new AbortController();
 
         try {
-            await this.refreshAuthToken();
+            await this.refreshAuthTokens();
         } catch (error) {
             this.disconnect();
             logger.error(`Failed to refresh Kick tokens: ${error}`);
@@ -65,13 +74,36 @@ export class AuthManager {
         return "";
     }
 
-    getAuthorizationRequestUrl(): string {
+    getBotAuthToken(): string {
+        if (!integration.getSettings().accounts.authorizeBotAccount) {
+            logger.debug("getBotAuthToken(): Bot account authorization is disabled.");
+            return "";
+        }
+
+        if (this.botAuthToken && this.botTokenExpiresAt > Date.now()) {
+            return this.botAuthToken;
+        }
+
+        if (this.botAuthToken) {
+            logger.warn("getBotAuthToken(): Bot auth token expired and has not yet been renewed");
+            return "";
+        }
+
+        // If we reach this point, it means the bot auth token is not available
+        logger.error("getBotAuthToken(): Bot auth token was never generated");
+        return "";
+    }
+
+    getAuthorizationRequestUrl(tokenType: 'streamer' | 'bot'): string {
         // Generate a random state value using uuidv4
         const state = randomUUID();
 
         // Generate a PKCE code challenge and verifier
         const { challenge: codeChallengeSha256, verifier: randomVerifier } = this.generatePKCEPair();
         this.codeChallenges[state] = randomVerifier;
+
+        // Are we getting this for the streamer or bot?
+        this.tokenRequests[state] = tokenType;
 
         // Depending on configuration, use either the webhook proxy or direct authorization
         if (integration.getSettings().webhookProxy.webhookProxyUrl) {
@@ -88,11 +120,13 @@ export class AuthManager {
     }
 
     private getAuthorizationRequestUrlWebhookProxy(state: string, codeChallengeSha256: string): string {
+        const tokenType = this.tokenRequests[state];
+
         // Upstream webhook proxy adds the client ID
         const params = new URLSearchParams({
             // eslint-disable-next-line camelcase
             redirect_uri: this.getLocalRedirectUri(),
-            scope: IntegrationConstants.SCOPES.join(" "),
+            scope: (tokenType === 'streamer' ? IntegrationConstants.STREAMER_SCOPES : IntegrationConstants.BOT_SCOPES).join(" "),
             // eslint-disable-next-line camelcase
             code_challenge: codeChallengeSha256,
             // eslint-disable-next-line camelcase
@@ -110,10 +144,12 @@ export class AuthManager {
             throw new Error("Kick app client ID or secret is not set in settings.");
         }
 
+        const tokenType = this.tokenRequests[state];
+
         const params = new URLSearchParams({
             // eslint-disable-next-line camelcase
             redirect_uri: this.getLocalRedirectUri(),
-            scope: IntegrationConstants.SCOPES.join(" "),
+            scope: (tokenType === 'streamer' ? IntegrationConstants.STREAMER_SCOPES : IntegrationConstants.BOT_SCOPES).join(" "),
             // eslint-disable-next-line camelcase
             code_challenge: codeChallengeSha256,
             // eslint-disable-next-line camelcase
@@ -127,18 +163,6 @@ export class AuthManager {
         const queryString = params.toString();
         const authUrl = `${IntegrationConstants.KICK_AUTH_SERVER}/oauth/authorize?${queryString}`;
         return authUrl;
-    }
-
-    unlink() {
-        this.authToken = "";
-        this.refreshToken = "";
-        this.tokenExpiresAt = 0;
-        this.codeChallenges = {};
-        if (this.authRenewer) {
-            clearTimeout(this.authRenewer);
-            this.authRenewer = null;
-        }
-        this.authAborter.abort();
     }
 
     private generatePKCEPair() {
@@ -157,7 +181,14 @@ export class AuthManager {
             res.status(400).send("Missing 'code' or 'state' in callback.");
             return;
         }
+
         logger.info(`handleAuthCallback received code for state: ${state}`);
+        const tokenType = this.tokenRequests[state];
+        if (!tokenType) {
+            logger.error(`Unknown token type for state: ${state}`);
+            res.status(400).send(`Unknown token type for state: ${state}`);
+            return;
+        }
 
         const payload = {
             // eslint-disable-next-line camelcase
@@ -186,16 +217,27 @@ export class AuthManager {
 
         try {
             const response = await httpCallWithTimeout(url, 'POST', '', payloadString);
-            this.authToken = response.access_token;
-            this.refreshToken = response.refresh_token;
-            const proxyPollKey = response.proxy_poll_key || "";
-            this.tokenExpiresAt = Date.now() + (response.expires_in * 1000); // Convert seconds to milliseconds
-            integration.kick.setAuthToken(this.authToken);
-            integration.saveIntegrationTokenData(this.refreshToken, proxyPollKey);
+
+            if (tokenType === 'streamer') {
+                this.authToken = response.access_token;
+                this.refreshToken = response.refresh_token;
+                this.tokenExpiresAt = Date.now() + (response.expires_in * 1000); // Convert seconds to milliseconds
+                integration.kick.setAuthToken(this.authToken);
+                logger.info(`Kick integration token for streamer refreshed successfully. Valid until: ${new Date(this.tokenExpiresAt).toISOString()}`);
+            } else {
+                this.botAuthToken = response.access_token;
+                this.botRefreshToken = response.refresh_token;
+                this.botTokenExpiresAt = Date.now() + (response.expires_in * 1000); // Convert seconds to milliseconds
+                integration.kick.setBotAuthToken(this.botAuthToken);
+                logger.info(`Kick integration token for bot refreshed successfully. Valid until: ${new Date(this.botTokenExpiresAt).toISOString()}`);
+            }
+
+            integration.saveIntegrationTokenData(this.refreshToken, this.botRefreshToken, tokenType === 'streamer' ? response.proxy_poll_key : null);
+            integration.disconnect();
             integration.connect();
 
             logger.info("Kick integration connected successfully!");
-            res.status(200).send("Kick integration connected successfully! You can close this tab.");
+            res.status(200).send(`Kick integration authorized for ${tokenType}! You can close this tab. (Be sure to save the integration settings in Firebot if you have that window open.)`);
         } catch (error) {
             logger.error(`Failed to exchange code for tokens: ${error}`);
             res.status(500).send(`Failed to exchange code for tokens: ${error}`);
@@ -203,8 +245,19 @@ export class AuthManager {
     }
 
     async handleLinkCallback(req: any, res: any) {
+        let tokenType: 'streamer' | 'bot' = 'streamer';
+
+        if (req.path.endsWith('/bot')) {
+            tokenType = 'bot';
+        } else if (req.path.endsWith('/streamer')) {
+            tokenType = 'streamer';
+        } else {
+            res.status(400).send(`Invalid token type requested - Make sure you copy the URL exactly from Firebot!`);
+            return;
+        }
+
         try {
-            const authUrl = this.getAuthorizationRequestUrl();
+            const authUrl = this.getAuthorizationRequestUrl(tokenType);
             logger.debug(`Redirecting user to authorization URL: ${authUrl}`);
             res.redirect(authUrl);
         } catch (error) {
@@ -213,33 +266,42 @@ export class AuthManager {
         }
     }
 
-    private async refreshAuthToken(): Promise<boolean> {
+    private async refreshAuthTokens(): Promise<boolean> {
         try {
-            await this.refreshAuthTokenReal();
+            await this.refreshAuthTokenReal('streamer');
             this.scheduleNextRenewal(this.tokenExpiresAt - Date.now() - 300000); // Refresh 5 minutes before expiration
-            return true;
         } catch (error) {
-            logger.error(`Error refreshing auth token: ${error}`);
+            logger.error(`Error refreshing streamer auth token: ${error}`);
 
             if (!this.refreshToken) {
-                logger.error("Refresh token is missing. Disconnecting integration.");
+                logger.error("Streamer refresh token is missing. Disconnecting integration.");
                 this.disconnect();
 
                 const { frontendCommunicator } = firebot.modules;
-                frontendCommunicator.send("error", "Kick Integration: Your refresh token is invalid. Please re-link the integration.");
+                frontendCommunicator.send("error", "Kick Integration: Your refresh token is invalid. Please re-authorize the streamer account.");
             } else {
                 this.scheduleNextRenewal(10000); // Try again in 10 seconds if there's an error
             }
             return false;
         }
+
+        if (integration.getSettings().accounts.authorizeBotAccount && this.botRefreshToken) {
+            try {
+                await this.refreshAuthTokenReal('bot');
+            } catch (error) {
+                logger.error(`Error refreshing bot auth token: ${error}`);
+            }
+        }
+
+        return true;
     }
 
-    private async refreshAuthTokenReal() {
+    private async refreshAuthTokenReal(tokenType: 'streamer' | 'bot') {
         const payload = {
             // eslint-disable-next-line camelcase
             grant_type: "refresh_token",
             // eslint-disable-next-line camelcase
-            refresh_token: this.refreshToken
+            refresh_token: tokenType === 'streamer' ? this.refreshToken : this.botRefreshToken
         };
 
         let url = "";
@@ -260,12 +322,20 @@ export class AuthManager {
         }
 
         const response = await httpCallWithTimeout(url, 'POST', '', payloadString);
-        this.authToken = response.access_token;
-        this.tokenExpiresAt = Date.now() + (response.expires_in * 1000); // Convert seconds to milliseconds
-        this.refreshToken = response.refresh_token;
-        integration.kick.setAuthToken(this.authToken);
-        integration.saveIntegrationTokenData(this.refreshToken);
-        logger.info(`Kick integration tokens refreshed successfully. Valid until: ${new Date(this.tokenExpiresAt).toISOString()}`);
+        if (tokenType === 'streamer') {
+            this.authToken = response.access_token;
+            this.refreshToken = response.refresh_token;
+            this.tokenExpiresAt = Date.now() + (response.expires_in * 1000); // Convert seconds to milliseconds
+            integration.kick.setAuthToken(this.authToken);
+            logger.info(`Kick integration token for streamer refreshed successfully. Valid until: ${new Date(this.tokenExpiresAt).toISOString()}`);
+        } else {
+            this.botAuthToken = response.access_token;
+            this.botRefreshToken = response.refresh_token;
+            this.botTokenExpiresAt = Date.now() + (response.expires_in * 1000); // Convert seconds to milliseconds
+            integration.kick.setBotAuthToken(this.botAuthToken);
+            logger.info(`Kick integration token for bot refreshed successfully. Valid until: ${new Date(this.botTokenExpiresAt).toISOString()}`);
+        }
+        integration.saveIntegrationTokenData(this.refreshToken, this.botRefreshToken);
     }
 
     private scheduleNextRenewal(delay: number) {
@@ -273,7 +343,7 @@ export class AuthManager {
             clearTimeout(this.authRenewer);
         }
         this.authRenewer = setTimeout(async () => {
-            await this.refreshAuthToken();
+            await this.refreshAuthTokens();
         }, delay);
         logger.debug(`Next auth token renewal scheduled at ${new Date(Date.now() + delay).toISOString()}.`);
     }

--- a/src/internal/auth.ts
+++ b/src/internal/auth.ts
@@ -59,7 +59,11 @@ export class AuthManager {
         logger.info("Auth manager disconnected.");
     }
 
-    getAuthToken(): string {
+    async getAuthToken(): Promise<string> {
+        if (!this.authToken) {
+            await this.refreshAuthTokenReal('streamer');
+        }
+
         if (this.authToken && this.tokenExpiresAt > Date.now()) {
             return this.authToken;
         }
@@ -74,10 +78,14 @@ export class AuthManager {
         return "";
     }
 
-    getBotAuthToken(): string {
+    async getBotAuthToken(): Promise<string> {
         if (!integration.getSettings().accounts.authorizeBotAccount) {
             logger.debug("getBotAuthToken(): Bot account authorization is disabled.");
             return "";
+        }
+
+        if (!this.botAuthToken) {
+            await this.refreshAuthTokenReal('bot');
         }
 
         if (this.botAuthToken && this.botTokenExpiresAt > Date.now()) {

--- a/src/internal/auth.ts
+++ b/src/internal/auth.ts
@@ -56,6 +56,8 @@ export class AuthManager {
             clearTimeout(this.authRenewer);
             this.authRenewer = null;
         }
+        this.authToken = "";
+        this.botAuthToken = "";
         logger.info("Auth manager disconnected.");
     }
 
@@ -142,7 +144,8 @@ export class AuthManager {
             state
         });
         const queryString = params.toString();
-        const authUrl = `${integration.getSettings().webhookProxy.webhookProxyUrl}/auth/authorize?${queryString}`;
+        const webhookProxyUrl = integration.getSettings().webhookProxy.webhookProxyUrl.replace(/\/+$/, "");
+        const authUrl = `${webhookProxyUrl}/auth/authorize?${queryString}`;
         return authUrl;
     }
 
@@ -210,7 +213,8 @@ export class AuthManager {
         let payloadString = "";
 
         if (integration.getSettings().webhookProxy.webhookProxyUrl) {
-            url = `${integration.getSettings().webhookProxy.webhookProxyUrl}/auth/token`;
+            const webhookProxyUrl = integration.getSettings().webhookProxy.webhookProxyUrl.replace(/\/+$/, "");
+            url = `${webhookProxyUrl}/auth/token`;
             payloadString = JSON.stringify(payload);
         } else {
             url = `${IntegrationConstants.KICK_AUTH_SERVER}/oauth/token`;
@@ -316,7 +320,8 @@ export class AuthManager {
         let payloadString = "";
 
         if (integration.getSettings().webhookProxy.webhookProxyUrl) {
-            url = `${integration.getSettings().webhookProxy.webhookProxyUrl}/auth/token`;
+            const webhookProxyUrl = integration.getSettings().webhookProxy.webhookProxyUrl.replace(/\/+$/, "");
+            url = `${webhookProxyUrl}/auth/token`;
             payloadString = JSON.stringify(payload);
         } else {
             url = `${IntegrationConstants.KICK_AUTH_SERVER}/oauth/token`;

--- a/src/internal/chat-manager.ts
+++ b/src/internal/chat-manager.ts
@@ -40,9 +40,14 @@ export class ChatManager {
             return;
         }
 
+        if (chatter === "Bot" && !this.kick.bot) {
+            logger.warn("Cannot send chat message as Bot as bot account is not authorized. Falling back to streamer.");
+            chatter = "Streamer";
+        }
+
         const payload: Record<string, any> = {
             content: message,
-            type: chatter === "Streamer" ? "user" : "bot",
+            type: "user", // "bot" here is the registered Kick integration, not the second account registered as the bot
             // eslint-disable-next-line camelcase
             broadcaster_user_id: this.kick.broadcaster.userId
         };
@@ -52,7 +57,7 @@ export class ChatManager {
         }
 
         try {
-            await this.kick.httpCallWithTimeout('/public/v1/chat', "POST", JSON.stringify(payload));
+            await this.kick.httpCallWithTimeout('/public/v1/chat', "POST", JSON.stringify(payload), null, undefined, chatter === "Bot" ? this.kick.getBotAuthToken() : this.kick.getAuthToken());
             logger.debug(`Successfully sent chat message as ${chatter}`);
         } catch (error) {
             logger.error(`Failed to send chat message: ${error}`);

--- a/src/internal/http.ts
+++ b/src/internal/http.ts
@@ -8,67 +8,63 @@ export async function httpCallWithTimeout(
     signal: AbortSignal | null = null,
     timeout = 10000
 ): Promise<any> {
-    return new Promise((resolve, reject) => {
-        if (signal && signal.aborted) {
-            logger.warn("API request aborted due to previous disconnection.");
-            reject(new Error("API request aborted"));
-        }
+    if (signal && signal.aborted) {
+        logger.warn("API request aborted due to previous disconnection.");
+        throw new Error("API request aborted");
+    }
 
-        const timeoutController = new AbortController();
-        const timer = setTimeout(() => {
-            if (timeout > 0) {
-                timeoutController.abort();
+    const timeoutController = new AbortController();
+    const timer = setTimeout(() => {
+        if (timeout > 0) {
+            timeoutController.abort();
+        }
+    }, timeout);
+
+    const headers: Record<string, string> = {};
+    if (authToken) {
+        headers["Authorization"] = `Bearer ${authToken}`;
+    }
+    if (body) {
+        if (/^[^=]+=[^=]+(&[^=]+=[^=]+)*$/.test(body)) {
+            headers["Content-Type"] = "application/x-www-form-urlencoded";
+        } else {
+            headers["Content-Type"] = "application/json";
+        }
+    }
+    headers["Accept"] = "application/json";
+
+    const signals: AbortSignal[] = [timeoutController.signal, ...(signal ? [signal] : [])];
+
+    const fetchOptions: Record<string, any> = {
+        method: method,
+        headers: headers,
+        signal: AbortSignal.any(signals),
+        redirect: "manual"
+    };
+
+    if (body !== '' || method !== "GET" && method !== "HEAD" && method !== "DELETE") {
+        // Only include body for methods that require it, or when it is defined
+        fetchOptions['body'] = body;
+    }
+
+    while (true) {
+        try {
+            const response = await fetch(url, fetchOptions);
+            if (response.status === 301 || response.status === 302) {
+                logger.debug(`HTTP request to ${url} was redirected to ${response.url}`);
+                continue;
             }
-        }, timeout);
-
-        const headers: Record<string, string> = {};
-        if (authToken) {
-            headers["Authorization"] = `Bearer ${authToken}`;
-        }
-        if (body) {
-            if (/^[^=]+=[^=]+(&[^=]+=[^=]+)*$/.test(body)) {
-                headers["Content-Type"] = "application/x-www-form-urlencoded";
-            } else {
-                headers["Content-Type"] = "application/json";
+            if (!response.ok) {
+                throw new Error(`HTTP error! Status: ${response.status} (URL: ${url}, payload: ${body})`);
             }
-        }
-        headers["Accept"] = "application/json";
-
-        const signals: AbortSignal[] = [timeoutController.signal, ...(signal ? [signal] : [])];
-
-        const fetchOptions: Record<string, any> = {
-            method: method,
-            headers: headers,
-            signal: AbortSignal.any(signals)
-        };
-
-        if (body !== '' || method !== "GET" && method !== "HEAD" && method !== "DELETE") {
-            // Only include body for methods that require it, or when it is defined
-            fetchOptions['body'] = body;
-        }
-
-        fetch(url, fetchOptions)
-            .then((response) => {
+            if (response.status === 204) {
+                return ({});
+            }
+            return await response.json();
+        } finally {
+            if (timer) {
                 clearTimeout(timer);
-                if (!response.ok) {
-                    reject(new Error(`HTTP error! Status: ${response.status} (URL: ${url}, payload: ${body})`));
-                }
-                if (response.status === 204) {
-                    resolve({}); // No content to return
-                    return;
-                }
-                return response.json();
-            })
-            .then((data) => {
-                resolve(data);
-            })
-            .catch((error) => {
-                reject(error);
-            })
-            .finally(() => {
-                if (timer) {
-                    clearTimeout(timer);
-                }
-            });
-    });
+            }
+        }
+    }
 }

--- a/src/internal/http.ts
+++ b/src/internal/http.ts
@@ -55,7 +55,9 @@ export async function httpCallWithTimeout(
                 continue;
             }
             if (!response.ok) {
-                throw new Error(`HTTP error! Status: ${response.status} (URL: ${url}, payload: ${body})`);
+                const error: any = new Error(`HTTP error! Status: ${response.status} (URL: ${url}, payload: ${body})`);
+                error.status = response.status;
+                throw error;
             }
             if (response.status === 204) {
                 return ({});

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -38,7 +38,7 @@ export class Kick {
             this.broadcaster = await this.userManager.lookupUserById();
         } catch (error) {
             logger.error(`Failed to get broadcaster ID: ${error}`);
-            this.disconnect();
+            await this.disconnect();
             throw error;
         }
 

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -99,7 +99,11 @@ export class Kick {
 
     setAuthToken(token: string) {
         this.authToken = token;
-        logger.debug("Kick auth token set successfully.");
+        if (token) {
+            logger.debug("Kick streamer auth token set successfully.");
+        } else {
+            logger.debug("Kick streamer auth token cleared.");
+        }
     }
 
     getBotAuthToken(): string {
@@ -108,7 +112,11 @@ export class Kick {
 
     setBotAuthToken(token: string) {
         this.botAuthToken = token;
-        logger.debug("Kick bot auth token set successfully.");
+        if (token) {
+            logger.debug("Kick bot auth token set successfully.");
+        } else {
+            logger.debug("Kick bot auth token cleared.");
+        }
     }
 
     private async deleteExistingSubscriptions(): Promise<void> {

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -192,7 +192,8 @@ export class Kick {
     async httpCallWithTimeout(uri: string, method: string, body = '', signal: AbortSignal | null = null, timeout = 10000, authToken = this.authToken): Promise<any> {
         const requestId = crypto.randomUUID();
         if (integration.getSettings().logging.logApiResponses) {
-            logger.debug(`[${requestId}] Making API call to ${uri} with method ${method} and body: ${JSON.stringify(body)}`);
+            const asUser = authToken === this.botAuthToken ? 'bot' : (this.authToken === this.authToken ? 'streamer' : (this.authToken === '' ? 'unauthenticated' : 'unknown'));
+            logger.debug(`[${requestId}] Making API call as ${asUser} to ${uri} with method ${method} and body: ${JSON.stringify(body)}`);
         }
 
         try {

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -7,10 +7,13 @@ import { ChatManager } from "./chat-manager";
 import { httpCallWithTimeout } from "./http";
 import { KickUserApi } from "./user-api";
 import { KickUserManager } from "./user-manager";
+import { parseBasicKickUser } from "./webhook-handler/webhook-handler";
 
 export class Kick {
     private apiAborter = new AbortController();
     private authToken = "";
+    private botAuthToken = "";
+    bot: BasicKickUser | null = null;
     broadcaster: BasicKickUser | null = null;
     channelManager: KickChannelManager;
     chatManager: ChatManager;
@@ -24,10 +27,11 @@ export class Kick {
         this.userManager = new KickUserManager(this);
     }
 
-    async connect(token: string): Promise<void> {
+    async connect(token: string, botToken: string): Promise<void> {
         logger.debug("Kick API integration connecting...");
 
         this.setAuthToken(token);
+        this.setBotAuthToken(botToken);
         this.apiAborter = new AbortController();
 
         try {
@@ -38,11 +42,38 @@ export class Kick {
             throw error;
         }
 
+        if (botToken) {
+            try {
+                const uri = `/public/v1/users`;
+                const response = await this.httpCallWithTimeout(uri, "GET", '', null, 10000, botToken);
+
+                if (!response || !response.data || response.data.length !== 1) {
+                    logger.debug(`Failed to retrieve user from Kick API response. ${JSON.stringify(response)}`);
+                    throw new Error("Failed to retrieve user from Kick API.");
+                }
+
+                const user = parseBasicKickUser(response.data[0]);
+                if (!user.userId) {
+                    logger.debug("No user ID found in Kick API response.");
+                    throw new Error("No user ID found in Kick API response.");
+                }
+
+                logger.debug(`Successfully retrieved bot user: ${user.userId} (${user.name})`);
+                this.bot = user;
+            } catch (error) {
+                logger.error(`Failed to get bot user: ${error}`);
+                this.bot = null;
+            }
+        } else {
+            logger.debug("No bot token is given.");
+            this.bot = null;
+        }
+
         try {
             await this.subscribeToEvents();
         } catch (error) {
             logger.error(`Failed to subscribe to events: ${error}`);
-            this.disconnect();
+            await this.disconnect();
             throw error;
         }
 
@@ -52,9 +83,9 @@ export class Kick {
         logger.info("Kick API integration connected.");
     }
 
-    disconnect(): void {
+    async disconnect(): Promise<void> {
         logger.debug("Kick API integration disconnecting...");
-        this.deleteExistingSubscriptions();
+        await this.deleteExistingSubscriptions();
         this.apiAborter.abort();
         this.channelManager.stop();
         this.userApi.stop();
@@ -62,9 +93,22 @@ export class Kick {
         logger.info("Kick API integration disconnected.");
     }
 
+    getAuthToken(): string {
+        return this.authToken;
+    }
+
     setAuthToken(token: string) {
         this.authToken = token;
         logger.debug("Kick auth token set successfully.");
+    }
+
+    getBotAuthToken(): string {
+        return this.botAuthToken;
+    }
+
+    setBotAuthToken(token: string) {
+        this.botAuthToken = token;
+        logger.debug("Kick bot auth token set successfully.");
     }
 
     private async deleteExistingSubscriptions(): Promise<void> {
@@ -137,7 +181,7 @@ export class Kick {
         });
     }
 
-    async httpCallWithTimeout(uri: string, method: string, body = '', signal: AbortSignal | null = null, timeout = 10000): Promise<any> {
+    async httpCallWithTimeout(uri: string, method: string, body = '', signal: AbortSignal | null = null, timeout = 10000, authToken = this.authToken): Promise<any> {
         const requestId = crypto.randomUUID();
         if (integration.getSettings().logging.logApiResponses) {
             logger.debug(`[${requestId}] Making API call to ${uri} with method ${method} and body: ${JSON.stringify(body)}`);
@@ -147,7 +191,7 @@ export class Kick {
             const response = await httpCallWithTimeout(
                 `${IntegrationConstants.KICK_API_SERVER}${uri}`,
                 method,
-                this.authToken,
+                authToken,
                 body,
                 AbortSignal.any([this.apiAborter.signal, ...(signal ? [signal] : [])]),
                 timeout

--- a/src/internal/poll.ts
+++ b/src/internal/poll.ts
@@ -9,7 +9,7 @@ export class Poller {
     private proxyPollUrl = "";
 
     connect(proxyPollKey: string): void {
-        const proxyPollUrl = integration.getSettings().webhookProxy.webhookProxyUrl.replace(/\/$/, "");
+        const proxyPollUrl = integration.getSettings().webhookProxy.webhookProxyUrl.replace(/\/+$/, "");
         if (!proxyPollUrl) {
             logger.warn("Cannot start poller: Missing proxy poll URL. (Configure in the integration settings.)");
             return;

--- a/src/internal/poll.ts
+++ b/src/internal/poll.ts
@@ -1,3 +1,4 @@
+import { IntegrationConstants } from "../constants";
 import { integration } from "../integration";
 import { logger } from "../main";
 import { httpCallWithTimeout } from "./http";
@@ -15,11 +16,12 @@ export class Poller {
 
         const proxyPollUrl = integration.getSettings().webhookProxy.webhookProxyUrl.replace(/\/+$/, "");
         if (!proxyPollUrl) {
-            logger.warn("Cannot start poller: Missing proxy poll URL. (Configure in the integration settings.)");
+            logger.debug("Cannot start poller: Missing proxy poll URL.");
             return;
         }
         if (!proxyPollKey) {
-            logger.warn("Cannot start poller: Missing proxy poll key.");
+            logger.error("Cannot start poller: Missing proxy poll key.");
+            integration.sendCriticalErrorNotification(`Failed to start the proxy poller. You probably need to re-authorize the streamer account in Settings > Integrations > ${IntegrationConstants.INTEGRATION_NAME}.`);
             return;
         }
 


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This adds the capability to connect a separate Kick account to send messages in chat. This is optional, and if not configured, the streamer account will be used to send messages. This also updates the flow for authenticating accounts to Kick, replacing the pop-up box with the copy-able URL with links in the integration configuration. Finally, this turns off the need to link or un-link the integration, moving this logic instead to the disconnect and connect operations.

### Motivation
This brings more parity with the Twitch integration and simplifies the process to authenticate the Kick account. This also removes the problem of the integration configuration being wiped out when unlinked.

### Testing
Set this up for my account :smile_cat: 
