### PR TITLE
Add username and streamer and/or bot filters

### DIFF
--- a/src/filters/__tests__/host-viewer-count.test.ts
+++ b/src/filters/__tests__/host-viewer-count.test.ts
@@ -1,0 +1,75 @@
+import { hostViewerCountFilter } from '../host-viewer-count';
+import { IntegrationConstants } from '../../constants';
+import { ComparisonType } from '../common';
+
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn()
+    }
+}));
+
+describe('hostViewerCountFilter.predicate', () => {
+    const baseEventData = {
+        eventSourceId: IntegrationConstants.INTEGRATION_ID,
+        eventId: 'raid',
+        eventMeta: { viewerCount: 5 }
+    };
+
+    const cases = [
+        // [comparisonType, viewerCount, value, expectedResult]
+        [ComparisonType.IS, 5, 5, true],
+        [ComparisonType.IS, 4, 5, false],
+        [ComparisonType.IS, 0, 0, true],
+        [ComparisonType.IS, 1, 0, false],
+
+        [ComparisonType.IS_NOT, 4, 5, true],
+        [ComparisonType.IS_NOT, 5, 5, false],
+        [ComparisonType.IS_NOT, 1, 0, true],
+        [ComparisonType.IS_NOT, 0, 0, false],
+
+        [ComparisonType.LESS_THAN, 4, 5, true],
+        [ComparisonType.LESS_THAN, 5, 5, false],
+        [ComparisonType.LESS_THAN, -1, 0, true],
+        [ComparisonType.LESS_THAN, 0, 0, false],
+
+        [ComparisonType.LESS_THAN_OR_EQUAL_TO, 5, 5, true],
+        [ComparisonType.LESS_THAN_OR_EQUAL_TO, 4, 5, true],
+        [ComparisonType.LESS_THAN_OR_EQUAL_TO, 6, 5, false],
+        [ComparisonType.LESS_THAN_OR_EQUAL_TO, 0, 0, true],
+        [ComparisonType.LESS_THAN_OR_EQUAL_TO, -1, 0, true],
+
+        [ComparisonType.GREATER_THAN, 6, 5, true],
+        [ComparisonType.GREATER_THAN, 5, 5, false],
+        [ComparisonType.GREATER_THAN, 1, 0, true],
+        [ComparisonType.GREATER_THAN, 0, 0, false],
+
+        [ComparisonType.GREATER_THAN_OR_EQUAL_TO, 5, 5, true],
+        [ComparisonType.GREATER_THAN_OR_EQUAL_TO, 6, 5, true],
+        [ComparisonType.GREATER_THAN_OR_EQUAL_TO, 4, 5, false],
+        [ComparisonType.GREATER_THAN_OR_EQUAL_TO, 0, 0, true],
+        [ComparisonType.GREATER_THAN_OR_EQUAL_TO, -1, 0, false]
+    ];
+
+    for (const [comparisonType, viewerCount, value, expectedResult] of cases) {
+        it(`returns ${expectedResult} for ${comparisonType} when viewerCount=${viewerCount} and value=${value}`, async () => {
+            const eventData = { ...baseEventData, eventMeta: { viewerCount: Number(viewerCount) } };
+            const result = await hostViewerCountFilter.predicate({ comparisonType: comparisonType as string, value }, eventData);
+            expect(result).toBe(expectedResult);
+        });
+    }
+
+    it('treats non-numeric viewerCount as 0', async () => {
+        const eventData = { ...baseEventData, eventMeta: { viewerCount: 'not-a-number' } };
+        // For value 0, is should be true, greater than should be false, less than or equal to should be true, etc.
+        expect(await hostViewerCountFilter.predicate({ comparisonType: ComparisonType.IS, value: 0 }, eventData)).toBe(true);
+        expect(await hostViewerCountFilter.predicate({ comparisonType: ComparisonType.IS_NOT, value: 0 }, eventData)).toBe(false);
+        expect(await hostViewerCountFilter.predicate({ comparisonType: ComparisonType.GREATER_THAN, value: 0 }, eventData)).toBe(false);
+        expect(await hostViewerCountFilter.predicate({ comparisonType: ComparisonType.GREATER_THAN_OR_EQUAL_TO, value: 0 }, eventData)).toBe(true);
+        expect(await hostViewerCountFilter.predicate({ comparisonType: ComparisonType.LESS_THAN, value: 0 }, eventData)).toBe(false);
+        expect(await hostViewerCountFilter.predicate({ comparisonType: ComparisonType.LESS_THAN, value: 1 }, eventData)).toBe(true);
+        expect(await hostViewerCountFilter.predicate({ comparisonType: ComparisonType.LESS_THAN_OR_EQUAL_TO, value: 0 }, eventData)).toBe(true);
+    });
+});

--- a/src/filters/__tests__/platform.test.ts
+++ b/src/filters/__tests__/platform.test.ts
@@ -1,6 +1,14 @@
-
 import { IntegrationConstants } from '../../constants';
 import { platformFilter } from '../platform';
