### PR TITLE
Track subs and gift subs persistently

### DIFF
--- a/src/events/__tests__/sub-events.gifts.test.ts
+++ b/src/events/__tests__/sub-events.gifts.test.ts
@@ -13,7 +13,9 @@ jest.mock('../../integration', () => ({
         kick: {
             userManager: {
                 getViewerById: (...args: any[]) => mockGetViewerById(...args),
-                createNewViewer: (...args: any[]) => mockCreateNewViewer(...args)
+                createNewViewer: (...args: any[]) => mockCreateNewViewer(...args),
+                recordSubscription: () => jest.fn(),
+                recordGift: () => jest.fn()
             }
         },
         getSettings: () => ({ triggerTwitchEvents: { subGift: false } })

--- a/src/events/__tests__/sub-events.test.ts
+++ b/src/events/__tests__/sub-events.test.ts
@@ -7,7 +7,9 @@ jest.mock('../../integration', () => ({
         kick: {
             userManager: {
                 getViewerById: jest.fn().mockResolvedValue(undefined),
-                createNewViewer: jest.fn().mockResolvedValue({ displayName: 'DisplayName' })
+                createNewViewer: jest.fn().mockResolvedValue({}),
+                recordSubscription: () => jest.fn(),
+                recordGift: () => jest.fn()
             }
         },
         getSettings: () => ({ triggerTwitchEvents: { sub: false } })
@@ -64,7 +66,7 @@ describe('handleChannelSubscriptionEvent', () => {
                 isResub: false,
                 username: 'subscriber@kick',
                 userId: 'k2',
-                userDisplayName: 'DisplayName',
+                userDisplayName: 'subscriber',
                 subPlan: 'kickDefault',
                 totalMonths: 1,
                 subMessage: '',
@@ -105,7 +107,7 @@ describe('handleChannelSubscriptionEvent', () => {
                 isResub: true,
                 username: 'subscriber@kick',
                 userId: 'k2',
-                userDisplayName: 'DisplayName',
+                userDisplayName: 'subscriber',
                 subPlan: 'kickDefault',
                 totalMonths: 69,
                 subMessage: '',

--- a/src/internal/__tests__/user-manager.gifts.test.ts
+++ b/src/internal/__tests__/user-manager.gifts.test.ts
@@ -1,0 +1,78 @@
+import Datastore from '@seald-io/nedb';
+import { KickUserManager } from '../user-manager';
+import { createMockKick } from '../mock-kick';
+
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+    }
+}));
+
+describe('KickUserManager recordGifter and getGifter', () => {
+    const fixedNow = new Date('2025-09-05T00:00:00Z');
+
+    beforeAll(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(fixedNow);
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+    let mgr: KickUserManager;
+    let inMemoryGiftDb: Datastore;
+    const gifterId = 'gifter-1';
+    const gifteeId1 = 'giftee-1';
+    const gifteeId2 = 'giftee-2';
+    const createdAt1 = new Date('2025-08-27T00:00:00Z');
+    const expiresAt1 = new Date('2025-09-01T00:00:00Z');
+    const createdAt2 = new Date('2025-09-02T00:00:00Z');
+    const expiresAt2 = new Date('2025-09-10T00:00:00Z');
+
+    beforeEach(async () => {
+        mgr = new KickUserManager(createMockKick());
+        inMemoryGiftDb = new Datastore();
+        // @ts-expect-error: access protected for test
+        mgr._giftDb = inMemoryGiftDb;
+        await inMemoryGiftDb.loadDatabaseAsync();
+    });
+
+    it('records a single gift and does not retrieve it if expired', async () => {
+        // expiresAt1 is 2025-09-01, fixedNow is 2025-09-05, so it should NOT be returned
+        await mgr.recordGift(gifterId, gifteeId1, createdAt1, expiresAt1);
+        const gifter = await mgr.getGifter(gifterId);
+        expect(gifter.gifts).toHaveLength(0);
+        expect(gifter.totalSubs).toBe(1);
+    });
+
+    it('returns gifts that have not expired', async () => {
+        // expiresAt2 is 2025-09-10, fixedNow is 2025-09-05, so it should be returned
+        await mgr.recordGift(gifterId, gifteeId2, createdAt2, expiresAt2);
+        const gifter = await mgr.getGifter(gifterId);
+        expect(gifter.gifts).toHaveLength(1);
+        expect(gifter.gifts[0].userId).toBe(gifteeId2);
+        expect(new Date(gifter.gifts[0].sub.createdAt).toISOString()).toBe(createdAt2.toISOString());
+        expect(new Date(gifter.gifts[0].sub.expiresAt).toISOString()).toBe(expiresAt2.toISOString());
+        expect(gifter.totalSubs).toBe(1);
+    });
+
+    it('records multiple gifts and only returns those that have not expired', async () => {
+        // Add both gifts again for a clean test
+        await mgr.recordGift(gifterId, gifteeId1, createdAt1, expiresAt1); // expired
+        await mgr.recordGift(gifterId, gifteeId2, createdAt2, expiresAt2); // not expired
+        const gifter = await mgr.getGifter(gifterId);
+        // Only gifteeId2's gift should be present
+        expect(gifter.gifts).toHaveLength(1);
+        expect(gifter.gifts[0].userId).toBe(gifteeId2);
+        expect(gifter.totalSubs).toBe(2);
+    });
+
+    it('returns an empty array if gifter has no gifts', async () => {
+        const gifter = await mgr.getGifter('nonexistent-gifter');
+        expect(gifter.gifts).toEqual([]);
+        expect(gifter.totalSubs).toBe(0);
+    });
+});

--- a/src/internal/__tests__/user-manager.purge-gifts.test.ts
+++ b/src/internal/__tests__/user-manager.purge-gifts.test.ts
@@ -1,0 +1,125 @@
+import Datastore from '@seald-io/nedb';
+import { KickUserManager } from '../user-manager';
+import { createMockKick } from '../mock-kick';
+
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+    }
+}));
+
+describe('KickUserManager purgeExpiredGiftSubs', () => {
+    const gifterId2 = 'gifter-2';
+    const gifteeId3 = 'giftee-3';
+    const gifteeId4 = 'giftee-4';
+    const createdAt3 = new Date('2025-08-20T00:00:00Z');
+    const expiresAt3 = new Date('2025-08-25T00:00:00Z'); // expired
+    const createdAt4 = new Date('2025-09-03T00:00:00Z');
+    const expiresAt4 = new Date('2025-09-20T00:00:00Z'); // not expired
+    const fixedNow = new Date('2025-09-05T00:00:00Z');
+
+    beforeAll(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(fixedNow);
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+
+    let mgr: KickUserManager;
+    let inMemoryGiftDb: Datastore;
+    const gifterId = 'gifter-1';
+    const gifteeId1 = 'giftee-1';
+    const gifteeId2 = 'giftee-2';
+    const createdAt1 = new Date('2025-08-27T00:00:00Z');
+    const expiresAt1 = new Date('2025-09-01T00:00:00Z'); // expired
+    const createdAt2 = new Date('2025-09-02T00:00:00Z');
+    const expiresAt2 = new Date('2025-09-10T00:00:00Z'); // not expired
+
+    beforeEach(async () => {
+        mgr = new KickUserManager(createMockKick());
+        inMemoryGiftDb = new Datastore();
+        // @ts-expect-error: access protected for test
+        mgr._giftDb = inMemoryGiftDb;
+        await inMemoryGiftDb.loadDatabaseAsync();
+    });
+
+    it('removes only expired gifts from a gifter', async () => {
+        // Insert a gifter with one expired and one non-expired gift
+        await inMemoryGiftDb.insertAsync({
+            _id: gifterId,
+            gifts: [
+                { _id: gifteeId1, sub: { createdAt: createdAt1, expiresAt: expiresAt1 } },
+                { _id: gifteeId2, sub: { createdAt: createdAt2, expiresAt: expiresAt2 } }
+            ],
+            totalSubs: 2
+        });
+        await mgr['purgeExpiredGiftSubs']();
+        const gifter = await inMemoryGiftDb.findOneAsync({ _id: gifterId });
+        expect(gifter.gifts).toHaveLength(1);
+        expect(gifter.gifts[0]._id).toBe(gifteeId2);
+    });
+
+    it('does not delete gifter record if all gifts are expired', async () => {
+        await inMemoryGiftDb.insertAsync({
+            _id: gifterId,
+            gifts: [
+                { _id: gifteeId1, sub: { createdAt: createdAt1, expiresAt: expiresAt1 } }
+            ],
+            totalSubs: 1
+        });
+        await mgr['purgeExpiredGiftSubs']();
+        const gifter = await inMemoryGiftDb.findOneAsync({ _id: gifterId });
+        expect(gifter).toBeTruthy();
+        expect(gifter.gifts).toHaveLength(0);
+    });
+
+    it('deletes gifter record if gifts is empty and totalSubs is 0', async () => {
+        await inMemoryGiftDb.insertAsync({
+            _id: gifterId,
+            gifts: [],
+            totalSubs: 0
+        });
+        await mgr['purgeExpiredGiftSubs']();
+        const gifter = await inMemoryGiftDb.findOneAsync({ _id: gifterId });
+        expect(gifter).toBeNull();
+    });
+
+    it('does nothing if there are no gifters', async () => {
+        await mgr['purgeExpiredGiftSubs']();
+        const allGifters = await inMemoryGiftDb.findAsync({});
+        expect(allGifters).toEqual([]);
+    });
+
+    it('removes expired gifts for multiple gifters and leaves all records', async () => {
+        // gifter-1: one expired, one not expired
+        // gifter-2: one expired, one not expired
+        await inMemoryGiftDb.insertAsync({
+            _id: gifterId,
+            gifts: [
+                { _id: gifteeId1, sub: { createdAt: createdAt1, expiresAt: expiresAt1 } },
+                { _id: gifteeId2, sub: { createdAt: createdAt2, expiresAt: expiresAt2 } }
+            ],
+            totalSubs: 2
+        });
+        await inMemoryGiftDb.insertAsync({
+            _id: gifterId2,
+            gifts: [
+                { _id: gifteeId3, sub: { createdAt: createdAt3, expiresAt: expiresAt3 } },
+                { _id: gifteeId4, sub: { createdAt: createdAt4, expiresAt: expiresAt4 } }
+            ],
+            totalSubs: 2
+        });
+        await mgr['purgeExpiredGiftSubs']();
+        const gifter1 = await inMemoryGiftDb.findOneAsync({ _id: gifterId });
+        const gifter2 = await inMemoryGiftDb.findOneAsync({ _id: gifterId2 });
+        expect(gifter1.gifts).toHaveLength(1);
+        expect(gifter1.gifts[0]._id).toBe(gifteeId2);
+        expect(gifter2.gifts).toHaveLength(1);
+        expect(gifter2.gifts[0]._id).toBe(gifteeId4);
+    });
+});

--- a/src/internal/__tests__/user-manager.subs.test.ts
+++ b/src/internal/__tests__/user-manager.subs.test.ts
@@ -1,0 +1,95 @@
+import Datastore from '@seald-io/nedb';
+import { KickUserManager } from '../user-manager';
+import { createMockKick } from '../mock-kick';
+
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+    }
+}));
+
+
+class KickUserManagerTest extends KickUserManager {
+    get db(): Datastore | null {
+        return this._db;
+    }
+
+    get giftDb(): Datastore | null {
+        return this._giftDb;
+    }
+
+    get subDb(): Datastore | null {
+        return this._subDb;
+    }
+}
+
+describe('KickUserManager recordSubscriber and getSubscriber', () => {
+    const fixedNow = new Date('2025-08-27T00:00:00Z');
+
+    beforeAll(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(fixedNow);
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+
+    let mgr: KickUserManagerTest;
+    let inMemoryDb: Datastore;
+    const userId = '12345678';
+    const now = new Date('2025-08-27T00:00:00Z');
+    const expires = new Date('2025-09-01T00:00:00Z');
+
+    beforeEach(async () => {
+        const mockKick = createMockKick();
+        mgr = new KickUserManagerTest(mockKick);
+        inMemoryDb = new Datastore();
+        // @ts-expect-error: access protected for test
+        mgr._subDb = inMemoryDb;
+        await inMemoryDb.loadDatabaseAsync();
+    });
+
+    it('records and retrieves a non-expired subscriber', async () => {
+        await mgr.recordSubscription(userId, now, expires);
+        const rec = await mgr.getSubscriber(userId);
+        expect(rec).toBeTruthy();
+        expect(rec?.createdAt).toBeDefined();
+        expect(rec?.expiresAt).toBeDefined();
+        if (rec?.createdAt) {
+            expect(rec.createdAt.toISOString()).toBe(now.toISOString());
+        }
+        if (rec?.expiresAt) {
+            expect(rec.expiresAt.toISOString()).toBe(expires.toISOString());
+        }
+    });
+
+    it('returns null for expired subscriber', async () => {
+        const expired = new Date('2025-08-01T00:00:00Z');
+        await mgr.recordSubscription(userId, now, expired);
+        const rec = await mgr.getSubscriber(userId);
+        expect(rec).toBeNull();
+    });
+
+    it('updates subscriber expiration if new expiresAt is later', async () => {
+        await mgr.recordSubscription(userId, now, expires);
+        const later = new Date('2025-09-10T00:00:00Z');
+        await mgr.recordSubscription(userId, now, later);
+        const rec = await mgr.getSubscriber(userId);
+        expect(rec).toBeTruthy();
+        expect(rec?.expiresAt.toISOString()).toBe(later.toISOString());
+    });
+
+    it('does not update subscriber expiration if new expiresAt is earlier', async () => {
+        const later = new Date('2025-09-10T00:00:00Z');
+        await mgr.recordSubscription(userId, now, later);
+        const earlier = new Date('2025-09-01T00:00:00Z');
+        await mgr.recordSubscription(userId, now, earlier);
+        const rec = await mgr.getSubscriber(userId);
+        expect(rec).toBeTruthy();
+        expect(rec?.expiresAt.toISOString()).toBe(later.toISOString());
+    });
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -146,3 +146,19 @@ export interface ChannelGiftSubscription {
     createdAt: Date,
     expiresAt?: Date
 }
+
+export interface KickGifter {
+    userId: string,
+    gifts: KickGiftSub[],
+    totalSubs: number,
+}
+
+export interface KickGiftSub {
+    userId: string,
+    sub: KickSubscription
+}
+
+export interface KickSubscription {
+    createdAt: Date,
+    expiresAt: Date
+}


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This keeps track of subs and gifts across streams within data files.

### Motivation
Kick doesn't have an endpoint that can enumerate this. We could eventually leverage this with variables to get lists of current subscribers, total gift subs given, etc. (Although this would be limited by events we saw during the stream.)

### Testing
Simulated Kick webhook payloads to trigger events and inspected files.
