### PR TITLE
Use dropdowns to select options in platform aware chat effect

### DIFF
--- a/src/effects/__tests__/chat-platform.test.ts
+++ b/src/effects/__tests__/chat-platform.test.ts
@@ -59,6 +59,173 @@ describe('chatPlatformEffect.onTriggerEvent', () => {
         jest.restoreAllMocks();
     });
 
+    describe('sendKick/sendTwitch', () => {
+        describe('kick platform', () => {
+            beforeEach(() => {
+                jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('kick');
+                mockSendKickChatMessage.mockClear();
+                mockSendChatMessage.mockClear();
+            });
+
+            it('sends to Kick when sendKick is "always"', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'always', sendTwitch: 'never' };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'kick' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('msg', 'Streamer', undefined);
+            });
+
+            it('does not send to Kick when sendKick is "never"', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'never', sendTwitch: 'never' };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'kick' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(integration.kick.chatManager.sendKickChatMessage).not.toHaveBeenCalled();
+            });
+
+            it('sends to Kick when sendKick is "trigger" and platform is kick', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'trigger', sendTwitch: 'never' };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'kick' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('msg', 'Streamer', undefined);
+            });
+        });
+
+        describe('twitch platform', () => {
+            beforeEach(() => {
+                jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('twitch');
+                mockSendKickChatMessage.mockClear();
+                mockSendChatMessage.mockClear();
+            });
+
+            it('sends to Twitch when sendTwitch is "always"', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'never', sendTwitch: 'always' };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'twitch' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(mockSendChatMessage).toHaveBeenCalledWith('msg', '', 'bot', undefined);
+            });
+
+            it('does not send to Twitch when sendTwitch is "never"', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'never', sendTwitch: 'never' };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'twitch' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(mockSendChatMessage).not.toHaveBeenCalled();
+            });
+
+            it('sends to Twitch when sendTwitch is "trigger" and platform is twitch', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'never', sendTwitch: 'trigger' };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'twitch' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(mockSendChatMessage).toHaveBeenCalledWith('msg', '', 'bot', undefined);
+            });
+        });
+
+        describe('unknown platform', () => {
+            beforeEach(() => {
+                jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('unknown');
+                mockSendKickChatMessage.mockClear();
+                mockSendChatMessage.mockClear();
+            });
+
+            it('sends to Kick when sendKick is "always"', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'always', sendTwitch: 'trigger' };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'unknown' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('msg', 'Streamer', undefined);
+                expect(mockSendChatMessage).not.toHaveBeenCalled();
+            });
+
+            it('does not send to Kick when sendKick is "trigger"', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'trigger', sendTwitch: 'trigger' };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'unknown' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(integration.kick.chatManager.sendKickChatMessage).not.toHaveBeenCalled();
+                expect(mockSendChatMessage).not.toHaveBeenCalled();
+            });
+
+            it('sends to Kick when default trigger option is selected', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'trigger', sendTwitch: 'trigger', defaultSendKick: true };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'unknown' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('msg', 'Streamer', undefined);
+                expect(mockSendChatMessage).not.toHaveBeenCalled();
+            });
+
+            it('sends to Twitch when sendTwitch is "always"', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'trigger', sendTwitch: 'always' };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'unknown' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(integration.kick.chatManager.sendKickChatMessage).not.toHaveBeenCalled();
+                expect(mockSendChatMessage).toHaveBeenCalledWith('msg', '', 'bot', undefined);
+            });
+
+            it('does not send to Twitch when sendTwitch is "trigger"', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'trigger', sendTwitch: 'trigger' };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'unknown' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(integration.kick.chatManager.sendKickChatMessage).not.toHaveBeenCalled();
+                expect(mockSendChatMessage).not.toHaveBeenCalled();
+            });
+
+            it('sends to Twitch when default trigger option is selected', async () => {
+                const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', sendKick: 'trigger', sendTwitch: 'trigger', defaultSendTwitch: true };
+                const trigger = { type: 'command', metadata: { eventSource: { id: 'unknown' } } } as any;
+                await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+                expect(integration.kick.chatManager.sendKickChatMessage).not.toHaveBeenCalled();
+                expect(mockSendChatMessage).toHaveBeenCalledWith('msg', '', 'bot', undefined);
+            });
+        });
+    });
+
+    describe('backward compatibility with deprecated options', () => {
+        beforeEach(() => {
+            jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('kick');
+        });
+
+        it('sends to Kick when alwaysSendKick is true (maps to sendKick="always")', async () => {
+            const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', alwaysSendKick: true };
+            const trigger = { type: 'command', metadata: { eventSource: { id: 'kick' } } } as any;
+            await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+            expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('msg', 'Streamer', undefined);
+        });
+
+        it('does not send to Kick when skipKick is true (maps to sendKick="never")', async () => {
+            const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', skipKick: true };
+            const trigger = { type: 'command', metadata: { eventSource: { id: 'kick' } } } as any;
+            await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+            expect(integration.kick.chatManager.sendKickChatMessage).not.toHaveBeenCalled();
+        });
+
+        it('sends to Kick when neither alwaysSendKick nor skipKick is set (maps to sendKick="trigger")', async () => {
+            const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot' };
+            const trigger = { type: 'command', metadata: { eventSource: { id: 'kick' } } } as any;
+            await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+            expect(integration.kick.chatManager.sendKickChatMessage).toHaveBeenCalledWith('msg', 'Streamer', undefined);
+        });
+
+        it('sends to Twitch when alwaysSendTwitch is true (maps to sendTwitch="always")', async () => {
+            jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('twitch');
+            const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', alwaysSendTwitch: true };
+            const trigger = { type: 'command', metadata: { eventSource: { id: 'twitch' } } } as any;
+            await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+            expect(mockSendChatMessage).toHaveBeenCalledWith('msg', '', 'bot', undefined);
+        });
+
+        it('does not send to Twitch when skipTwitch is true (maps to sendTwitch="never")', async () => {
+            jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('twitch');
+            const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot', skipTwitch: true };
+            const trigger = { type: 'command', metadata: { eventSource: { id: 'twitch' } } } as any;
+            await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+            expect(mockSendChatMessage).not.toHaveBeenCalled();
+        });
+
+        it('sends to Twitch when neither alwaysSendTwitch nor skipTwitch is set (maps to sendTwitch="trigger")', async () => {
+            jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('twitch');
+            const effect = { message: 'msg', chatterKick: 'Streamer', chatterTwitch: 'Bot' };
+            const trigger = { type: 'command', metadata: { eventSource: { id: 'twitch' } } } as any;
+            await chatPlatformEffect.onTriggerEvent({ trigger, effect } as any);
+            expect(mockSendChatMessage).toHaveBeenCalledWith('msg', '', 'bot', undefined);
+        });
+    });
+
     it('sends to Kick with correct params (no reply)', async () => {
         jest.spyOn(ChatManagerModule.ChatManager, 'getPlatformFromTrigger').mockReturnValue('kick');
         const effect: chatPlatformEffectParams = { message: 'hello', chatterKick: 'Streamer', chatterTwitch: 'Bot', copyMessageKick: true, defaultSendKick: true };


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
We previously had checkboxes for "Always send to Twitch" and "Never send to Twitch". (And the same for Kick.) This has been replaced with a dropdown as shown. (The previous settings are still recognized despite the change.)

<img width="592" height="580" alt="image" src="https://github.com/user-attachments/assets/60a92e14-32bd-4e0d-90a8-c9fbd59a6798" />

### Motivation
Better UI.

### Testing
Updated unit tests to cover the updated setting and also make sure the now-deprecated former settings are still properly implemented.
