### PR TITLE
Add category and title changed events

### DIFF
--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -194,6 +194,37 @@ export const eventSource: EventSource = {
                     return `**${userDisplayName}** hosted on Kick with **${eventData.viewerCount}** viewer(s)`;
                 }
             }
+        },
+        {
+            id: "title-changed",
+            name: "Title Changed",
+            description: "When you change your Kick stream title.",
+            cached: false,
+            manualMetadata: {
+                title: "Stream Title"
+            },
+            activityFeed: {
+                icon: "fad fa-text",
+                getMessage: (eventData) => {
+                    return `Kick stream title changed to **${eventData.title}**`;
+                }
+            }
+        },
+        {
+            id: "category-changed",
+            name: "Category Changed",
+            description: "When you change your Kick stream category.",
+            cached: false,
+            manualMetadata: {
+                category: "Just Chatting",
+                categoryId: 15
+            },
+            activityFeed: {
+                icon: "fad fa-th-large",
+                getMessage: (eventData) => {
+                    return `Kick stream category changed to **${eventData.category}**`;
+                }
+            }
         }
     ]
 };

--- a/src/events/livestream-metadata-updated.ts
+++ b/src/events/livestream-metadata-updated.ts
@@ -1,0 +1,45 @@
+import { IntegrationConstants } from "../constants";
+import { integration } from "../integration";
+import { firebot } from "../main";
+import { CategoryInfo, LivestreamMetadataUpdated } from "../shared/types";
+
+export function triggerCategoryChangedEvent(category: CategoryInfo): void {
+    const { eventManager } = firebot.modules;
+    const metadata = {
+        category: category.name,
+        categoryId: category.id,
+        platform: "kick"
+    };
+    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "category-changed", metadata);
+
+    // Not triggering the Twitch category changed event because the category
+    // names and IDs do not match between the platforms.
+}
+
+export function triggerTitleChangedEvent(title: string): void {
+    const { eventManager } = firebot.modules;
+    const metadata = {
+        title: title,
+        platform: "kick"
+    };
+    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "title-changed", metadata);
+
+    // Trigger the Twitch title changed event if enabled via the integration settings
+    if (integration.getSettings().triggerTwitchEvents.titleChanged) {
+        eventManager.triggerEvent("twitch", "title-changed", metadata);
+    }
+}
+
+export async function handleLivestreamMetadataUpdatedEvent(event: LivestreamMetadataUpdated): Promise<void> {
+    const titleUpdated = integration.kick.channelManager.updateTitle(event.metadata.title);
+    if (titleUpdated) {
+        triggerTitleChangedEvent(event.metadata.title);
+    }
+    const categoryUpdated = integration.kick.channelManager.updateCategory(event.metadata.category);
+    if (categoryUpdated) {
+        triggerCategoryChangedEvent(event.metadata.category);
+    }
+    if (titleUpdated || categoryUpdated) {
+        integration.kick.channelManager.triggerChannelDataUpdatedEvent();
+    }
+}

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -70,6 +70,7 @@ type IntegrationParameters = {
         raid: boolean;
         streamOnline: boolean;
         streamOffline: boolean;
+        titleChanged: boolean;
         viewerArrived: boolean;
         viewerBanned: boolean;
         viewerTimeout: boolean;
@@ -143,6 +144,7 @@ export class KickIntegration extends EventEmitter {
             raid: false,
             streamOffline: false,
             streamOnline: false,
+            titleChanged: false,
             viewerArrived: false,
             viewerBanned: false,
             viewerTimeout: false

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -157,26 +157,33 @@ export const definition: IntegrationDefinition = {
                     default: false,
                     sortRank: 5
                 },
+                titleChanged: {
+                    title: "Title Changed",
+                    tip: "Trigger the 'Twitch:Title Changed' event when the Kick stream title changes",
+                    type: "boolean",
+                    default: false,
+                    sortRank: 6
+                },
                 viewerArrived: {
                     title: "Viewer Arrived",
                     tip: "Trigger the 'Twitch:Viewer Arrived' event when a viewer arrives on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 6
+                    sortRank: 7
                 },
                 viewerBanned: {
                     title: "Viewer Banned",
                     tip: "Trigger the 'Twitch:Viewer Banned' event when a viewer is banned on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 7
+                    sortRank: 8
                 },
                 viewerTimeout: {
                     title: "Viewer Timeout",
                     tip: "Trigger the 'Twitch:Viewer Timeout' event when a viewer is timed out on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 8
+                    sortRank: 9
                 }
             }
         },

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -168,6 +168,10 @@ export class Kick {
                     version: 1
                 },
                 {
+                    name: "livestream.metadata.updated",
+                    version: 1
+                },
+                {
                     name: "livestream.status.updated",
                     version: 1
                 },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -50,6 +50,20 @@ export interface BasicKickUser {
     userId: number;
 }
 
+export interface LivestreamMetadataUpdated {
+    broadcaster: KickUser;
+    metadata: {
+        title: string;
+        language: string;
+        hasMatureContent: boolean;
+        category: {
+            id: number;
+            name: string;
+            thumbnail: string;
+        };
+    };
+}
+
 export interface LivestreamStatusUpdated {
     broadcaster: KickUser;
     isLive: boolean;


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds "category changed" and "title changed" events for Kick. There's also a forwarder for the title change event to trigger the Twitch title change event. (There's no forwarder for the category since the category ID and even some game names are different between the platforms.)

### Motivation
Supporting additional events.

### Testing
Tested with existing variables (`$kickCategory`, `$kickCategoryId`, `$kickTitle`).