### PR TITLE
Chat to Kick from the chat feed

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -95,13 +95,15 @@ Here's how to do it:
 
       _We will come back very soon and authorize the accounts. Just skip this for now while you review the rest of the settings._
 
-    - **General Settings**
+    - **Chat Settings**
 
       - **Chat Feed**: If checked (default), chat messages on Kick will be added to the Firebot chat feed, shown when you click on DASHBOARD in Firebot. Don't worry, this will not forward these messages to Twitch, add them to any on-screen chat overlay, etc. The [Twitch Simulcasting FAQ](https://help.twitch.tv/s/article/simulcasting-guidelines?language=en_US) explicitly notes that it's fine for you to use a tool that combines Twitch and Kick activity for your own use so long as you do not show it on stream:
 
         > Can I use third-party tools that combine activity from other platforms or services such as chat if I am just using them for my personal usage?
         >
         > Yes, you are free to use tools that are for your personal use. The prohibition on third-party tools only applies to content presented to viewers either on or off Twitch.
+
+      - **Send Your Chat Feed Messages to Kick**: If checked, messages that you type in the box at the bottom of Firebot's chat feed will also be sent to Kick. (Note that any messages you type in that box are automatically sent to Twitch, and there's no way to turn that off. Also, any "slash commands" (e.g. `/clear`) are only sent to Twitch.)
 
     - **Trigger Twitch Events**
 

--- a/src/effects/__tests__/chat-platform.test.ts
+++ b/src/effects/__tests__/chat-platform.test.ts
@@ -18,8 +18,8 @@ type chatPlatformEffectParams = {
     defaultSendTwitch?: boolean;
 };
 
