### PR TITLE
Add handlers and events for subs and gift subs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Currently supported:
 - Chat integration:
   - Kick messages appear in Firebot's chat feed (Dashboard), displaying Kick usernames and supporting emotes.
   - Ban user from the context menu in the chat feed.
+  - Badges: broadcaster, moderator, VIP, OG
 - Commands:
   - Standard commands mostly work, including restriction logic (with a custom Platform restriction).
 - Conditions:
@@ -51,8 +52,13 @@ Currently supported:
   - Chat message
   - Follow
   - Host (raid)
-  - Stream started
+  - Stream category (game) updated
   - Stream ended
+  - Stream started
+  - Stream title updated
+  - Sub
+  - Sub (Community Gifted)
+  - Sub (Gifted)
   - Viewer arrived
   - Viewer banned
   - Viewer timed out
@@ -67,6 +73,13 @@ Currently supported:
   - `$kickChatMessage`
   - `$kickChannelId` for your channel or another channel
   - `$kickCurrentViewerCount` for your channel or another channel
+  - `$kickGiftCount` (also works for Twitch events)
+  - `$kickGiftGiverUsername` (also works for Twitch events)
+  - `$kickGiftReceiverUsername` (also works for Twitch events)
+  - `$kickIsAnonymous` (for gift sub events; also works for Twitch events)
+  - `$kickSubMonths` (also works for Twitch events)
+  - `$kickSubStreak` (also works for Twitch events; for Kick this always equals `$kickSubMonths`)
+  - `$kickSubType` (also works for Twitch events; for Kick this always equals `"kickDefault"`)
   - `$kickModerator` (for bans/timeouts)
   - `$kickModReason` (for bans/timeouts)
   - `$kickRewardId` (for redeems)
@@ -84,11 +97,13 @@ Currently supported:
 
 Planned but not yet supported:
 
-- Subscription-related events (renewals, gifts, first time subs)
-- Live stream metadata updates (e.g., game/title change)
+- Subscription-related replacement variables
+- Track subscriptions we know about to estimate which users are current subscribers
+- Subscriber badge in chat feed
 - Events when a user is unbanned or untimed-out
 - Effects to ban, unban, timeout, and untimeout users
 - Chat roles
+- Outgoing host (raid) event
 
 Limitations due to Kick:
 
@@ -96,6 +111,7 @@ Limitations due to Kick:
 - Kick delivers profile image URLs that only resolve from kick.com, so these images may not display correctly elsewhere.
 - Kick's public API is lacking basic chat management options (e.g. delete message, clear chat), so we cannot implement these in Firebot's chat feed.
 - There is currently no API for fetching the viewer list, which prevents watch-time tracking and currency accrual.
+- There is currently no API to get your followers, subscribers, VIPs, moderators, etc. This limits what can be practically achieved with roles.
 - Channel point redeems on Kick cannot be managed via API (creation, approval, rejection), nor can they be disabled or paused. This means that Firebot cannot control them.
 - Configuration of the "pusher" websocket requires your channel ID and chatroom ID, which are different from your user ID. The process to determine these can be tedious. Thankfully, you'll only need to do this once.
 

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -225,6 +225,78 @@ export const eventSource: EventSource = {
                     return `Kick stream category changed to **${eventData.category}**`;
                 }
             }
+        },
+        {
+            id: "sub",
+            name: "Sub",
+            description: "When someone subscribes (or resubscribes) to your channel on Kick.",
+            cached: false,
+            manualMetadata: {
+                username: "firebot@kick",
+                userDisplayName: "Firebot",
+                userId: "k1234567",
+                isResub: false,
+                subMessage: "Test message",
+                totalMonths: 10
+            },
+            activityFeed: {
+                icon: "fas fa-star",
+                getMessage: (eventData) => {
+                    const username = typeof eventData.username === "string" ? unkickifyUsername(eventData.username) : "Unknown User";
+                    const userDisplayName = typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : username;
+                    const totalMonths = typeof eventData.totalMonths === "number" ? eventData.totalMonths : parseInt(String(eventData.totalMonths), 10) || 1;
+                    const durationString = eventData.isResub ? ` for **${totalMonths}** month(s)` : "";
+                    return `**${userDisplayName}** ${eventData.isResub ? "resubscribed" : "subscribed"} on Kick${durationString}`;
+                }
+            }
+        },
+        {
+            id: "subs-gifted",
+            name: "Sub Gifted",
+            description: "When someone gifts a sub to someone else in your channel on Kick.",
+            cached: false,
+            manualMetadata: {
+                gifterUsername: "Firebot@kick",
+                isAnonymous: false,
+                gifteeUsername: "MageEnclave@kick"
+            },
+            activityFeed: {
+                icon: "fad fa-gift",
+                getMessage: (eventData) => {
+                    const username = eventData.isAnonymous ? "An Anonymous Gifter" : typeof eventData.gifterUsername === "string" ? unkickifyUsername(eventData.gifterUsername) : "Unknown User";
+                    const userDisplayName = eventData.isAnonymous ? "An Anonymous Gifter" : typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : username;
+                    return `**${userDisplayName}** gifted a sub to **${eventData.gifteeUsername}** on Kick`;
+                }
+            }
+        },
+        {
+            id: "community-subs-gifted",
+            name: "Community Subs Gifted",
+            description: "When someone gifts subs to the community of the channel on Kick.",
+            cached: false,
+            manualMetadata: {
+                gifterUsername: "Firebot@kick",
+                isAnonymous: false,
+                subCount: 5,
+                giftReceivers: {
+                    type: "gift-receivers-list",
+                    value: [
+                        { gifteeUsername: "User1@kick", giftSubMonths: 1 },
+                        { gifteeUsername: "User2@kick", giftSubMonths: 1 },
+                        { gifteeUsername: "User3@kick", giftSubMonths: 1 },
+                        { gifteeUsername: "User4@kick", giftSubMonths: 1 },
+                        { gifteeUsername: "User5@kick", giftSubMonths: 1 }
+                    ]
+                }
+            },
+            activityFeed: {
+                icon: "fad fa-gifts",
+                getMessage: (eventData) => {
+                    const username = eventData.isAnonymous ? "An Anonymous Gifter" : typeof eventData.gifterUsername === "string" ? unkickifyUsername(eventData.gifterUsername) : "Unknown User";
+                    const userDisplayName = eventData.isAnonymous ? "An Anonymous Gifter" : typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : username;
+                    return `**${userDisplayName}** gifted **${eventData.subCount}** sub(s) to the community on Kick`;
+                }
+            }
         }
     ]
 };

