### PR TITLE
Identify injected webhooks as test events

### DIFF
--- a/server/pkg/model/webhook.go
+++ b/server/pkg/model/webhook.go
@@ -12,7 +12,8 @@ type WebhookHeaders struct {
 
 type Webhook struct {
 	WebhookHeaders
-	RawData []byte `json:"raw_data"`
+	IsTestEvent bool   `json:"is_test_event"`
+	RawData     []byte `json:"raw_data"`
 }
 
 type InjectableWebhook struct {

--- a/server/pkg/server/inject.go
+++ b/server/pkg/server/inject.go
@@ -96,7 +96,8 @@ func (s *Server) HandleInject(ctx context.Context) func(w http.ResponseWriter, r
 				EventType:             injectable.EventType,
 				EventVersion:          injectable.EventVersion,
 			},
-			RawData: injectable.Payload,
+			IsTestEvent: true,
+			RawData:     injectable.Payload,
 		}
 
 		// Add the webhook to the user's state

--- a/server/pkg/server/webhook.go
+++ b/server/pkg/server/webhook.go
@@ -78,7 +78,8 @@ func (s *Server) HandleWebHook(ctx context.Context) func(w http.ResponseWriter, 
 				EventType:             eventType,
 				EventVersion:          eventVersion,
 			},
-			RawData: body,
+			IsTestEvent: false,
+			RawData:     body,
 		}
 
 		// Add the webhook to the user's state

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -91,6 +91,7 @@ type IntegrationParameters = {
         logWebsocketEvents: boolean;
     };
     advanced: {
+        allowTestWebhooks: boolean;
         dangerousOperations: boolean;
     };
 };
@@ -168,6 +169,7 @@ export class KickIntegration extends EventEmitter {
             logWebsocketEvents: false
         },
         advanced: {
+            allowTestWebhooks: false,
             dangerousOperations: false
         }
     };

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -239,6 +239,13 @@ export const definition: IntegrationDefinition = {
             title: "Advanced Settings",
             sortRank: 99,
             settings: {
+                allowTestWebhooks: {
+                    title: "Allow Test Webhooks",
+                    tip: "Process test webhooks from the webhook proxy as if they were real webhooks. Enable this only if you are actively developing the integration and you know exactly what this does.",
+                    type: "boolean",
+                    default: false,
+                    sortRank: 1
+                },
                 dangerousOperations: {
                     title: "Allow Dangerous Operations -- THIS COULD BREAK FIREBOT!",
                     tip: "Enable dangerous operations that can create and modify users in the Firebot database. THIS COULD BREAK FIREBOT! READ DOCUMENTATION CAREFULLY BEFORE ENABLING!",

--- a/src/internal/webhook-handler/webhook-handler.ts
+++ b/src/internal/webhook-handler/webhook-handler.ts
@@ -18,6 +18,15 @@ export async function handleWebhook(webhook: InboundWebhook): Promise<void> {
         throw new Error("Invalid webhook data");
     }
 
+    // This is NOT intended to be for security, since you are implicitly
+    // trusting the proxy owner and they could just send you fake data. Rather,
+    // it's meant to protect you against innocent mistakes (e.g. developer
+    // accidentally sending test webhooks with the wrong key).
+    if (webhook.is_test_event && !integration.getSettings().advanced.allowTestWebhooks) {
+        logger.warn(`Received test webhook but test webhooks are disabled: ${JSON.stringify(webhook)}`);
+        return;
+    }
+
     switch (webhook.kick_event_type) {
         case "chat.message.sent": {
             const event = parseChatMessageEvent(webhook.raw_data);

--- a/src/internal/webhook-handler/webhook.d.ts
+++ b/src/internal/webhook-handler/webhook.d.ts
@@ -4,5 +4,6 @@ interface InboundWebhook {
     kick_event_message_timestamp: string;
     kick_event_type: string;
     kick_event_version: string;
+    is_test_event?: boolean;
     raw_data: string; // Assuming rawData is a base64 encoded JSON string
 }


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This causes the server to explicitly identify injected webhooks as being test webhooks, and Firebot to reject these unless enabled.

As noted in the comment, this is not a security mechanism (because whoever operates your proxy can send whatever they want if they're malicious). 

### Motivation
It should help prevent accidental cross-sending of webhooks for multi-user proxies.

### Testing
Confirmed Firebot rejected the test webhook when set to do so, and then accepted it when the option is enabled.
