### PR TITLE
Server: Add ability to inject webhook into proxy for testing

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -7,4 +7,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 )
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+)

--- a/server/go.sum
+++ b/server/go.sum
@@ -3,6 +3,8 @@ github.com/caarlos0/env/v10 v10.0.0/go.mod h1:ZfulV76NvVPw3tm591U4SwL3Xx9ldzBP9a
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/server/pkg/config/config.go
+++ b/server/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Config struct {
+	AdminToken   string            `env:"ADMIN_TOKEN" envDefault:""`
 	ClientID     string            `env:"CLIENT_ID" required:"true"`
 	ClientSecret string            `env:"CLIENT_SECRET" required:"true"`
 	HTTPPort     string            `env:"HTTP_PORT" envDefault:"10000"`

--- a/server/pkg/model/webhook.go
+++ b/server/pkg/model/webhook.go
@@ -1,15 +1,24 @@
 package model
 
-type Webhook struct {
-	// Headers
+import "encoding/json"
+
+type WebhookHeaders struct {
 	EventMessageID        string `json:"kick_event_message_id"`
 	EventSubscriptionID   string `json:"kick_event_subscription_id"`
 	EventMessageTimestamp string `json:"kick_event_message_timestamp"`
 	EventType             string `json:"kick_event_type"`
 	EventVersion          string `json:"kick_event_version"`
+}
 
-	// Raw Data
+type Webhook struct {
+	WebhookHeaders
 	RawData []byte `json:"raw_data"`
+}
+
+type InjectableWebhook struct {
+	WebhookHeaders
+	RawData string          `json:"raw_data"`
+	Payload json.RawMessage `json:"payload"`
 }
 
 type WebhookBroadcaster struct {

--- a/server/pkg/server/inject.go
+++ b/server/pkg/server/inject.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"mage-kick-webhook-proxy/pkg/config"
+	"mage-kick-webhook-proxy/pkg/model"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func (s *Server) HandleInject(ctx context.Context) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Extract the key from the URL path
+		parts := strings.Split(r.URL.Path, "/")
+		if len(parts) < 3 || parts[2] == "" {
+			s.log(ctx, r, "Rejecting injection request: missing key in URL")
+			http.Error(w, "Bad Request: missing key in URL", http.StatusBadRequest)
+			return
+		}
+		keyID := parts[2]
+
+		// Currently there's one static admin token for the entire site.
+		// We can do better if we have to.
+		if config.FromContext(ctx).AdminToken == "" {
+			s.log(ctx, r, "Rejecting injection request: Admin token is not configured")
+			http.Error(w, "This endpoint is restricted", http.StatusForbidden)
+			return
+		}
+
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "Bearer "+config.FromContext(ctx).AdminToken && authHeader != "Token "+config.FromContext(ctx).AdminToken && authHeader != config.FromContext(ctx).AdminToken {
+			s.log(ctx, r, "Rejecting injection request: Admin token mismatch")
+			http.Error(w, "This endpoint is restricted", http.StatusForbidden)
+			return
+		}
+
+		// Read the request body
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			s.log(ctx, r, "Failed to read request body: %v", err)
+			http.Error(w, "Internal Server Error: failed to read body", http.StatusInternalServerError)
+			return
+		}
+
+		// Parse the body into the injectable struct
+		var injectable model.InjectableWebhook
+		if err := json.Unmarshal(body, &injectable); err != nil {
+			s.log(ctx, r, "Failed to parse request body: %v", err)
+			http.Error(w, "Bad Request: invalid JSON body", http.StatusBadRequest)
+			return
+		}
+
+		// We can default some of these missing fields, but others are required
+		if injectable.EventType == "" {
+			s.log(ctx, r, "Invalid injection request: missing event type")
+			http.Error(w, "Bad Request: missing event type", http.StatusBadRequest)
+			return
+		}
+		if injectable.EventVersion == "" {
+			injectable.EventVersion = "1" // Right now most events are version 1
+		}
+		if injectable.EventMessageID == "" {
+			injectable.EventMessageID = strings.ReplaceAll(uuid.New().String(), "-", "")
+		}
+		if injectable.EventMessageTimestamp == "" {
+			injectable.EventMessageTimestamp = time.Now().UTC().Format("2006-01-02T15:04:05Z")
+		}
+		if injectable.EventSubscriptionID == "" {
+			injectable.EventSubscriptionID = strings.ReplaceAll(uuid.New().String(), "-", "")
+		}
+
+		// If payload is not given but raw_data is, then we base64-decode raw_data into the payload
+		if len(injectable.RawData) > 0 && len(injectable.Payload) == 0 {
+			injectable.Payload = make([]byte, base64.StdEncoding.DecodedLen(len(injectable.RawData)))
+			n, err := base64.StdEncoding.Decode(injectable.Payload, []byte(injectable.RawData))
+			if err != nil {
+				s.log(ctx, r, "Failed to decode raw_data: %v", err)
+				http.Error(w, "Bad Request: invalid raw_data", http.StatusBadRequest)
+				return
+			}
+			injectable.Payload = injectable.Payload[:n]
+		}
+
+		// Convert injectable into webhook
+		webhook := model.Webhook{
+			WebhookHeaders: model.WebhookHeaders{
+				EventMessageID:        injectable.EventMessageID,
+				EventSubscriptionID:   injectable.EventSubscriptionID,
+				EventMessageTimestamp: injectable.EventMessageTimestamp,
+				EventType:             injectable.EventType,
+				EventVersion:          injectable.EventVersion,
+			},
+			RawData: injectable.Payload,
+		}
+
+		// Add the webhook to the user's state
+		s.log(ctx, r, "Injected webhook! key=%s username=%s eventType=%s eventVersion=%s messageID=%s timestamp=%s",
+			keyID, config.FromContext(ctx).IDToKickName[keyID], webhook.EventType, webhook.EventVersion, webhook.EventMessageID, webhook.EventMessageTimestamp)
+		s.state.Put(keyID, webhook)
+
+		// Signal any waiters that a webhook has been received
+		s.notifyWaiter(keyID)
+
+		// Respond to the request
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"success": true}`))
+	}
+}

--- a/server/pkg/server/server.go
+++ b/server/pkg/server/server.go
@@ -113,6 +113,14 @@ func (s *Server) main(ctx context.Context, wg *sync.WaitGroup) {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
+	http.HandleFunc("/inject/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.HandleInject(ctx)(w, r)
+	})
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Not Found", http.StatusNotFound)
 	})

--- a/server/pkg/server/webhook.go
+++ b/server/pkg/server/webhook.go
@@ -71,12 +71,14 @@ func (s *Server) HandleWebHook(ctx context.Context) func(w http.ResponseWriter, 
 
 		// Construct the Webhook object
 		webhook := model.Webhook{
-			EventMessageID:        messageID,
-			EventSubscriptionID:   r.Header.Get("Kick-Event-Subscription-ID"),
-			EventMessageTimestamp: timestamp,
-			EventType:             eventType,
-			EventVersion:          eventVersion,
-			RawData:               body,
+			WebhookHeaders: model.WebhookHeaders{
+				EventMessageID:        messageID,
+				EventSubscriptionID:   r.Header.Get("Kick-Event-Subscription-ID"),
+				EventMessageTimestamp: timestamp,
+				EventType:             eventType,
+				EventVersion:          eventVersion,
+			},
+			RawData: body,
 		}
 
 		// Add the webhook to the user's state


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Updating the server to add an `/inject/<uuid>` endpoint to send webhooks for testing. This is secured by a configurable token and is disabled if said token is not configured.

### Motivation
This will help during testing. It isn't possible to inject webhooks at this point because Kick signs them cryptographically.

### Testing
Ensured that injection and actual webhooks work correctly on my instance of this.