--- a/src/events/__tests__/sub-events.gifts.test.ts
+++ b/src/events/__tests__/sub-events.gifts.test.ts
@@ -1,0 +1,234 @@
+import { handleChannelSubscriptionGiftsEvent } from '../sub-events';
+import { IntegrationConstants } from '../../constants';
+import { ChannelGiftSubscription } from '../../shared/types';
+
+const mockGetViewerById = jest.fn().mockResolvedValue(undefined);
+const mockCreateNewViewer = jest.fn().mockResolvedValue({ displayName: 'DisplayName' });
+const mockTriggerEvent = jest.fn();
+const mockLoggerDebug = jest.fn();
+const mockLoggerWarn = jest.fn();
+
+jest.mock('../../integration', () => ({
+    integration: {
+        kick: {
+            userManager: {
+                getViewerById: (...args: any[]) => mockGetViewerById(...args),
+                createNewViewer: (...args: any[]) => mockCreateNewViewer(...args)
+            }
+        },
+        getSettings: () => ({ triggerTwitchEvents: { subGift: false } })
+    }
+}));
+
+jest.mock('../../main', () => ({
+    firebot: {
+        modules: {
+            eventManager: {
+                triggerEvent: (...args: any[]) => mockTriggerEvent(...args)
+            }
+        },
+        firebot: {
+            settings: {
+                getSetting: jest.fn()
+            }
+        }
+    },
+    logger: {
+        debug: (...args: any[]) => mockLoggerDebug(...args),
+        warn: (...args: any[]) => mockLoggerWarn(...args)
+    }
+}));
+
+const { firebot } = require('../../main');
+
+describe('handleChannelSubscriptionGiftsEvent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('handles anonymous gifter', async () => {
+        const payload: ChannelGiftSubscription = {
+            broadcaster: { userId: 'k1', username: 'broadcaster@kick' },
+            gifter: { userId: 'k2', username: 'anon@kick', isAnonymous: true },
+            giftees: [{ userId: 'k3', username: 'giftee@kick' }],
+            createdAt: new Date()
+        } as any;
+        await handleChannelSubscriptionGiftsEvent(payload);
+        expect(mockTriggerEvent).toHaveBeenCalledWith(
+            IntegrationConstants.INTEGRATION_ID,
+            'subs-gifted',
+            {
+                gifterUsername: 'Anonymous',
+                gifterUserId: '',
+                gifterUserDisplayName: 'Anonymous',
+                isAnonymous: true,
+                subPlan: 'kickDefault',
+                giftSubMonths: 1,
+                giftSubDuration: 1,
+                gifteeUsername: 'giftee@kick',
+                gifteeUserId: 'k3',
+                gifteeUserDisplayName: 'giftee',
+                platform: 'kick'
+            }
+        );
+    });
+
+    it('handles single giftee, IgnoreSubsequentSubEventsAfterCommunitySub false', async () => {
+        firebot.firebot.settings.getSetting.mockReturnValue(false);
+        const payload: ChannelGiftSubscription = {
+            broadcaster: { userId: 'k1', username: 'broadcaster@kick' },
+            gifter: { userId: 'k2', username: 'gifter@kick', isAnonymous: false },
+            giftees: [{ userId: 'k3', username: 'giftee@kick' }],
+            createdAt: new Date()
+        } as any;
+        await handleChannelSubscriptionGiftsEvent(payload);
+        expect(mockTriggerEvent).toHaveBeenCalledWith(
+            IntegrationConstants.INTEGRATION_ID,
+            'subs-gifted',
+            {
+                gifterUsername: 'gifter@kick',
+                gifterUserId: 'k2',
+                gifterUserDisplayName: 'gifter',
+                isAnonymous: false,
+                subPlan: 'kickDefault',
+                giftSubMonths: 1,
+                giftSubDuration: 1,
+                gifteeUsername: 'giftee@kick',
+                gifteeUserId: 'k3',
+                gifteeUserDisplayName: 'giftee',
+                platform: 'kick'
+            }
+        );
+    });
+
+    it('handles multiple giftees, IgnoreSubsequentSubEventsAfterCommunitySub false', async () => {
+        firebot.firebot.settings.getSetting.mockReturnValue(false);
+        const payload: ChannelGiftSubscription = {
+            broadcaster: { userId: 'k1', username: 'broadcaster@kick' },
+            gifter: { userId: 'k2', username: 'gifter@kick', isAnonymous: false },
+            giftees: [
+                { userId: 'k3', username: 'giftee1@kick' },
+                { userId: 'k4', username: 'giftee2@kick' }
+            ],
+            createdAt: new Date()
+        } as any;
+        await handleChannelSubscriptionGiftsEvent(payload);
+        expect(mockTriggerEvent).toHaveBeenCalledWith(
+            IntegrationConstants.INTEGRATION_ID,
+            'community-subs-gifted',
+            {
+                gifterUsername: 'gifter@kick',
+                gifterUserId: 'k2',
+                gifterUserDisplayName: 'gifter',
+                isAnonymous: false,
+                subCount: 2,
+                subPlan: 'kickDefault',
+                giftReceivers: [
+                    { gifteeUsername: 'giftee1@kick', gifteeUserId: 'k3', gifteeUserDisplayName: 'giftee1', giftSubMonths: 1 },
+                    { gifteeUsername: 'giftee2@kick', gifteeUserId: 'k4', gifteeUserDisplayName: 'giftee2', giftSubMonths: 1 }
+                ],
+                platform: 'kick'
+            }
+        );
+        expect(mockTriggerEvent).toHaveBeenCalledWith(
+            IntegrationConstants.INTEGRATION_ID,
+            'subs-gifted',
+            {
+                gifterUsername: 'gifter@kick',
+                gifterUserId: 'k2',
+                gifterUserDisplayName: 'gifter',
+                isAnonymous: false,
+                subPlan: 'kickDefault',
+                giftSubMonths: 1,
+                giftSubDuration: 1,
+                gifteeUsername: 'giftee1@kick',
+                gifteeUserId: 'k3',
+                gifteeUserDisplayName: 'giftee1',
+                platform: 'kick'
+            }
+        );
+        expect(mockTriggerEvent).toHaveBeenCalledWith(
+            IntegrationConstants.INTEGRATION_ID,
+            'subs-gifted',
+            {
+                gifterUsername: 'gifter@kick',
+                gifterUserId: 'k2',
+                gifterUserDisplayName: 'gifter',
+                isAnonymous: false,
+                subPlan: 'kickDefault',
+                giftSubMonths: 1,
+                giftSubDuration: 1,
+                gifteeUsername: 'giftee2@kick',
+                gifteeUserId: 'k4',
+                gifteeUserDisplayName: 'giftee2',
+                platform: 'kick'
+            }
+        );
+    });
+
+    it('handles multiple giftees, IgnoreSubsequentSubEventsAfterCommunitySub true', async () => {
+        firebot.firebot.settings.getSetting.mockReturnValue(true);
+        const payload: ChannelGiftSubscription = {
+            broadcaster: { userId: 'k1', username: 'broadcaster@kick' },
+            gifter: { userId: 'k2', username: 'gifter@kick', isAnonymous: false },
+            giftees: [
+                { userId: 'k3', username: 'giftee1@kick' },
+                { userId: 'k4', username: 'giftee2@kick' }
+            ],
+            createdAt: new Date()
+        } as any;
+        await handleChannelSubscriptionGiftsEvent(payload);
+        expect(mockTriggerEvent).toHaveBeenCalledWith(
+            IntegrationConstants.INTEGRATION_ID,
+            'community-subs-gifted',
+            {
+                gifterUsername: 'gifter@kick',
+                gifterUserId: 'k2',
+                gifterUserDisplayName: 'gifter',
+                isAnonymous: false,
+                subCount: 2,
+                subPlan: 'kickDefault',
+                giftReceivers: [
+                    { gifteeUsername: 'giftee1@kick', gifteeUserId: 'k3', gifteeUserDisplayName: 'giftee1', giftSubMonths: 1 },
+                    { gifteeUsername: 'giftee2@kick', gifteeUserId: 'k4', gifteeUserDisplayName: 'giftee2', giftSubMonths: 1 }
+                ],
+                platform: 'kick'
+            }
+        );
+        // Should NOT trigger individual subs-gifted events
+        expect(mockTriggerEvent).not.toHaveBeenCalledWith(
+            IntegrationConstants.INTEGRATION_ID,
+            'subs-gifted',
+            {
+                gifterUsername: 'gifter@kick',
+                gifterUserId: 'k2',
+                gifterUserDisplayName: 'gifter@kick',
+                isAnonymous: false,
+                subPlan: 'kickDefault',
+                giftSubMonths: 1,
+                giftSubDuration: 1,
+                gifteeUsername: 'giftee1@kick',
+                gifteeUserId: 'k3',
+                gifteeUserDisplayName: 'giftee1@kick',
+                platform: 'kick'
+            }
+        );
+        expect(mockTriggerEvent).not.toHaveBeenCalledWith(
+            IntegrationConstants.INTEGRATION_ID,
+            'subs-gifted',
+            {
+                gifterUsername: 'gifter@kick',
+                gifterUserId: 'k2',
+                gifterUserDisplayName: 'gifter@kick',
+                isAnonymous: false,
+                subPlan: 'kickDefault',
+                giftSubMonths: 1,
+                giftSubDuration: 1,
+                gifteeUsername: 'giftee2@kick',
+                gifteeUserId: 'k4',
+                gifteeUserDisplayName: 'giftee2@kick',
+                platform: 'kick'
+            }
+        );
+    });
+});

