### PR TITLE
Ensure that viewer get/create is idempotent

### DIFF
--- a/src/events/__tests__/sub-events.gifts.test.ts
+++ b/src/events/__tests__/sub-events.gifts.test.ts
@@ -1,9 +1,7 @@
-import { handleChannelSubscriptionGiftsEvent } from '../sub-events';
 import { IntegrationConstants } from '../../constants';
 import { ChannelGiftSubscription } from '../../shared/types';
+import { handleChannelSubscriptionGiftsEvent } from '../sub-events';
 
-const mockGetViewerById = jest.fn().mockResolvedValue(undefined);
-const mockCreateNewViewer = jest.fn().mockResolvedValue({ displayName: 'DisplayName' });
 const mockTriggerEvent = jest.fn();
 const mockLoggerDebug = jest.fn();
 const mockLoggerWarn = jest.fn();
@@ -12,8 +10,7 @@ jest.mock('../../integration', () => ({
     integration: {
         kick: {
             userManager: {
-                getViewerById: (...args: any[]) => mockGetViewerById(...args),
-                createNewViewer: (...args: any[]) => mockCreateNewViewer(...args),
+                getOrCreateViewer: jest.fn().mockResolvedValue(undefined),
                 recordSubscription: () => jest.fn(),
                 recordGift: () => jest.fn()
             }

--- a/src/events/__tests__/sub-events.test.ts
+++ b/src/events/__tests__/sub-events.test.ts
@@ -6,8 +6,7 @@ jest.mock('../../integration', () => ({
     integration: {
         kick: {
             userManager: {
-                getViewerById: jest.fn().mockResolvedValue(undefined),
-                createNewViewer: jest.fn().mockResolvedValue({}),
+                getOrCreateViewer: jest.fn().mockResolvedValue(undefined),
                 recordSubscription: () => jest.fn(),
                 recordGift: () => jest.fn()
             }

--- a/src/events/stream-hosted-event.ts
+++ b/src/events/stream-hosted-event.ts
@@ -7,29 +7,26 @@ import { StreamHostedEvent } from "../shared/types";
 export async function handleStreamHostedEvent(payload: StreamHostedEvent): Promise<void> {
     const userId = kickifyUserId(payload.user.userId.toString());
     const username = kickifyUsername(payload.user.username);
+    logger.debug(`Handling stream hosted event for userId=${userId}, username=${username}, numberOfViewers=${payload.numberOfViewers}`);
 
     // Create the user if they don't exist
-    let viewer = await integration.kick.userManager.getViewerById(userId);
-    if (!viewer) {
-        viewer = await integration.kick.userManager.createNewViewer(payload.user, [], true);
-        if (!viewer) {
-            logger.warn(`Failed to create new viewer for userId=${userId}`);
-        }
-    }
+    const viewer = await integration.kick.userManager.getOrCreateViewer(payload.user, [], true);
 
-    // Trigger the follow event
+    // Trigger the raid/host event
     const { eventManager } = firebot.modules;
     const metadata = {
         username: username,
         userId: userId,
-        userDisplayName: viewer && viewer.displayName ? viewer.displayName : unkickifyUsername(username),
+        userDisplayName: viewer?.displayName || unkickifyUsername(username),
         viewerCount: payload.numberOfViewers,
         platform: "kick"
     };
+    logger.debug(`Triggering "${IntegrationConstants.INTEGRATION_ID}:raid" event with metadata: ${JSON.stringify(metadata)}`);
     eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "raid", metadata);
 
     // Trigger the Twitch raid event if enabled via the integration settings
     if (integration.getSettings().triggerTwitchEvents.raid) {
+        logger.debug(`Triggering "twitch:raid" event with metadata: ${JSON.stringify(metadata)}`);
         eventManager.triggerEvent("twitch", "raid", metadata);
     }
 }


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
When the various events were creating entries in the user database, they were coded to call get and then create. There was no use case for creating where we did not first call the get method. This consolidates that logic into a new `getOrCreateViewer` method that is more robust against duplicate user insertion.

This also fixes duplicate user creation in the "host" event, so this is marked as a bug fix.

### Motivation
Duplicate user creation is never desired and throws an error at the database layer. Handling this gracefully is good.

### Testing
Testing of events via actual webhooks where possible and simulations where not possible. Also CI passes.
