### PR TITLE
Add badges to chat feed and viewer DB roles

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,5 +17,12 @@ export const IntegrationConstants = {
     BOT_SCOPES: [
         "user:read",
         "chat:write"
-    ]
+    ],
+    KICK_BADGE_URLS: {
+        // Currently Kick does not have URLs for the badges as they are embedded SVG
+        // files. We're just going to fall back to the Twitch badges for now.
+        // https://discord.com/channels/1341256548323692586/1341264509511143424/1401335108635459685
+        "broadcaster": "https://static-cdn.jtvnw.net/badges/v1/5527c58c-fb7d-422d-b71b-f309dcb85cc1/1",
+        "moderator": "https://static-cdn.jtvnw.net/badges/v1/3267646d-33f0-4b17-b3df-f923a41db1d0/1"
+    } as Record<string, string>
 } as const;

--- a/src/internal/pusher/__tests__/pusher.test.ts
+++ b/src/internal/pusher/__tests__/pusher.test.ts
@@ -63,7 +63,7 @@ describe('KickPusher.dispatchChatroomEvent', () => {
         const spy = jest.spyOn<any, any>(pusher, 'parseChatMessageEvent').mockReturnValue('parsed');
         await (pusher as any).dispatchChatroomEvent('App\\Events\\ChatMessageEvent', { foo: 'bar' });
         expect(spy).toHaveBeenCalledWith({ foo: 'bar' });
-        expect(handleChatMessageSentEvent).toHaveBeenCalledWith('parsed');
+        expect(handleChatMessageSentEvent).toHaveBeenCalledWith('parsed', 2);
     });
 
     it('calls handleRewardRedeemedEvent for RewardRedeemedEvent', async () => {

--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -93,7 +93,7 @@ export class KickPusher {
         try {
             switch (event) {
                 case 'App\\Events\\ChatMessageEvent':
-                    await handleChatMessageSentEvent(this.parseChatMessageEvent(data));
+                    await handleChatMessageSentEvent(this.parseChatMessageEvent(data), 2); // Delay by 2 seconds in hopes webhook arrives first
                     break;
                 case 'App\\Events\\StreamHostedEvent':
                     await handleStreamHostedEvent(this.parseStreamHostedEvent(data));


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This change adds badges to the chat feed display in Firebot. Currently supports broadcaster and moderator badges. More may come in the future. This also saves the roles in the `twitchRoles` field in the user database.

Limitations:
- Other badge types are unimplemented because I don't have a good way to test them right now, but theoretically this can include VIPs, subscribers, and OGs.
- Kick doesn't provide image URLs (it provides SVG definitions) so this falls back to the Twitch icons. This is potentially fragile if those icons change. There's a Discord request for Kick to publish standard URLs for the icons.

### Motivation
Enhancement for the display, and could lead to future enhancement around restrictions and filters based on roles.

### Testing
Tested in my instance with broadcaster and moderator posting messages in chat.