--- a/src/events/__tests__/sub-events.test.ts
+++ b/src/events/__tests__/sub-events.test.ts
@@ -1,0 +1,118 @@
+import { IntegrationConstants } from '../../constants';
+import { ChannelSubscription } from '../../shared/types';
+import { handleChannelSubscriptionEvent } from '../sub-events';
+
+jest.mock('../../integration', () => ({
+    integration: {
+        kick: {
+            userManager: {
+                getViewerById: jest.fn().mockResolvedValue(undefined),
+                createNewViewer: jest.fn().mockResolvedValue({ displayName: 'DisplayName' })
+            }
+        },
+        getSettings: () => ({ triggerTwitchEvents: { sub: false } })
+    }
+}));
+
+jest.mock('../../main', () => ({
+    firebot: {
+        modules: {
+            eventManager: {
+                triggerEvent: jest.fn()
+            }
+        }
+    },
+    logger: {
+        warn: jest.fn()
+    }
+}));
+
+const { firebot } = require('../../main');
+
+describe('handleChannelSubscriptionEvent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('triggers event with isResub=false', async () => {
+        const payload: ChannelSubscription = {
+            broadcaster: {
+                userId: 'k1',
+                username: 'broadcaster@kick',
+                displayName: '',
+                isVerified: false,
+                profilePicture: '',
+                channelSlug: ''
+            },
+            subscriber: {
+                userId: 'k2',
+                username: 'subscriber@kick',
+                displayName: '',
+                isVerified: false,
+                profilePicture: '',
+                channelSlug: ''
+            },
+            duration: 1,
+            isResub: false,
+            createdAt: new Date()
+        };
+        await handleChannelSubscriptionEvent(payload as any);
+        expect(firebot.modules.eventManager.triggerEvent).toHaveBeenCalledWith(
+            IntegrationConstants.INTEGRATION_ID,
+            'sub',
+            expect.objectContaining({
+                isResub: false,
+                username: 'subscriber@kick',
+                userId: 'k2',
+                userDisplayName: 'DisplayName',
+                subPlan: 'kickDefault',
+                totalMonths: 1,
+                subMessage: '',
+                streak: 1,
+                isPrime: false,
+                platform: 'kick'
+            })
+        );
+    });
+
+    it('triggers event with isResub=true', async () => {
+        const payload: ChannelSubscription = {
+            broadcaster: {
+                userId: 'k1',
+                username: 'broadcaster@kick',
+                displayName: '',
+                isVerified: false,
+                profilePicture: '',
+                channelSlug: ''
+            },
+            subscriber: {
+                userId: 'k2',
+                username: 'subscriber@kick',
+                displayName: '',
+                isVerified: false,
+                profilePicture: '',
+                channelSlug: ''
+            },
+            duration: 69,
+            isResub: true,
+            createdAt: new Date()
+        };
+        await handleChannelSubscriptionEvent(payload as any);
+        expect(firebot.modules.eventManager.triggerEvent).toHaveBeenCalledWith(
+            IntegrationConstants.INTEGRATION_ID,
+            'sub',
+            expect.objectContaining({
+                isResub: true,
+                username: 'subscriber@kick',
+                userId: 'k2',
+                userDisplayName: 'DisplayName',
+                subPlan: 'kickDefault',
+                totalMonths: 69,
+                subMessage: '',
+                streak: 69,
+                isPrime: false,
+                platform: 'kick'
+            })
+        );
+    });
+});