-const mockSendKickChatMessage = jest.fn().mockResolvedValue(undefined);
-const mockSendChatMessage = jest.fn().mockResolvedValue(undefined);
+export const mockSendKickChatMessage = jest.fn().mockResolvedValue(undefined);
+export const mockSendChatMessage = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../../integration', () => {
     return {

--- a/src/events/chat-message-sent.ts
+++ b/src/events/chat-message-sent.ts
@@ -6,15 +6,12 @@ import { kickifyUserId, kickifyUsername, unkickifyUsername } from "../internal/u
 import { firebot, logger } from "../main";
 import { ChatMessage } from "../shared/types";
 
-const messageCache = new Set<string>();
-
 export async function handleChatMessageSentEvent(payload: ChatMessage): Promise<void> {
-    // Deduplication -- we can get messages via Pusher and webhook but they have the same ID
-    if (messageCache.has(payload.messageId)) {
+    const isRegistered = await integration.kick.chatManager.registerMessage(payload.messageId, 'kick');
+    if (!isRegistered) {
         logger.debug(`Duplicate chat message ignored: id=${payload.messageId}`);
         return;
     }
-    messageCache.add(payload.messageId);
 
     // Basic message parsing
     const helpers = new FirebotChatHelpers();

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -60,8 +60,9 @@ type IntegrationParameters = {
         authorizeStreamerAccount: null;
         authorizeBotAccount: boolean;
     };
-    general: {
+    chat: {
         chatFeed: boolean;
+        chatSend: boolean;
     };
     triggerTwitchEvents: {
         chatMessage: boolean;
@@ -132,8 +133,9 @@ export class KickIntegration extends EventEmitter {
             authorizeStreamerAccount: null,
             authorizeBotAccount: false
         },
-        general: {
-            chatFeed: true
+        chat: {
+            chatFeed: true,
+            chatSend: false
         },
         triggerTwitchEvents: {
             chatMessage: false,
@@ -375,7 +377,7 @@ export class KickIntegration extends EventEmitter {
     }
 
     isChatFeedEnabled(): boolean {
-        return this.settings.general.chatFeed;
+        return this.settings.chat.chatFeed;
     }
 
     getModules(): ScriptModules {

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -98,8 +98,8 @@ export const definition: IntegrationDefinition = {
                 }
             }
         },
-        general: {
-            title: "General Settings",
+        chat: {
+            title: "Chat Settings",
             sortRank: 5,
             settings: {
                 chatFeed: {
@@ -108,6 +108,13 @@ export const definition: IntegrationDefinition = {
                     type: "boolean",
                     default: true,
                     sortRank: 1
+                },
+                chatSend: {
+                    title: "Send Your Chat Feed Messages to Kick",
+                    tip: "Messages you type in the chat feed are sent to Twitch automatically. Check this box to send them to Kick as well.",
+                    type: "boolean",
+                    default: false,
+                    sortRank: 2
                 }
             }
         },

--- a/src/internal/__tests__/chat-manager.test.ts
+++ b/src/internal/__tests__/chat-manager.test.ts
@@ -1,0 +1,95 @@
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+    }
+}));
+jest.mock('../../variables/platform', () => ({
+    platformVariable: {
+        evaluator: jest.fn()
+    }
+}));
+
+jest.mock('../kick', () => ({
+    Kick: jest.fn()
+}));
+
+import { ChatManager } from '../chat-manager';
+import { logger } from '../../main';
+import { platformVariable } from '../../variables/platform';
+
+describe('ChatManager', () => {
+    let chatManager: ChatManager;
+    let mockKick: any;
+
+    beforeEach(() => {
+        mockKick = {
+            broadcaster: { userId: 'broadcasterId' },
+            bot: { userId: 'botId' },
+            httpCallWithTimeout: jest.fn().mockResolvedValue(undefined),
+            getAuthToken: jest.fn().mockReturnValue('authToken'),
+            getBotAuthToken: jest.fn().mockReturnValue('botAuthToken')
+        };
+        chatManager = new ChatManager(mockKick);
+    });
+
+    it('registers and checks message platform', async () => {
+        expect(await chatManager.registerMessage('msg1', 'kick')).toBe(true);
+        expect(await chatManager.registerMessage('msg1', 'kick')).toBe(false);
+    });
+
+    it('splits and sends long messages in segments', async () => {
+        const longMsg = 'a'.repeat(1200);
+        const sendSpy = jest.spyOn<any, any>(chatManager, 'sendChatMessage').mockResolvedValue(undefined);
+        await chatManager.sendKickChatMessage(longMsg, 'Streamer');
+        expect(sendSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not send reply if replyToMessageId is not a kick message', async () => {
+        const sendSpy = jest.spyOn<any, any>(chatManager, 'sendChatMessage').mockResolvedValue(undefined);
+        // Register the message as a non-kick message
+        await chatManager.registerMessage('notKickMsg', 'twitch');
+        await chatManager.sendKickChatMessage('msg', 'Streamer', 'notKickMsg');
+        expect(sendSpy).toHaveBeenCalledWith('msg', 'Streamer', undefined);
+    });
+
+    it('sends chat message as bot if bot is authorized', async () => {
+        await chatManager['sendChatMessage']('msg', 'Bot');
+        expect(mockKick.httpCallWithTimeout).toHaveBeenCalledWith(
+            '/public/v1/chat', 'POST', expect.any(String), null, undefined, 'botAuthToken'
+        );
+    });
+
+    it('falls back to streamer if bot is not authorized', async () => {
+        mockKick.bot = undefined;
+        const warnSpy = jest.spyOn(logger, 'warn');
+        await chatManager['sendChatMessage']('msg', 'Bot');
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Falling back to streamer'));
+        expect(mockKick.httpCallWithTimeout).toHaveBeenCalledWith(
+            '/public/v1/chat', 'POST', expect.any(String), null, undefined, 'authToken'
+        );
+    });
+
+    it('does not send if broadcaster is missing', async () => {
+        mockKick.broadcaster = undefined;
+        const errorSpy = jest.spyOn(logger, 'error');
+        await chatManager['sendChatMessage']('msg', 'Streamer');
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('broadcaster info not available'));
+    });
+
+    it('adds and checks viewerArrivedCache', () => {
+        expect(chatManager.checkViewerArrived('user1')).toBe(true);
+        expect(chatManager.checkViewerArrived('user1')).toBe(false);
+    });
+
+    it('getPlatformFromTrigger returns platform or unknown', () => {
+        (platformVariable.evaluator as jest.Mock).mockReturnValue('kick');
+        expect(ChatManager.getPlatformFromTrigger({} as any)).toBe('kick');
+        (platformVariable.evaluator as jest.Mock).mockImplementation(() => {
+            throw new Error('fail');
+        });
+        expect(ChatManager.getPlatformFromTrigger({} as any)).toBe('unknown');
+    });
+});

--- a/src/internal/chat-manager.ts
+++ b/src/internal/chat-manager.ts
@@ -1,17 +1,86 @@
 import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
-import { logger } from "../main";
+import { firebot, logger } from "../main";
 import { platformVariable } from "../variables/platform";
 import { Kick } from "./kick";
+import { integration } from "../integration";
+
+interface inboundSendChatMessage {
+    message: string,
+    accountType: "Streamer" | "Bot",
+    replyToMessageId: string | undefined
+}
 
 export class ChatManager {
+    private isListeningForChatMessages = false;
+    private isRunning = false;
     private kick: Kick;
+    private messagePlatform: Record<string, 'twitch' | 'kick' | 'unknown'> = {};
     private viewerArrivedCache = new Set<string>();
 
     constructor(kick: Kick) {
         this.kick = kick;
     }
 
+    async start(): Promise<void> {
+        logger.debug("Starting ChatManager...");
+
+        if (!this.isListeningForChatMessages) {
+            const { frontendCommunicator } = firebot.modules;
+            frontendCommunicator.onAsync("send-chat-message", this.handleChatMessageTypedInChatFeed.bind(this));
+            this.isListeningForChatMessages = true;
+        }
+
+        this.isRunning = true;
+        return;
+    }
+
+    async stop(): Promise<void> {
+        logger.debug("Stopping ChatManager...");
+        this.isRunning = false;
+        // Currently not possible to un-listen to frontendCommunicator events
+        return;
+    }
+
+    private async handleChatMessageTypedInChatFeed(payload: inboundSendChatMessage): Promise<boolean> {
+        logger.debug("Handling chat message from frontend");
+
+        if (!this.isRunning) {
+            logger.warn("ChatManager is not running. Ignoring inbound chat message.");
+            return false;
+        }
+
+        if (!integration.getSettings().chat.chatSend) {
+            logger.debug("Not sending message typed in chat feed: This option is disabled in the settings.");
+            return false;
+        }
+
+        // Slash commands in the message are not implemented (yet).
+        if (payload.message.startsWith("/")) {
+            logger.debug(`Not sending unimplemented slash command as a Kick chat message: ${payload.message}`);
+            return false;
+        }
+
+        // Handle the chat message
+        return this.sendKickChatMessage(payload.message, payload.accountType, payload.replyToMessageId);
+    }
+
+    async registerMessage(messageId: string, platform: 'twitch' | 'kick' | 'unknown'): Promise<boolean> {
+        if (this.messagePlatform[messageId]) {
+            return false;
+        }
+        this.messagePlatform[messageId] = platform;
+        return true;
+    }
+
     async sendKickChatMessage(msg: string, chatter: "Streamer" | "Bot", replyToMessageId: string | undefined = undefined): Promise<boolean> {
+        // This could get called with a twitch message ID, so we're going to
+        // make sure that we have seen the Kick message we are supposedly
+        // replying to. This can avoid problems with the API call.
+        if (replyToMessageId && (!this.messagePlatform[replyToMessageId] || this.messagePlatform[replyToMessageId] !== 'kick')) {
+            logger.debug(`Discarding reply-to with non-Kick message ID: ${replyToMessageId}`);
+            replyToMessageId = undefined;
+        }
+
         const segments: string[] = [];
         const maxLen = 500;
         while (msg.length > 0) {

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -78,6 +78,7 @@ export class Kick {
         }
 
         this.channelManager.start();
+        await this.chatManager.start();
         this.userApi.start();
         await this.userManager.connectViewerDatabase();
         logger.info("Kick API integration connected.");
@@ -88,6 +89,7 @@ export class Kick {
         await this.deleteExistingSubscriptions();
         this.apiAborter.abort();
         this.channelManager.stop();
+        await this.chatManager.stop();
         this.userApi.stop();
         this.userManager.disconnectViewerDatabase();
         logger.info("Kick API integration disconnected.");


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds an option (must be toggled on in settings) to send chat messages that you type in the Firebot chat feed to Kick. (Note: sending to Twitch is baked into Firebot and cannot be disabled. This merely sends the messages to Kick in addition to Twitch.)

### Motivation
I probably want to be able to do this during my streams.

### Testing
Tested it with the options. Also added some unit tests which cover other aspects of chat message sending.