+
+jest.mock('../../main', () => ({
+    logger: {
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn()
+    }
+}));
 
 describe('platformFilter.predicate', () => {
     it('returns true when platform matches and comparisonType is "is"', () => {

--- a/src/filters/__tests__/streamer-or-bot.test.ts
+++ b/src/filters/__tests__/streamer-or-bot.test.ts
@@ -1,0 +1,290 @@
+import { streamerOrBotFilter } from '../streamer-or-bot';
+import { IntegrationConstants } from '../../constants';
+
+jest.mock('../../integration', () => ({
+    integration: {
+        kick: {
+            broadcaster: { name: 'StreamerKick' },
+            bot: { name: 'BotKick' }
+        },
+        getSettings: () => ({ accounts: { authorizeBotAccount: true } })
+    }
+}));
+
+jest.mock('../../main', () => ({
+    firebot: {
+        firebot: {
+            accounts: {
+                streamer: { username: 'StreamerTwitch' },
+                bot: { username: 'BotTwitch' }
+            }
+        }
+    },
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn()
+    }
+}));
+
+jest.mock('../../variables/platform', () => ({
+    platformVariable: {
+        evaluator: jest.fn()
+    }
+}));
+
+const { platformVariable } = require('../../variables/platform');
+
+describe('streamerOrBotFilter.predicate', () => {
+    const baseEventData = {
+        eventSourceId: IntegrationConstants.INTEGRATION_ID,
+        eventId: 'test-event',
+        eventMeta: { username: '' }
+    };
+
+    it('returns false for Kick bot when authorizeBotAccount is false (is)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const integration = require('../../integration').integration;
+        // Set authorizeBotAccount to false
+        integration.getSettings = () => ({ accounts: { authorizeBotAccount: false } });
+        const eventData = { ...baseEventData, eventMeta: { username: 'BotKick' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'bot' }, eventData);
+        expect(result).toBe(false);
+        // Restore
+        integration.getSettings = () => ({ accounts: { authorizeBotAccount: true } });
+    });
+
+    it('returns true for Kick bot when authorizeBotAccount is false (is not)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const integration = require('../../integration').integration;
+        // Set authorizeBotAccount to false
+        integration.getSettings = () => ({ accounts: { authorizeBotAccount: false } });
+        const eventData = { ...baseEventData, eventMeta: { username: 'BotKick' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'bot' }, eventData);
+        expect(result).toBe(true);
+        // Restore
+        integration.getSettings = () => ({ accounts: { authorizeBotAccount: true } });
+    });
+
+    it('returns false for Kick bot when bot name is empty string (is)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const integration = require('../../integration').integration;
+        integration.kick.bot.name = '';
+        const eventData = { ...baseEventData, eventMeta: { username: 'somebody' } };
+        // Should be false for bot
+        let result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'bot' }, eventData);
+        expect(result).toBe(false);
+        // Should be false for either
+        result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'either' }, eventData);
+        expect(result).toBe(false);
+        // Restore
+        integration.kick.bot.name = 'BotKick';
+    });
+
+    it('returns true for Kick bot when bot name is empty string (is not)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const integration = require('../../integration').integration;
+        integration.kick.bot.name = '';
+        const eventData = { ...baseEventData, eventMeta: { username: 'somebody' } };
+        // Should be false for bot
+        let result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'bot' }, eventData);
+        expect(result).toBe(true);
+        // Should be false for either
+        result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'either' }, eventData);
+        expect(result).toBe(true);
+        // Restore
+        integration.kick.bot.name = 'BotKick';
+    });
+
+    it('returns false for Twitch bot when bot username is empty string (is)', async () => {
+        platformVariable.evaluator.mockReturnValue('twitch');
+        const firebot = require('../../main').firebot;
+        firebot.firebot.accounts.bot.username = '';
+        const eventData = { ...baseEventData, eventMeta: { username: 'somebody' } };
+        // Should be false for bot
+        let result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'bot' }, eventData);
+        expect(result).toBe(false);
+        // Should be false for either
+        result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'either' }, eventData);
+        expect(result).toBe(false);
+        // Restore
+        firebot.firebot.accounts.bot.username = 'BotTwitch';
+    });
+
+    it('returns true for Twitch bot when bot username is empty string (is not)', async () => {
+        platformVariable.evaluator.mockReturnValue('twitch');
+        const firebot = require('../../main').firebot;
+        firebot.firebot.accounts.bot.username = '';
+        const eventData = { ...baseEventData, eventMeta: { username: 'somebody' } };
+        // Should be false for bot
+        let result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'bot' }, eventData);
+        expect(result).toBe(true);
+        // Should be false for either
+        result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'either' }, eventData);
+        expect(result).toBe(true);
+        // Restore
+        firebot.firebot.accounts.bot.username = 'BotTwitch';
+    });
+
+    it('returns true for Kick streamer (is)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const eventData = { ...baseEventData, eventMeta: { username: 'StreamerKick' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'streamer' }, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns true for Kick bot (is)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const eventData = { ...baseEventData, eventMeta: { username: 'BotKick' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'bot' }, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns true for Kick either (is)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        let eventData = { ...baseEventData, eventMeta: { username: 'StreamerKick' } };
+        let result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'either' }, eventData);
+        expect(result).toBe(true);
+        eventData = { ...baseEventData, eventMeta: { username: 'BotKick' } };
+        result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'either' }, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns false for Kick either (is not)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        let eventData = { ...baseEventData, eventMeta: { username: 'StreamerKick' } };
+        let result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'either' }, eventData);
+        expect(result).toBe(false);
+        eventData = { ...baseEventData, eventMeta: { username: 'BotKick' } };
+        result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'either' }, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns false for Kick not streamer (is)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const eventData = { ...baseEventData, eventMeta: { username: 'NotAStreamer' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'streamer' }, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for Twitch streamer', async () => {
+        platformVariable.evaluator.mockReturnValue('twitch');
+        const eventData = { ...baseEventData, eventMeta: { username: 'StreamerTwitch' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'streamer' }, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns true for Twitch bot', async () => {
+        platformVariable.evaluator.mockReturnValue('twitch');
+        const eventData = { ...baseEventData, eventMeta: { username: 'BotTwitch' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'bot' }, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns true for Twitch either (is)', async () => {
+        platformVariable.evaluator.mockReturnValue('twitch');
+        let eventData = { ...baseEventData, eventMeta: { username: 'StreamerTwitch' } };
+        let result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'either' }, eventData);
+        expect(result).toBe(true);
+        eventData = { ...baseEventData, eventMeta: { username: 'BotTwitch' } };
+        result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'either' }, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns true for Twitch either (is not)', async () => {
+        platformVariable.evaluator.mockReturnValue('twitch');
+        let eventData = { ...baseEventData, eventMeta: { username: 'StreamerTwitch' } };
+        let result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'either' }, eventData);
+        expect(result).toBe(false);
+        eventData = { ...baseEventData, eventMeta: { username: 'BotTwitch' } };
+        result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'either' }, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns false for Twitch not streamer', async () => {
+        platformVariable.evaluator.mockReturnValue('twitch');
+        const eventData = { ...baseEventData, eventMeta: { username: 'NotAStreamer' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'streamer' }, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns false for unknown platform (is)', async () => {
+        platformVariable.evaluator.mockReturnValue('unknown');
+        const eventData = { ...baseEventData, eventMeta: { username: 'StreamerKick' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'streamer' }, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for unknown platform (is not)', async () => {
+        platformVariable.evaluator.mockReturnValue('unknown');
+        const eventData = { ...baseEventData, eventMeta: { username: 'StreamerKick' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'streamer' }, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns false for empty username (is)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const eventData = { ...baseEventData, eventMeta: { username: '' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is', value: 'streamer' }, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for empty username (is not)', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const eventData = { ...baseEventData, eventMeta: { username: '' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'streamer' }, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns true for "is not" when username does not match', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const eventData = { ...baseEventData, eventMeta: { username: 'NotAStreamer' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'streamer' }, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns false for "is not" when username matches', async () => {
+        platformVariable.evaluator.mockReturnValue('kick');
+        const eventData = { ...baseEventData, eventMeta: { username: 'StreamerKick' } };
+        const result = await streamerOrBotFilter.predicate({ comparisonType: 'is not', value: 'streamer' }, eventData);
+        expect(result).toBe(false);
+    });
+});
+
+describe('streamerOrBotFilter.events', () => {
+    it('should contain both twitch and INTEGRATION_ID "chat-message" events', () => {
+        const twitchEvent = streamerOrBotFilter.events.find(
+            e => e.eventSourceId === 'twitch' && e.eventId === 'chat-message'
+        );
+        const integrationEvent = streamerOrBotFilter.events.find(
+            e => e.eventSourceId === IntegrationConstants.INTEGRATION_ID && e.eventId === 'chat-message'
+        );
+        expect(twitchEvent).toBeDefined();
+        expect(integrationEvent).toBeDefined();
+    });
+});
+
+describe('streamerOrBotFilter.getSelectedValueDisplay', () => {
+    const dummyComparisonType = 'is';
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const getSelectedValueDisplay = streamerOrBotFilter.getSelectedValueDisplay;
+    if (!getSelectedValueDisplay) {
+        throw new Error('getSelectedValueDisplay is not defined');
+    }
+    it('returns correct display value for "streamer"', () => {
+        expect(getSelectedValueDisplay({ comparisonType: dummyComparisonType, value: 'streamer' })).toBe('Streamer');
+    });
+
+    it('returns correct display value for "bot"', () => {
+        expect(getSelectedValueDisplay({ comparisonType: dummyComparisonType, value: 'bot' })).toBe('Stream Bot');
+    });
+
+    it('returns correct display value for "either"', () => {
+        expect(getSelectedValueDisplay({ comparisonType: dummyComparisonType, value: 'either' })).toBe('Streamer or Stream Bot');
+    });
+
+    it('returns the fallback string if unknown value', () => {
+        expect(getSelectedValueDisplay({ comparisonType: dummyComparisonType, value: 'unknown' })).toBe('??? (unknown)');
+    });
+});

--- a/src/filters/__tests__/username.test.ts
+++ b/src/filters/__tests__/username.test.ts
@@ -1,0 +1,235 @@
+import { IntegrationConstants } from '../../constants';
+import { usernameFilter } from '../username';
+
+jest.mock('../../main', () => ({
+    logger: {
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn()
+    }
+}));
+
+describe('usernameFilter.predicate', () => {
+    it('returns true when the username is equal and comparison type is "is"', async () => {
+        const filterSettings = { comparisonType: 'is', value: 'jimbo' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {
+                username: 'jimbo'
+            }
+        };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns false when the username is not equal and comparison type is "is"', async () => {
+        const filterSettings = { comparisonType: 'is', value: 'jimbo' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {
+                username: 'jane'
+            }
+        };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true when the value has @kick and the condition does not', async () => {
+        const filterSettings = { comparisonType: 'is', value: 'jimbo' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {
+                username: 'jimbo@kick'
+            }
+        };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns true when the condition has @kick and the value does not', async () => {
+        const filterSettings = { comparisonType: 'is', value: 'jimbo@kick' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {
+                username: 'jimbo'
+            }
+        };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+
+
+    it('returns true when the condition and value both have @kick', async () => {
+        const filterSettings = { comparisonType: 'is', value: 'jimbo@kick' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {
+                username: 'jimbo@kick'
+            }
+        };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns true for "is not" condition when the username does not match', async () => {
+        const filterSettings = { comparisonType: 'is not', value: 'jimbo' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {
+                username: 'jane'
+            }
+        };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+
+    it('returns false for "is not" condition when the username matches', async () => {
+        const filterSettings = { comparisonType: 'is not', value: 'jimbo' };
+        const eventData = {
+            eventSourceId: IntegrationConstants.INTEGRATION_ID,
+            eventId: 'test-event',
+            eventMeta: {
+                username: 'jimbo'
+            }
+        };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for "contains" when username contains value', async () => {
+        const filterSettings = { comparisonType: 'contains', value: 'jim' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+    it('returns false for "contains" when username does not contain value', async () => {
+        const filterSettings = { comparisonType: 'contains', value: 'bob' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for "doesn\'t contain" when username does not contain value', async () => {
+        const filterSettings = { comparisonType: "doesn't contain", value: 'bob' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+    it('returns false for "doesn\'t contain" when username contains value', async () => {
+        const filterSettings = { comparisonType: "doesn't contain", value: 'jim' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for "starts with" when username starts with value', async () => {
+        const filterSettings = { comparisonType: 'starts with', value: 'jim' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+    it('returns false for "starts with" when username does not start with value', async () => {
+        const filterSettings = { comparisonType: 'starts with', value: 'bo' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for "doesn\'t start with" when username does not start with value', async () => {
+        const filterSettings = { comparisonType: "doesn't start with", value: 'bo' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+    it('returns false for "doesn\'t start with" when username starts with value', async () => {
+        const filterSettings = { comparisonType: "doesn't start with", value: 'jim' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for "ends with" when username ends with value', async () => {
+        const filterSettings = { comparisonType: 'ends with', value: 'bo' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+    it('returns false for "ends with" when username does not end with value', async () => {
+        const filterSettings = { comparisonType: 'ends with', value: 'jim' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for "doesn\'t end with" when username does not end with value', async () => {
+        const filterSettings = { comparisonType: "doesn't end with", value: 'jim' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+    it('returns false for "doesn\'t end with" when username ends with value', async () => {
+        const filterSettings = { comparisonType: "doesn't end with", value: 'bo' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for "matches regex (case-sensitive)" when username matches', async () => {
+        const filterSettings = { comparisonType: 'matches regex (case-sensitive)', value: '^jim' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+    it('returns false for "matches regex (case-sensitive)" when username does not match', async () => {
+        const filterSettings = { comparisonType: 'matches regex (case-sensitive)', value: '^bo' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for "doesn\'t match regex (case-sensitive)" when username does not match', async () => {
+        const filterSettings = { comparisonType: "doesn't match regex (case-sensitive)", value: '^bo' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+    it('returns false for "doesn\'t match regex (case-sensitive)" when username matches', async () => {
+        const filterSettings = { comparisonType: "doesn't match regex (case-sensitive)", value: '^jim' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for "matches regex" when username matches (case-insensitive)', async () => {
+        const filterSettings = { comparisonType: 'matches regex', value: '^JIM' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+    it('returns false for "matches regex" when username does not match (case-insensitive)', async () => {
+        const filterSettings = { comparisonType: 'matches regex', value: '^BO' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+
+    it('returns true for "doesn\'t match regex" when username does not match (case-insensitive)', async () => {
+        const filterSettings = { comparisonType: "doesn't match regex", value: '^BO' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(true);
+    });
+    it('returns false for "doesn\'t match regex" when username matches (case-insensitive)', async () => {
+        const filterSettings = { comparisonType: "doesn't match regex", value: '^JIM' };
+        const eventData = { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: 'test-event', eventMeta: { username: 'jimbo' } };
+        const result = await usernameFilter.predicate(filterSettings, eventData);
+        expect(result).toBe(false);
+    });
+});

--- a/src/filters/common.ts
+++ b/src/filters/common.ts
@@ -1,0 +1,85 @@
+import { logger } from "../main";
+
+export enum ComparisonType {
+    IS = "is",
+    IS_NOT = "is not",
+    CONTAINS = "contains",
+    DOESNT_CONTAIN = "doesn't contain",
+    DOESNT_STARTS_WITH = "doesn't start with",
+    STARTS_WITH = "starts with",
+    DOESNT_END_WITH = "doesn't end with",
+    ENDS_WITH = "ends with",
+    MATCHES_REGEX_CS = "matches regex (case-sensitive)",
+    DOESNT_MATCH_REGEX_CS = "doesn't match regex (case-sensitive)",
+    MATCHES_REGEX = "matches regex",
+    DOESNT_MATCH_REGEX = "doesn't match regex",
+    LESS_THAN = "less than",
+    LESS_THAN_OR_EQUAL_TO = "less than or equal to",
+    GREATER_THAN = "greater than",
+    GREATER_THAN_OR_EQUAL_TO = "greater than or equal to"
+}
+
+export function compareValue(
+    filterName: string,
+    comparisonType: ComparisonType,
+    expectedValue: string | number | boolean | RegExp,
+    actualValue: string | number | boolean
+): boolean {
+    logger.debug(`${filterName}: Comparing values: type=${comparisonType}, expected='${expectedValue}', actual='${actualValue}'`);
+    switch (comparisonType) {
+        case ComparisonType.IS:
+            return actualValue === expectedValue;
+        case ComparisonType.IS_NOT:
+            return actualValue !== expectedValue;
+        case ComparisonType.CONTAINS:
+            return actualValue?.toString().includes(expectedValue?.toString() ?? "") || false;
+        case ComparisonType.DOESNT_CONTAIN:
+            return !actualValue?.toString().includes(expectedValue?.toString() ?? "");
+        case ComparisonType.STARTS_WITH:
+            return actualValue?.toString().startsWith(expectedValue?.toString() ?? "") || false;
+        case ComparisonType.DOESNT_STARTS_WITH:
+            return !actualValue?.toString().startsWith(expectedValue?.toString() ?? "");
+        case ComparisonType.ENDS_WITH:
+            return actualValue?.toString().endsWith(expectedValue?.toString() ?? "") || false;
+        case ComparisonType.DOESNT_END_WITH:
+            return !actualValue?.toString().endsWith(expectedValue?.toString() ?? "");
+        case ComparisonType.MATCHES_REGEX: {
+            const regex = new RegExp(expectedValue?.toString() ?? "", "gi");
+            return regex.test(actualValue?.toString() ?? "");
+        }
+        case ComparisonType.DOESNT_MATCH_REGEX: {
+            const regex = new RegExp(expectedValue?.toString() ?? "", "gi");
+            return !regex.test(actualValue?.toString() ?? "");
+        }
+        case ComparisonType.MATCHES_REGEX_CS: {
+            const regex = new RegExp(expectedValue?.toString() ?? "", "g");
+            return regex.test(actualValue?.toString() ?? "");
+        }
+        case ComparisonType.DOESNT_MATCH_REGEX_CS: {
+            const regex = new RegExp(expectedValue?.toString() ?? "", "g");
+            return !regex.test(actualValue?.toString() ?? "");
+        }
+        case ComparisonType.LESS_THAN: {
+            const expectedNum = Number(expectedValue);
+            const actualNum = Number(actualValue);
+            return actualNum < expectedNum;
+        }
+        case ComparisonType.LESS_THAN_OR_EQUAL_TO: {
+            const expectedNum = Number(expectedValue);
+            const actualNum = Number(actualValue);
+            return actualNum <= expectedNum;
+        }
+        case ComparisonType.GREATER_THAN: {
+            const expectedNum = Number(expectedValue);
+            const actualNum = Number(actualValue);
+            return actualNum > expectedNum;
+        }
+        case ComparisonType.GREATER_THAN_OR_EQUAL_TO: {
+            const expectedNum = Number(expectedValue);
+            const actualNum = Number(actualValue);
+            return actualNum >= expectedNum;
+        }
+        default:
+            return false;
+    }
+}

--- a/src/filters/host-viewer-count.ts
+++ b/src/filters/host-viewer-count.ts
@@ -1,15 +1,6 @@
-import { EventFilter } from "@crowbartools/firebot-custom-scripts-types/types/modules/event-filter-manager";
+import { EventData, EventFilter } from "@crowbartools/firebot-custom-scripts-types/types/modules/event-filter-manager";
 import { IntegrationConstants } from "../constants";
-import { logger } from "../main";
-
-enum ComparisonType {
-    IS = "is",
-    IS_NOT = "is not",
-    LESS_THAN = "less than",
-    LESS_THAN_OR_EQUAL_TO = "less than or equal to",
-    GREATER_THAN = "greater than",
-    GREATER_THAN_OR_EQUAL_TO = "greater than or equal to"
-}
+import { ComparisonType, compareValue } from "./common";
 
 export const hostViewerCountFilter: EventFilter = {
     id: `${IntegrationConstants.INTEGRATION_ID}:host-viewer-count`,
@@ -29,41 +20,11 @@ export const hostViewerCountFilter: EventFilter = {
     valueType: "number",
     predicate: async (
         filterSettings,
-        eventData: {
-            eventMeta: {
-                viewerCount?: number;
-            }
-        }
+        eventData: EventData
     ): Promise<boolean> => {
         const { comparisonType, value } = filterSettings;
-        const viewerCount = eventData.eventMeta.viewerCount || 0;
-        return compareValue(comparisonType as ComparisonType, value, viewerCount);
+        const viewerCountNumber = Number(eventData.eventMeta.viewerCount);
+        const viewerCount = isNaN(viewerCountNumber) ? 0 : viewerCountNumber;
+        return compareValue("hostViewerCountFilter", comparisonType as ComparisonType, value, viewerCount);
     }
 };
-
-function compareValue(
-    comparisonType: ComparisonType,
-    expectedValue: unknown,
-    actualValue: unknown
-): boolean {
-    logger.debug(`Comparing values: type=${comparisonType}, expected='${expectedValue}', actual='${actualValue}'`);
-    const expectedNum = Number(expectedValue);
-    const actualNum = Number(actualValue);
-
-    switch (comparisonType) {
-        case ComparisonType.IS:
-            return actualNum === expectedNum;
-        case ComparisonType.IS_NOT:
-            return actualNum !== expectedNum;
-        case ComparisonType.LESS_THAN:
-            return actualNum < expectedNum;
-        case ComparisonType.LESS_THAN_OR_EQUAL_TO:
-            return actualNum <= expectedNum;
-        case ComparisonType.GREATER_THAN:
-            return actualNum > expectedNum;
-        case ComparisonType.GREATER_THAN_OR_EQUAL_TO:
-            return actualNum >= expectedNum;
-        default:
-            return false;
-    }
-}

--- a/src/filters/reward-title.ts
+++ b/src/filters/reward-title.ts
@@ -1,21 +1,6 @@
 import { EventFilter } from "@crowbartools/firebot-custom-scripts-types/types/modules/event-filter-manager";
 import { IntegrationConstants } from "../constants";
-import { logger } from "../main";
-
-enum ComparisonType {
-    IS = "is",
-    IS_NOT = "is not",
-    CONTAINS = "contains",
-    DOESNT_CONTAIN = "doesn't contain",
-    DOESNT_STARTS_WITH = "doesn't start with",
-    STARTS_WITH = "starts with",
-    DOESNT_END_WITH = "doesn't end with",
-    ENDS_WITH = "ends with",
-    MATCHES_REGEX_CS = "matches regex (case-sensitive)",
-    DOESNT_MATCH_REGEX_CS = "doesn't match regex (case-sensitive)",
-    MATCHES_REGEX = "matches regex",
-    DOESNT_MATCH_REGEX = "doesn't match regex"
-}
+import { ComparisonType, compareValue } from "./common";
 
 export const rewardTitleFilter: EventFilter = {
     id: `${IntegrationConstants.INTEGRATION_ID}:reward-title`,
@@ -49,50 +34,6 @@ export const rewardTitleFilter: EventFilter = {
     ): Promise<boolean> => {
         const { comparisonType, value } = filterSettings;
         const rewardName = eventData.eventMeta.rewardName || "";
-        return compareValue(comparisonType as ComparisonType, value, rewardName);
+        return compareValue("rewardTitleFilter", comparisonType as ComparisonType, value, rewardName);
     }
 };
-
-function compareValue(
-    comparisonType: ComparisonType,
-    expectedValue: unknown,
-    actualValue: unknown
-): boolean {
-    logger.debug(`Comparing values: type=${comparisonType}, expected='${expectedValue}', actual='${actualValue}'`);
-    switch (comparisonType) {
-        case ComparisonType.IS:
-            return actualValue === expectedValue;
-        case ComparisonType.IS_NOT:
-            return actualValue !== expectedValue;
-        case ComparisonType.CONTAINS:
-            return actualValue?.toString().includes(expectedValue?.toString() ?? "") || false;
-        case ComparisonType.DOESNT_CONTAIN:
-            return !actualValue?.toString().includes(expectedValue?.toString() ?? "");
-        case ComparisonType.STARTS_WITH:
-            return actualValue?.toString().startsWith(expectedValue?.toString() ?? "") || false;
-        case ComparisonType.DOESNT_STARTS_WITH:
-            return !actualValue?.toString().startsWith(expectedValue?.toString() ?? "");
-        case ComparisonType.ENDS_WITH:
-            return actualValue?.toString().endsWith(expectedValue?.toString() ?? "") || false;
-        case ComparisonType.DOESNT_END_WITH:
-            return !actualValue?.toString().endsWith(expectedValue?.toString() ?? "");
-        case ComparisonType.MATCHES_REGEX: {
-            const regex = new RegExp(expectedValue?.toString() ?? "", "gi");
-            return regex.test(actualValue?.toString() ?? "");
-        }
-        case ComparisonType.DOESNT_MATCH_REGEX: {
-            const regex = new RegExp(expectedValue?.toString() ?? "", "gi");
-            return !regex.test(actualValue?.toString() ?? "");
-        }
-        case ComparisonType.MATCHES_REGEX_CS: {
-            const regex = new RegExp(expectedValue?.toString() ?? "", "g");
-            return regex.test(actualValue?.toString() ?? "");
-        }
-        case ComparisonType.DOESNT_MATCH_REGEX_CS: {
-            const regex = new RegExp(expectedValue?.toString() ?? "", "g");
-            return !regex.test(actualValue?.toString() ?? "");
-        }
-        default:
-            return false;
-    }
-}

--- a/src/filters/streamer-or-bot.ts
+++ b/src/filters/streamer-or-bot.ts
@@ -1,0 +1,126 @@
+import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
+import { EventData, EventFilter, FilterEvent, FilterSettings, PresetValue } from "@crowbartools/firebot-custom-scripts-types/types/modules/event-filter-manager";
+import { IntegrationConstants } from "../constants";
+import { integration } from "../integration";
+import { unkickifyUsername } from "../internal/util";
+import { firebot, logger } from "../main";
+import { platformVariable } from "../variables/platform";
+import { ComparisonType } from "./common";
+
+const events: string[] = [
+    "chat-message",
+    "follow",
+    "viewer-arrived",
+    "banned",
+    "timeout",
+    "raid"
+];
+
+const applicableEvents: FilterEvent[] = [
+    ...events.map(eventId => ({
+        eventSourceId: "twitch",
+        eventId
+    })),
+    ...events.map(eventId => ({
+        eventSourceId: IntegrationConstants.INTEGRATION_ID,
+        eventId
+    }))
+];
+
+export const streamerOrBotFilter: EventFilter = {
+    id: `${IntegrationConstants.INTEGRATION_ID}:streamer-or-bot`,
+    name: "User",
+    description: "Checks if the user triggering the event is the streamer and/or stream bot. (Works on both Twitch and Kick events.)",
+    events: applicableEvents,
+    comparisonTypes: [
+        ComparisonType.IS,
+        ComparisonType.IS_NOT
+    ],
+    valueType: "preset",
+    getSelectedValueDisplay: (filterSettings: FilterSettings): string => {
+        const presetValues: PresetValue[] = [
+            { value: "streamer", display: "Streamer" },
+            { value: "bot", display: "Stream Bot" },
+            { value: "either", display: "Streamer or Stream Bot" }
+        ];
+        return presetValues.find(pv => pv.value === String(filterSettings.value))?.display ?? `??? (${String(filterSettings.value)})`;
+    },
+    valueIsStillValid: (filterSettings: FilterSettings): boolean => {
+        return ["streamer", "bot", "either"].includes(String(filterSettings.value));
+    },
+    presetValues(): PresetValue[] {
+        return [
+            { value: "streamer", display: "Streamer" },
+            { value: "bot", display: "Stream Bot" },
+            { value: "either", display: "Streamer or Stream Bot" }
+        ];
+    },
+    predicate: async (
+        filterSettings,
+        eventData: EventData
+    ): Promise<boolean> => {
+        const { comparisonType, value } = filterSettings;
+        const trigger: Effects.Trigger = {
+            type: "event",
+            metadata: {
+                eventSource: { id: eventData.eventSourceId, name: eventData.eventSourceId },
+                eventData: eventData.eventMeta,
+                username: typeof eventData.eventMeta.username === "string" ? eventData.eventMeta.username : ""
+            }
+        };
+
+        const platform = platformVariable.evaluator(trigger);
+        let username = "";
+        const checkName: string[] = [];
+
+        if (platform === "kick") {
+            const kickStreamer = integration.kick.broadcaster?.name;
+            const kickBot = integration.getSettings().accounts.authorizeBotAccount ? integration.kick.bot?.name : "";
+            username = unkickifyUsername(trigger.metadata.username).toLowerCase();
+            switch (value) {
+                case "streamer":
+                    checkName.push(unkickifyUsername(kickStreamer).toLowerCase());
+                    break;
+                case "bot":
+                    checkName.push(unkickifyUsername(kickBot).toLowerCase());
+                    break;
+                case "either":
+                    checkName.push(unkickifyUsername(kickStreamer).toLowerCase());
+                    checkName.push(unkickifyUsername(kickBot).toLowerCase());
+                    break;
+            }
+        } else if (platform === "twitch") {
+            const twitchStreamer = firebot.firebot.accounts.streamer.username;
+            const twitchBot = firebot.firebot.accounts.bot.username;
+            username = trigger.metadata.username.toLowerCase();
+            switch (value) {
+                case "streamer":
+                    checkName.push(twitchStreamer.toLowerCase());
+                    break;
+                case "bot":
+                    checkName.push(twitchBot.toLowerCase());
+                    break;
+                case "either":
+                    checkName.push(twitchStreamer.toLowerCase());
+                    checkName.push(twitchBot.toLowerCase());
+                    break;
+            }
+        } else {
+            logger.debug(`streamerOrBotFilter: Unknown platform: ${JSON.stringify(trigger)}`);
+            return (comparisonType === ComparisonType.IS as any) ? false : true;
+        }
+
+        if (username === '') {
+            logger.debug(`streamerOrBotFilter: No username found in trigger metadata: ${JSON.stringify(trigger)}`);
+            return (comparisonType === ComparisonType.IS as any) ? false : true;
+        }
+
+        let match = false;
+        for (const name of checkName) {
+            match ||= name === username;
+        }
+
+        logger.debug(`streamerOrBotFilter: ${match ? "match" : "no match"} found for username=${username} value=${value}`);
+        return (comparisonType === ComparisonType.IS as any) ? match : !match;
+    }
+};

--- a/src/filters/username.ts
+++ b/src/filters/username.ts
@@ -1,0 +1,41 @@
+import { EventData, EventFilter } from "@crowbartools/firebot-custom-scripts-types/types/modules/event-filter-manager";
+import { IntegrationConstants } from "../constants";
+import { unkickifyUsername } from "../internal/util";
+import { ComparisonType, compareValue } from "./common";
+
+export const usernameFilter: EventFilter = {
+    id: `${IntegrationConstants.INTEGRATION_ID}:username`,
+    name: "Username",
+    description: "Checks if the username equals or matches the provided value. Comparisons are case-insensitive. This removes the '@kick' suffix.",
+    events: [
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "chat-message" },
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "follow" },
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "viewer-arrived" },
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "banned" },
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "timeout" },
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "raid" }
+    ],
+    comparisonTypes: [
+        ComparisonType.IS,
+        ComparisonType.IS_NOT,
+        ComparisonType.CONTAINS,
+        ComparisonType.DOESNT_CONTAIN,
+        ComparisonType.STARTS_WITH,
+        ComparisonType.DOESNT_STARTS_WITH,
+        ComparisonType.ENDS_WITH,
+        ComparisonType.DOESNT_END_WITH,
+        ComparisonType.MATCHES_REGEX_CS,
+        ComparisonType.DOESNT_MATCH_REGEX_CS,
+        ComparisonType.MATCHES_REGEX,
+        ComparisonType.DOESNT_MATCH_REGEX
+    ],
+    valueType: "text",
+    predicate: async (
+        filterSettings,
+        eventData: EventData
+    ): Promise<boolean> => {
+        const { comparisonType, value } = filterSettings;
+        const username = unkickifyUsername(typeof eventData.eventMeta.username === "string" ? eventData.eventMeta.username : "");
+        return compareValue("usernameFilter", comparisonType as ComparisonType, unkickifyUsername(value), username);
+    }
+};

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -11,6 +11,7 @@ import { eventSource } from './event-source';
 import { hostViewerCountFilter } from "./filters/host-viewer-count";
 import { platformFilter } from "./filters/platform";
 import { rewardTitleFilter } from "./filters/reward-title";
+import { usernameFilter } from "./filters/username";
 import { AuthManager } from "./internal/auth";
 import { Kick } from "./internal/kick";
 import { Poller } from "./internal/poll";
@@ -39,6 +40,7 @@ import { kickStreamerIdVariable } from "./variables/streamer-id";
 import { kickTimeoutDurationVariable } from "./variables/timeout-duration";
 import { kickUptimeVariable } from "./variables/uptime";
 import { kickUserDisplayNameVariable } from "./variables/user-display-name";
+import { streamerOrBotFilter } from "./filters/streamer-or-bot";
 
 type IntegrationParameters = {
     connectivity: {
@@ -189,6 +191,8 @@ export class KickIntegration extends EventEmitter {
         eventFilterManager.registerFilter(hostViewerCountFilter);
         eventFilterManager.registerFilter(platformFilter);
         eventFilterManager.registerFilter(rewardTitleFilter);
+        eventFilterManager.registerFilter(streamerOrBotFilter);
+        eventFilterManager.registerFilter(usernameFilter);
 
         const { replaceVariableManager } = firebot.modules;
 

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -1,16 +1,28 @@
-export function kickifyUserId(userId: string | number): string {
+export function kickifyUserId(userId: string | number | undefined): string {
+    if (userId === undefined || userId === null) {
+        return "";
+    }
     return String(userId).startsWith("k") ? String(userId) : `k${userId}`;
 }
 
-export function unkickifyUserId(userId: string | number): string {
+export function unkickifyUserId(userId: string | number | undefined): string {
+    if (userId === undefined || userId === null) {
+        return "";
+    }
     return String(userId).startsWith("k") ? String(userId).substring(1) : String(userId);
 }
 
-export function kickifyUsername(username: string): string {
+export function kickifyUsername(username: string | undefined): string {
+    if (!username) {
+        return "";
+    }
     return username.endsWith("@kick") ? username : `${username}@kick`;
 }
 
-export function unkickifyUsername(username: string): string {
+export function unkickifyUsername(username: string | undefined): string {
+    if (!username) {
+        return "";
+    }
     return username.endsWith("@kick") ? username.substring(0, username.length - 5) : username;
 }
 


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds two filters:
- Username filter (works like the Twitch filter)
- User is Streamer, Bot, Streamer or Bot (added to Kick events and Twitch equivalents)

The User filter works correctly to detect the Kick streamer and the Kick streamer bot on both the Kick events and the events that are forwarded to the Twitch events.

### Motivation
Often we don't want an event to run if the streamer or bot triggered it.

### Testing
Added tests for these, and also tested extensively on my own setup with forwarding of chat message events from Kick to Twitch.