--- a/src/events/sub-events.ts
+++ b/src/events/sub-events.ts
@@ -1,0 +1,121 @@
+import { IntegrationConstants } from "../constants";
+import { integration } from "../integration";
+import { kickifyUserId, kickifyUsername, unkickifyUsername } from "../internal/util";
+import { firebot, logger } from "../main";
+import { ChannelSubscription, ChannelGiftSubscription } from "../shared/types";
+
+export async function handleChannelSubscriptionEvent(payload: ChannelSubscription): Promise<void> {
+    const userId = kickifyUserId(payload.subscriber.userId.toString());
+    const username = kickifyUsername(payload.subscriber.username);
+
+    // Create the user if they don't exist
+    let viewer = await integration.kick.userManager.getViewerById(userId);
+    if (!viewer) {
+        viewer = await integration.kick.userManager.createNewViewer(payload.subscriber, [], true);
+        if (!viewer) {
+            logger.warn(`Failed to create new viewer for userId=${userId}`);
+        }
+    }
+
+    // Trigger the subscriber event
+    const { eventManager } = firebot.modules;
+    const metadata = {
+        username,
+        userId,
+        userDisplayName: viewer && viewer.displayName ? viewer.displayName : unkickifyUsername(username),
+        subPlan: "kickDefault", // Not a thing on Kick, so invent our own metadata consistent with Twitch
+        totalMonths: payload.duration || 1,
+        subMessage: "", // Not set on Kick
+        streak: payload.duration || 1, // Not set on Kick
+        isPrime: false, // Does not exist on Kick
+        isResub: payload.isResub,
+        platform: "kick"
+    };
+    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "sub", metadata);
+
+    // Trigger the equivalent Twitch event if enabled
+    if (integration.getSettings().triggerTwitchEvents.sub) {
+        eventManager.triggerEvent("twitch", "sub", metadata);
+    }
+}
+
+export async function handleChannelSubscriptionGiftsEvent(payload: ChannelGiftSubscription): Promise<void> {
+    // Kick doesn't really have the concept of community subscriptions versus
+    // normal gifted subscriptions, so we'll treat any gift of multiple
+    // subscriptions as a community gift, and any gift of a single subscription
+    // as a normal gift.
+    if (payload.gifter.isAnonymous) {
+        logger.debug("Skipping anonymous gifter for Kick gift subscription event.");
+    } else {
+        // Create the gifter user if they don't exist
+        const gifterId = kickifyUserId(payload.gifter.userId.toString());
+        let viewer = await integration.kick.userManager.getViewerById(gifterId);
+        if (!viewer) {
+            viewer = await integration.kick.userManager.createNewViewer(payload.gifter, [], true);
+            if (!viewer) {
+                logger.warn(`Failed to create new viewer for gifter: userId=${gifterId}`);
+            }
+        }
+    }
+
+    // Create each giftee user if they don't exist
+    for (const giftee of payload.giftees) {
+        const gifteeId = kickifyUserId(giftee.userId.toString());
+        let viewer = await integration.kick.userManager.getViewerById(gifteeId);
+        if (!viewer) {
+            viewer = await integration.kick.userManager.createNewViewer(giftee, [], true);
+            if (!viewer) {
+                logger.warn(`Failed to create new viewer for giftee: userId=${gifteeId}`);
+            }
+        }
+    }
+
+    // Trigger the community subs event if giftee count > 1
+    const { eventManager } = firebot.modules;
+
+    if (payload.giftees.length > 1) {
+        const metadata = {
+            gifterUsername: payload.gifter.isAnonymous ? "Anonymous" : kickifyUsername(payload.gifter.username),
+            gifterUserId: payload.gifter.isAnonymous ? "" : kickifyUserId(payload.gifter.userId.toString()),
+            gifterUserDisplayName: payload.gifter.isAnonymous ? "Anonymous" : payload.gifter.displayName || unkickifyUsername(payload.gifter.username),
+            isAnonymous: payload.gifter.isAnonymous,
+            subCount: payload.giftees.length,
+            subPlan: "kickDefault", // Not a thing on Kick, so invent our own metadata consistent with Twitch
+            giftReceivers: payload.giftees.map(giftee => ({
+                gifteeUsername: kickifyUsername(giftee.username),
+                gifteeUserId: kickifyUserId(giftee.userId.toString()),
+                gifteeUserDisplayName: giftee.displayName || unkickifyUsername(giftee.username),
+                giftSubMonths: 1
+            })),
+            platform: "kick"
+        };
+        eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "community-subs-gifted", metadata);
+    }
+
+    // Trigger individual gift events for each sub, except skip this if the
+    // option to ignore subsequent Gift Sub events after a Community Gift Sub
+    // event is enabled.
+    if (payload.giftees.length === 1 || !firebot.firebot.settings.getSetting("IgnoreSubsequentSubEventsAfterCommunitySub")) {
+        for (const giftee of payload.giftees) {
+            const metadata = {
+                gifterUsername: payload.gifter.isAnonymous ? "Anonymous" : kickifyUsername(payload.gifter.username),
+                gifterUserId: payload.gifter.isAnonymous ? "" : kickifyUserId(payload.gifter.userId.toString()),
+                gifterUserDisplayName: payload.gifter.isAnonymous ? "Anonymous" : payload.gifter.displayName || unkickifyUsername(payload.gifter.username),
+                isAnonymous: payload.gifter.isAnonymous,
+                subPlan: "kickDefault", // Not a thing on Kick, so invent our own metadata consistent with Twitch
+                giftSubMonths: 1,
+                giftSubDuration: 1,
+                gifteeUsername: kickifyUsername(giftee.username),
+                gifteeUserId: kickifyUserId(giftee.userId.toString()),
+                gifteeUserDisplayName: giftee.displayName || unkickifyUsername(giftee.username),
+                platform: "kick"
+            };
+            eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "subs-gifted", metadata);
+
+            // Trigger the equivalent Twitch event if enabled
+            if (integration.getSettings().triggerTwitchEvents.subGift) {
+                eventManager.triggerEvent("twitch", "subs-gifted", metadata);
+            }
+        }
+    }
+}

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -41,6 +41,13 @@ import { kickTimeoutDurationVariable } from "./variables/timeout-duration";
 import { kickUptimeVariable } from "./variables/uptime";
 import { kickUserDisplayNameVariable } from "./variables/user-display-name";
 import { streamerOrBotFilter } from "./filters/streamer-or-bot";
+import { kickSubTypeVariable } from "./variables/subs/sub-type";
+import { kickGiftReceiverUsernameVariable } from "./variables/subs/gift-receiver-username";
+import { kickGiftGiverUsernameVariable } from "./variables/subs/gift-giver-username";
+import { kickIsAnonymousVariable } from "./variables/subs/is-anonymous";
+import { kickSubStreakVariable } from "./variables/subs/sub-streak";
+import { kickSubMonthsVariable } from "./variables/subs/sub-months";
+import { kickGiftCountVariable } from "./variables/subs/gift-count";
 
 type IntegrationParameters = {
     connectivity: {
@@ -70,6 +77,9 @@ type IntegrationParameters = {
         raid: boolean;
         streamOnline: boolean;
         streamOffline: boolean;
+        sub: boolean;
+        subCommunityGift: boolean;
+        subGift: boolean;
         titleChanged: boolean;
         viewerArrived: boolean;
         viewerBanned: boolean;
@@ -144,6 +154,9 @@ export class KickIntegration extends EventEmitter {
             raid: false,
             streamOffline: false,
             streamOnline: false,
+            sub: false,
+            subCommunityGift: false,
+            subGift: false,
             titleChanged: false,
             viewerArrived: false,
             viewerBanned: false,
@@ -235,6 +248,15 @@ export class KickIntegration extends EventEmitter {
         replaceVariableManager.registerReplaceVariable(kickRewardIdVariable);
         replaceVariableManager.registerReplaceVariable(kickRewardNameVariable);
         replaceVariableManager.registerReplaceVariable(kickRewardMessageVariable);
+
+        // Subscription related variables
+        replaceVariableManager.registerReplaceVariable(kickGiftCountVariable);
+        replaceVariableManager.registerReplaceVariable(kickGiftGiverUsernameVariable);
+        replaceVariableManager.registerReplaceVariable(kickGiftReceiverUsernameVariable);
+        replaceVariableManager.registerReplaceVariable(kickIsAnonymousVariable);
+        replaceVariableManager.registerReplaceVariable(kickSubMonthsVariable);
+        replaceVariableManager.registerReplaceVariable(kickSubStreakVariable);
+        replaceVariableManager.registerReplaceVariable(kickSubTypeVariable);
 
         // Miscellaneous variables
         replaceVariableManager.registerReplaceVariable(platformVariable);

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -157,33 +157,54 @@ export const definition: IntegrationDefinition = {
                     default: false,
                     sortRank: 5
                 },
+                sub: {
+                    title: "Sub",
+                    tip: "Trigger the 'Twitch:Sub' event when someone subscribes or resubscribes on Kick",
+                    type: "boolean",
+                    default: false,
+                    sortRank: 6
+                },
+                subCommunityGift: {
+                    title: "Sub Community Gift",
+                    tip: "Trigger the 'Twitch:Community Subs Gifted' event when someone gifts community subscriptions on Kick",
+                    type: "boolean",
+                    default: false,
+                    sortRank: 7
+                },
+                subGift: {
+                    title: "Sub Gifted",
+                    tip: "Trigger the 'Twitch:Sub Gifted' event when someone gifts a subscription on Kick",
+                    type: "boolean",
+                    default: false,
+                    sortRank: 8
+                },
                 titleChanged: {
                     title: "Title Changed",
                     tip: "Trigger the 'Twitch:Title Changed' event when the Kick stream title changes",
                     type: "boolean",
                     default: false,
-                    sortRank: 6
+                    sortRank: 9
                 },
                 viewerArrived: {
                     title: "Viewer Arrived",
                     tip: "Trigger the 'Twitch:Viewer Arrived' event when a viewer arrives on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 7
+                    sortRank: 10
                 },
                 viewerBanned: {
                     title: "Viewer Banned",
                     tip: "Trigger the 'Twitch:Viewer Banned' event when a viewer is banned on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 8
+                    sortRank: 11
                 },
                 viewerTimeout: {
                     title: "Viewer Timeout",
                     tip: "Trigger the 'Twitch:Viewer Timeout' event when a viewer is timed out on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 9
+                    sortRank: 12
                 }
             }
         },

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -176,6 +176,18 @@ export class Kick {
                     version: 1
                 },
                 {
+                    name: "channel.subscription.renewal",
+                    version: 1
+                },
+                {
+                    name: "channel.subscription.gifts",
+                    version: 1
+                },
+                {
+                    name: "channel.subscription.new",
+                    version: 1
+                },
+                {
                     name: "moderation.banned",
                     version: 1
                 }

--- a/src/internal/webhook-handler/__tests__/webhook-handler.subs.test.ts
+++ b/src/internal/webhook-handler/__tests__/webhook-handler.subs.test.ts
@@ -1,0 +1,137 @@
+/* eslint-disable camelcase */
+import {
+    parseChannelSubscriptionGiftsEvent,
+    parseChannelSubscriptionNewEvent,
+    parseChannelSubscriptionRenewalEvent
+} from '../webhook-handler';
+
+describe('parseChannelSubscriptionNewEvent', () => {
+    beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2025-08-26T00:00:00Z'));
+    });
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+    it('parses a new subscription event', () => {
+        const createdAt = '2025-08-26T10:00:00Z';
+        const expiresAt = '2025-09-10T10:00:00Z'; // 15 days later
+        const event = {
+            broadcaster: { user_id: 1, username: 'broad', is_verified: true },
+            subscriber: { user_id: 2, username: 'sub', is_verified: false },
+            duration: 3,
+            created_at: createdAt,
+            expires_at: expiresAt
+        };
+        const encoded = Buffer.from(JSON.stringify(event), 'utf-8').toString('base64');
+        const result = parseChannelSubscriptionNewEvent(encoded);
+        expect(result.broadcaster.username).toBe('broad');
+        expect(result.subscriber.username).toBe('sub');
+        expect(result.duration).toBe(3);
+        expect(result.isResub).toBe(false);
+        expect(result.createdAt).toEqual(new Date(createdAt));
+        expect(result.expiresAt).toEqual(new Date(expiresAt));
+    });
+
+    it('uses default dates if created_at and expires_at are invalid', () => {
+        const event = {
+            broadcaster: { user_id: 1, username: 'broad', is_verified: true },
+            subscriber: { user_id: 2, username: 'sub', is_verified: false },
+            duration: 3,
+            created_at: 'not-a-date',
+            expires_at: 'not-a-date'
+        };
+        const encoded = Buffer.from(JSON.stringify(event), 'utf-8').toString('base64');
+        const result = parseChannelSubscriptionNewEvent(encoded);
+        expect(result.createdAt).toEqual(new Date('2025-08-26T00:00:00Z'));
+        expect(result.expiresAt).toEqual(new Date('2025-09-25T00:00:00Z'));
+    });
+});
+
+describe('parseChannelSubscriptionRenewalEvent', () => {
+    beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2025-08-26T00:00:00Z'));
+    });
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+    it('parses a renewal event', () => {
+        const createdAt = '2025-08-26T11:00:00Z';
+        const expiresAt = '2025-09-10T11:00:00Z'; // 15 days later
+        const event = {
+            broadcaster: { user_id: 1, username: 'broad', is_verified: true },
+            subscriber: { user_id: 2, username: 'sub', is_verified: false },
+            duration: 5,
+            created_at: createdAt,
+            expires_at: expiresAt
+        };
+        const encoded = Buffer.from(JSON.stringify(event), 'utf-8').toString('base64');
+        const result = parseChannelSubscriptionRenewalEvent(encoded);
+        expect(result.broadcaster.username).toBe('broad');
+        expect(result.subscriber.username).toBe('sub');
+        expect(result.duration).toBe(5);
+        expect(result.isResub).toBe(true);
+        expect(result.createdAt).toEqual(new Date(createdAt));
+        expect(result.expiresAt).toEqual(new Date(expiresAt));
+    });
+
+    it('uses default dates if created_at and expires_at are invalid', () => {
+        const event = {
+            broadcaster: { user_id: 1, username: 'broad', is_verified: true },
+            subscriber: { user_id: 2, username: 'sub', is_verified: false },
+            duration: 5,
+            created_at: 'not-a-date',
+            expires_at: 'not-a-date'
+        };
+        const encoded = Buffer.from(JSON.stringify(event), 'utf-8').toString('base64');
+        const result = parseChannelSubscriptionRenewalEvent(encoded);
+        expect(result.createdAt).toEqual(new Date('2025-08-26T00:00:00Z'));
+        expect(result.expiresAt).toEqual(new Date('2025-09-25T00:00:00Z'));
+    });
+});
+
+describe('parseChannelSubscriptionGiftsEvent', () => {
+    beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2025-08-26T00:00:00Z'));
+    });
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+    it('parses a gift event', () => {
+        const createdAt = '2025-08-26T12:00:00Z';
+        const expiresAt = '2025-09-10T12:00:00Z'; // 15 days later
+        const event = {
+            broadcaster: { user_id: 1, username: 'broad', is_verified: true },
+            gifter: { user_id: 3, username: 'gifter', is_verified: false },
+            giftees: [
+                { user_id: 4, username: 'gift1', is_verified: false },
+                { user_id: 5, username: 'gift2', is_verified: false }
+            ],
+            created_at: createdAt,
+            expires_at: expiresAt
+        };
+        const encoded = Buffer.from(JSON.stringify(event), 'utf-8').toString('base64');
+        const result = parseChannelSubscriptionGiftsEvent(encoded);
+        expect(result.broadcaster.username).toBe('broad');
+        expect(result.gifter.username).toBe('gifter');
+        expect(result.giftees.map(u => u.username)).toEqual(['gift1', 'gift2']);
+        expect(result.createdAt).toEqual(new Date(createdAt));
+        expect(result.expiresAt).toEqual(new Date(expiresAt));
+    });
+
+    it('uses default dates if created_at and expires_at are invalid', () => {
+        const event = {
+            broadcaster: { user_id: 1, username: 'broad', is_verified: true },
+            gifter: { user_id: 3, username: 'gifter', is_verified: false },
+            giftees: [
+                { user_id: 4, username: 'gift1', is_verified: false },
+                { user_id: 5, username: 'gift2', is_verified: false }
+            ],
+            created_at: 'not-a-date',
+            expires_at: 'not-a-date'
+        };
+        const encoded = Buffer.from(JSON.stringify(event), 'utf-8').toString('base64');
+        const result = parseChannelSubscriptionGiftsEvent(encoded);
+        expect(result.createdAt).toEqual(new Date('2025-08-26T00:00:00Z'));
+        expect(result.expiresAt).toEqual(new Date('2025-09-25T00:00:00Z'));
+    });
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -129,3 +129,20 @@ export interface StreamHostedEvent {
     optionalMessage: string;
     createdAt: Date | undefined;
 }
+
+export interface ChannelSubscription {
+    broadcaster: KickUser,
+    subscriber: KickUser,
+    duration: number,
+    isResub: boolean
+    createdAt: Date,
+    expiresAt?: Date
+}
+
+export interface ChannelGiftSubscription {
+    broadcaster: KickUser,
+    gifter: KickUser,
+    giftees: KickUser[],
+    createdAt: Date,
+    expiresAt?: Date
+}

--- a/src/variables/platform.ts
+++ b/src/variables/platform.ts
@@ -9,11 +9,7 @@ export const platformVariable: ReplaceVariable = {
         aliases: ["platform"],
         description: "Returns the platform on which the event was triggered (twitch, kick, firebot, etc.)",
         categories: ["common"],
-        possibleDataOutput: ["text"],
-        triggers: {
-            event: true,
-            manual: true
-        }
+        possibleDataOutput: ["text"]
     },
     evaluator: (trigger) => {
         // Manual trigger prefers the event source regardless of metadata

--- a/src/variables/subs/gift-count.ts
+++ b/src/variables/subs/gift-count.ts
@@ -1,0 +1,18 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../../constants';
+
+export const kickGiftCountVariable: ReplaceVariable = {
+    definition: {
+        handle: "kickGiftCount",
+        description: "The number of subs gifted. (Compatible with Kick and Twitch community subs gifted events.)",
+        triggers: {
+            "event": ["twitch:community-subs-gifted", `${IntegrationConstants.INTEGRATION_ID}:community-subs-gifted`],
+            "manual": true
+        },
+        categories: ["common"],
+        possibleDataOutput: ["number"]
+    },
+    evaluator: (trigger) => {
+        return trigger.metadata.eventData?.subCount ?? 0;
+    }
+};

--- a/src/variables/subs/gift-giver-username.ts
+++ b/src/variables/subs/gift-giver-username.ts
@@ -1,0 +1,41 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../../constants';
+import { kickifyUsername, unkickifyUsername } from '../../internal/util';
+import { logger } from '../../main';
+import { platformVariable } from '../platform';
+
+export const kickGiftGiverUsernameVariable: ReplaceVariable = {
+    definition: {
+        handle: "kickGiftGiverUsername",
+        description: "The name of the user who gifted a sub(s). (Compatible with Kick and Twitch subs gifted and community subs events.)",
+        triggers: {
+            "event": [
+                "twitch:subs-gifted",
+                `${IntegrationConstants.INTEGRATION_ID}:subs-gifted`,
+                "twitch:community-subs-gifted",
+                `${IntegrationConstants.INTEGRATION_ID}:community-subs-gifted`
+            ],
+            "manual": true
+        },
+        categories: ["common"],
+        possibleDataOutput: ["number"]
+    },
+    evaluator: (trigger) => {
+        let gifterUsername: string = trigger.metadata.eventData?.gifterUsername as string;
+        if (!gifterUsername) {
+            logger.warn(`kickGiftGiverUsernameVariable: Unknown gifter username! ${JSON.stringify(trigger.metadata)}`);
+            gifterUsername = "UnknownUser";
+        }
+
+        const platform = platformVariable.evaluator(trigger);
+        switch (platform) {
+            case "kick":
+                return kickifyUsername(gifterUsername);
+            case "twitch":
+                return unkickifyUsername(gifterUsername);
+            default:
+                logger.warn(`kickGiftGiverUsernameVariable: Unknown platform! ${JSON.stringify(trigger.metadata)}`);
+                return "UnknownUser";
+        }
+    }
+};

--- a/src/variables/subs/gift-receiver-username.ts
+++ b/src/variables/subs/gift-receiver-username.ts
@@ -1,0 +1,36 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../../constants';
+import { kickifyUsername, unkickifyUsername } from '../../internal/util';
+import { logger } from '../../main';
+import { platformVariable } from '../platform';
+
+export const kickGiftReceiverUsernameVariable: ReplaceVariable = {
+    definition: {
+        handle: "kickGiftReceiverUsername",
+        description: "The name of the user who received a gifted sub. (Compatible with Kick and Twitch subs gifted events.)",
+        triggers: {
+            "event": ["twitch:subs-gifted", `${IntegrationConstants.INTEGRATION_ID}:subs-gifted`],
+            "manual": true
+        },
+        categories: ["common"],
+        possibleDataOutput: ["number"]
+    },
+    evaluator: (trigger) => {
+        let gifteeUsername: string = trigger.metadata.eventData?.gifteeUsername as string;
+        if (!gifteeUsername) {
+            logger.warn(`kickGiftReceiverUsernameVariable: Unknown giftee username! ${JSON.stringify(trigger.metadata)}`);
+            gifteeUsername = "UnknownUser";
+        }
+
+        const platform = platformVariable.evaluator(trigger);
+        switch (platform) {
+            case "kick":
+                return kickifyUsername(gifteeUsername);
+            case "twitch":
+                return unkickifyUsername(gifteeUsername);
+            default:
+                logger.warn(`kickGiftReceiverUsernameVariable: Unknown platform! ${JSON.stringify(trigger.metadata)}`);
+                return gifteeUsername;
+        }
+    }
+};

--- a/src/variables/subs/is-anonymous.ts
+++ b/src/variables/subs/is-anonymous.ts
@@ -1,0 +1,18 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../../constants';
+
+export const kickIsAnonymousVariable: ReplaceVariable = {
+    definition: {
+        handle: "kickIsAnonymous",
+        description: "Whether or not the gift sub(s) were given anonymously. (Compatible with gift subs and community subs events on Twitch and Kick.)",
+        triggers: {
+            "event": ["twitch:subs-gifted", "twitch:community-subs-gifted", `${IntegrationConstants.INTEGRATION_ID}:subs-gifted`, `${IntegrationConstants.INTEGRATION_ID}:community-subs-gifted`],
+            "manual": true
+        },
+        categories: ["common"],
+        possibleDataOutput: ["bool"]
+    },
+    evaluator: async (trigger) => {
+        return trigger.metadata?.eventData?.isAnonymous === true;
+    }
+};

--- a/src/variables/subs/sub-months.ts
+++ b/src/variables/subs/sub-months.ts
@@ -1,0 +1,18 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../../constants';
+
+export const kickSubMonthsVariable: ReplaceVariable = {
+    definition: {
+        handle: "kickSubMonths",
+        description: "The total number of months the user has been subscribed since the beginning of time. (Compatible with Kick and Twitch sub events.)",
+        triggers: {
+            event: ["twitch:sub", `${IntegrationConstants.INTEGRATION_ID}:sub`],
+            manual: true
+        },
+        categories: ["common"],
+        possibleDataOutput: ["number"]
+    },
+    evaluator: (trigger) => {
+        return trigger.metadata.eventData?.totalMonths ?? 1;
+    }
+};

--- a/src/variables/subs/sub-streak.ts
+++ b/src/variables/subs/sub-streak.ts
@@ -1,0 +1,18 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../../constants';
+
+export const kickSubStreakVariable: ReplaceVariable = {
+    definition: {
+        handle: "kickSubStreak",
+        description: "Number of consecutive months a user has been subscribed to your channel (Twitch) and total number of months subscribed (Kick).",
+        triggers: {
+            event: ["twitch:sub", `${IntegrationConstants.INTEGRATION_ID}:sub`],
+            manual: true
+        },
+        categories: ["common"],
+        possibleDataOutput: ["number"]
+    },
+    evaluator: (trigger) => {
+        return trigger.metadata.eventData?.streak ?? 1;
+    }
+};

--- a/src/variables/subs/sub-type.ts
+++ b/src/variables/subs/sub-type.ts
@@ -1,0 +1,38 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from '../../constants';
+import { logger } from '../../main';
+import { platformVariable } from '../platform';
+
+export const kickSubTypeVariable: ReplaceVariable = {
+    definition: {
+        handle: "kickSubType",
+        description: "The type of subscription (for Twitch: Tier 1, Tier 2, Tier 3, Prime; for Kick, hard-coded since Kick does not report sub types.)",
+        triggers: {
+            event: ["twitch:sub", "twitch:prime-sub-upgraded", `${IntegrationConstants.INTEGRATION_ID}:sub`]
+        },
+        categories: ["common"],
+        possibleDataOutput: ["text"]
+    },
+    evaluator: (trigger) => {
+        const platform = platformVariable.evaluator(trigger);
+        switch (platform) {
+            case "kick":
+                return trigger.metadata.eventData?.subPlan || "kickDefault";
+            case "twitch":
+                switch (trigger.metadata.eventData?.subPlan) {
+                    case "Prime":
+                        return "Prime";
+                    case "1000":
+                        return "Tier 1";
+                    case "2000":
+                        return "Tier 2";
+                    case "3000":
+                        return "Tier 3";
+                }
+                logger.warn(`kickSubTypeVariable: Unknown Twitch sub plan! ${JSON.stringify(trigger.metadata)}`);
+                return "";
+        }
+        logger.warn(`kickSubTypeVariable: Unknown platform! ${JSON.stringify(trigger.metadata)}`);
+        return "";
+    }
+};


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This adds webhook handlers and tooling for the following events:
- Community subs gifted
- Sub gifted
- Sub

This adds the following related variables:
  - `$kickGiftCount` (also works for Twitch events)
  - `$kickGiftGiverUsername` (also works for Twitch events)
  - `$kickGiftReceiverUsername` (also works for Twitch events)
  - `$kickIsAnonymous` (for gift sub events; also works for Twitch events)
  - `$kickSubMonths` (also works for Twitch events)
  - `$kickSubStreak` (also works for Twitch events; for Kick this always equals `$kickSubMonths`)
  - `$kickSubType` (also works for Twitch events; for Kick this always equals `"kickDefault"`)

### Motivation
Support subscriptions

### Testing
I can't really test this IRL since nobody has subscribed to me :crying_cat_face: but I did add unit tests for the events and tested the variables via manual simulation of the events in Firebot. It's still possible that something is broken here which won't be seen until this registers an actual sub/gift.
