### PR TITLE
Add outgoing host (raid) event and variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ node_modules/
 
 # Coverage
 /coverage/
+
+# For local testing
+/test-payloads/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Currently supported:
   - Platform
   - Viewer count (hosts)
 - Variables:
+  - `$hostTargetUserDisplayName` (also works for Twitch raids)
+  - `$hostTargetUserId` (also works for Twitch raids)
+  - `$hostTargetUsername` (also works for Twitch raids)
   - `$hostViewerCount` (also returns viewer count for Twitch raids)
   - `$kickCategory` (alias: `$kickGame`) for your channel or another channel
   - `$kickCategoryId` (alias: `$kickGameId`) for your channel or another channel
@@ -130,7 +133,7 @@ Limitations due to Firebot:
 | Chat message | :white_check_mark: | :white_check_mark: |  |
 | Follow | :white_check_mark: | :x: |  |
 | Host (raid) (incoming) | :white_check_mark: | :white_check_mark: | Via Pusher |
-| Host (raid) (outgoing) | Planned | Planned |  |
+| Host (raid) (outgoing) | :white_check_mark: | :white_check_mark: | Via Pusher |
 | Stream category (game) updated | :white_check_mark: | :x: |  |
 | Stream ended | :white_check_mark: | Planned |  |
 | Stream started | :white_check_mark: | Planned |  |

--- a/src/__tests__/host.test.ts
+++ b/src/__tests__/host.test.ts
@@ -8,6 +8,12 @@ jest.mock('../integration', () => ({
     integration: {
         getSettings: () => null,
         kick: {
+            broadcaster: {
+                email: "you@example.com",
+                name: "You",
+                profilePicture: "https://your-profile-pic",
+                userId: 1234567890
+            },
             userManager: userManagerMock
         }
     }
@@ -32,7 +38,7 @@ jest.mock('../main', () => ({
 import { IntegrationConstants } from '../constants';
 import { KickPusher } from '../internal/pusher/pusher';
 
-describe('e2e stream hosted', () => {
+describe('e2e stream incoming hosted', () => {
     let pusher: KickPusher;
 
     beforeEach(() => {
@@ -93,6 +99,56 @@ describe('e2e stream hosted', () => {
             );
             expect(triggerEventMock).toHaveBeenCalledTimes(1);
             expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "raid", expectedMetadata);
+        });
+    });
+});
+
+describe('e2e stream outgoing hosted', () => {
+    let pusher: KickPusher;
+
+    beforeEach(() => {
+        pusher = new KickPusher();
+        jest.clearAllMocks();
+    });
+
+    const jsonInput = `{"channel":{"id":12345678,"user_id":23456789,"slug":"slug","is_banned":false,"playback_url":"https://playback_url","name_updated_at":null,"vod_enabled":true,"subscription_enabled":true,"is_affiliate":true,"can_host":false,"current_livestream":{"id":3456789,"slug":"stream-slug","channel_id":12345678,"created_at":"2025-08-21 17:06:41","session_title":"Title of my stream","is_live":true,"risk_level_id":null,"start_time":"2025-08-21 17:06:40","source":null,"twitch_channel":null,"duration":0,"language":"English","is_mature":false,"viewer_count":14}},"slug":"target-slug","hosted":{"id":87654321,"username":"Target_User","slug":"target-slug","viewers_count":19,"is_live":true,"profile_pic":"https://profile_pic","category":"Games","preview_thumbnail":{"srcset":"https://thumbnail_srcset","src":"https://thumbnail_src"}}}`;
+    const payload = JSON.parse(jsonInput);
+    const event = 'App\\Events\\ChatMoveToSupportedChannelEvent';
+    const expectedMetadata = {
+        userId: 'k1234567890',
+        username: 'You@kick',
+        userDisplayName: 'You',
+        raidTargetUserDisplayName: "Target_User",
+        raidTargetUserId: "k87654321",
+        raidTargetUsername: "Target_User@kick",
+        viewerCount: 19,
+        platform: 'kick'
+    };
+
+    describe('twitch forwarding enabled', () => {
+        beforeEach(() => {
+            const integration = require('../integration').integration;
+            integration.getSettings = () => ({ triggerTwitchEvents: { raidSentOff: true } });
+        });
+
+        it('triggers all expected events', async () => {
+            await expect((pusher as any).dispatchChannelEvent(event, payload)).resolves.not.toThrow();
+            expect(triggerEventMock).toHaveBeenCalledTimes(2);
+            expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "raid-sent-off", expectedMetadata);
+            expect(triggerEventMock).toHaveBeenCalledWith("twitch", "raid-sent-off", expectedMetadata);
+        });
+    });
+
+    describe('twitch forwarding disabled', () => {
+        beforeEach(() => {
+            const integration = require('../integration').integration;
+            integration.getSettings = () => ({ triggerTwitchEvents: { raidSentOff: false } });
+        });
+
+        it('triggers all expected events', async () => {
+            await expect((pusher as any).dispatchChannelEvent(event, payload)).resolves.not.toThrow();
+            expect(triggerEventMock).toHaveBeenCalledTimes(1);
+            expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "raid-sent-off", expectedMetadata);
         });
     });
 });

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -1,5 +1,6 @@
 import { EventSource } from '@crowbartools/firebot-custom-scripts-types/types/modules/event-manager';
 import { unkickifyUsername } from './internal/util';
+import { getNumberFromUnknown } from './util/util';
 
 export const eventSource: EventSource = {
     id: "mage-kick-integration",
@@ -131,8 +132,9 @@ export const eventSource: EventSource = {
                     const userDisplayName = typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : username;
                     const moderator = typeof eventData.moderator === "string" ? unkickifyUsername(eventData.moderator) : "Unknown Moderator";
                     const modReason = typeof eventData.modReason === "string" ? eventData.modReason : "";
+                    const timeoutDuration = getNumberFromUnknown(eventData.timeoutDuration, "Unknown");
 
-                    let message = `**${userDisplayName}** was timed out for **${eventData.timeoutDuration} sec(s)** by **${moderator}** on Kick.`;
+                    let message = `**${userDisplayName}** was timed out for **${timeoutDuration} sec(s)** by **${moderator}** on Kick.`;
                     if (modReason) {
                         message = `${message} Reason: **${modReason}**`;
                     }
@@ -191,7 +193,8 @@ export const eventSource: EventSource = {
                 getMessage: (eventData) => {
                     const username = typeof eventData.username === "string" ? unkickifyUsername(eventData.username) : "Unknown User";
                     const userDisplayName = typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : username;
-                    return `**${userDisplayName}** hosted on Kick with **${eventData.viewerCount}** viewer(s)`;
+                    const viewerCount = getNumberFromUnknown(eventData.viewerCount, "Unknown");
+                    return `**${userDisplayName}** hosted on Kick with **${viewerCount}** viewer(s)`;
                 }
             }
         },
@@ -244,7 +247,7 @@ export const eventSource: EventSource = {
                 getMessage: (eventData) => {
                     const username = typeof eventData.username === "string" ? unkickifyUsername(eventData.username) : "Unknown User";
                     const userDisplayName = typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : username;
-                    const totalMonths = typeof eventData.totalMonths === "number" ? eventData.totalMonths : parseInt(String(eventData.totalMonths), 10) || 1;
+                    const totalMonths = getNumberFromUnknown(eventData.totalMonths, "1");
                     const durationString = eventData.isResub ? ` for **${totalMonths}** month(s)` : "";
                     return `**${userDisplayName}** ${eventData.isResub ? "resubscribed" : "subscribed"} on Kick${durationString}`;
                 }
@@ -294,7 +297,32 @@ export const eventSource: EventSource = {
                 getMessage: (eventData) => {
                     const username = eventData.isAnonymous ? "An Anonymous Gifter" : typeof eventData.gifterUsername === "string" ? unkickifyUsername(eventData.gifterUsername) : "Unknown User";
                     const userDisplayName = eventData.isAnonymous ? "An Anonymous Gifter" : typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : username;
-                    return `**${userDisplayName}** gifted **${eventData.subCount}** sub(s) to the community on Kick`;
+                    const subCount = getNumberFromUnknown(eventData.subCount, "Unknown Number");
+                    return `**${userDisplayName}** gifted **${subCount}** sub(s) to the community on Kick`;
+                }
+            }
+        },
+        {
+            id: "raid-sent-off",
+            name: "Outgoing Host (Raid)",
+            description: "When your outgoing host (raid) is completed on Kick.",
+            cached: false,
+            manualMetadata: {
+                username: "firebot@kick",
+                userId: "k1234567",
+                userDisplayName: "Firebot",
+                raidTargetUsername: "user@kick",
+                raidTargetUserId: "k7654321",
+                raidTargetUserDisplayName: "User",
+                viewerCount: 5
+            },
+            activityFeed: {
+                icon: "fad fa-inbox-out",
+                getMessage: (eventData) => {
+                    const username = typeof eventData.raidTargetUsername === "string" ? unkickifyUsername(eventData.raidTargetUsername) : "Unknown User";
+                    const userDisplayName = typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : username;
+                    const viewerCount = getNumberFromUnknown(eventData.viewerCount, "Unknown");
+                    return `Hosted **${userDisplayName}** with **${viewerCount}** viewer(s)`;
                 }
             }
         }

--- a/src/events/raid-sent-off-event.ts
+++ b/src/events/raid-sent-off-event.ts
@@ -1,0 +1,29 @@
+import { IntegrationConstants } from "../constants";
+import { integration } from "../integration";
+import { kickifyUserId, kickifyUsername, unkickifyUsername } from "../internal/util";
+import { firebot, logger } from "../main";
+import { RaidSentOffEvent } from "../shared/types";
+
+export async function handleRaidSentOffEvent(payload: RaidSentOffEvent): Promise<void> {
+    logger.debug(`Handling raid sent off event (sending ${payload.numberOfViewers} viewers to ${payload.targetUser.username})`);
+
+    const { eventManager } = firebot.modules;
+    const metadata = {
+        raidTargetUsername: kickifyUsername(payload.targetUser.username),
+        raidTargetUserId: kickifyUserId(payload.targetUser.userId),
+        raidTargetUserDisplayName: payload.targetUser.displayName ? payload.targetUser.displayName : unkickifyUsername(payload.targetUser.username),
+        username: kickifyUsername(integration.kick.broadcaster?.name),
+        userDisplayName: unkickifyUsername(integration.kick.broadcaster?.name),
+        userId: kickifyUserId(integration.kick.broadcaster?.userId.toString()),
+        viewerCount: payload.numberOfViewers,
+        platform: "kick"
+    };
+    logger.debug(`Triggering "${IntegrationConstants.INTEGRATION_ID}:raid-sent-off" event with metadata: ${JSON.stringify(metadata)}`);
+    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "raid-sent-off", metadata);
+
+    // Trigger the Twitch outgoing raid event if enabled via the integration settings
+    if (integration.getSettings().triggerTwitchEvents.raidSentOff) {
+        logger.debug(`Triggering "twitch:raid-sent-off" event with metadata: ${JSON.stringify(metadata)}`);
+        eventManager.triggerEvent("twitch", "raid-sent-off", metadata);
+    }
+}

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -48,6 +48,9 @@ import { kickIsAnonymousVariable } from "./variables/subs/is-anonymous";
 import { kickSubStreakVariable } from "./variables/subs/sub-streak";
 import { kickSubMonthsVariable } from "./variables/subs/sub-months";
 import { kickGiftCountVariable } from "./variables/subs/gift-count";
+import { hostTargetUserDisplayName } from "./variables/host-target-user-display-name";
+import { hostTargetUserId } from "./variables/host-target-user-id";
+import { hostTargetUsername } from "./variables/host-target-username";
 
 type IntegrationParameters = {
     connectivity: {
@@ -75,6 +78,7 @@ type IntegrationParameters = {
         chatMessage: boolean;
         follower: boolean;
         raid: boolean;
+        raidSentOff: boolean;
         streamOnline: boolean;
         streamOffline: boolean;
         sub: boolean;
@@ -153,6 +157,7 @@ export class KickIntegration extends EventEmitter {
             chatMessage: false,
             follower: false,
             raid: false,
+            raidSentOff: false,
             streamOffline: false,
             streamOnline: false,
             sub: false,
@@ -230,8 +235,13 @@ export class KickIntegration extends EventEmitter {
         replaceVariableManager.registerReplaceVariable(kickStreamerIdVariable);
         replaceVariableManager.registerReplaceVariable(kickStreamerVariable);
 
-        // Stream variables
+        // Hosts (raids)
         replaceVariableManager.registerReplaceVariable(hostViewerCount);
+        replaceVariableManager.registerReplaceVariable(hostTargetUserId);
+        replaceVariableManager.registerReplaceVariable(hostTargetUserDisplayName);
+        replaceVariableManager.registerReplaceVariable(hostTargetUsername);
+
+        // Stream variables
         replaceVariableManager.registerReplaceVariable(kickCurrentViewerCountVariable);
         replaceVariableManager.registerReplaceVariable(kickStreamIsLiveVariable);
         replaceVariableManager.registerReplaceVariable(kickStreamTitleVariable);

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -137,74 +137,81 @@ export const definition: IntegrationDefinition = {
                     sortRank: 2
                 },
                 raid: {
-                    title: "Host (Raid)",
+                    title: "Host - Incoming",
                     tip: "Trigger the 'Twitch:Raid' event when someone hosts (raids) your stream on Kick",
                     type: "boolean",
                     default: false,
                     sortRank: 3
+                },
+                raidSentOff: {
+                    title: "Host - Outgoing",
+                    tip: "Trigger the 'Twitch:Raid Sent Off' event when you send a host (raid) to another channel on Kick",
+                    type: "boolean",
+                    default: false,
+                    sortRank: 4
                 },
                 streamOffline: {
                     title: "Stream Ended",
                     tip: "Trigger the 'Twitch:Stream Ended' event when the Kick stream goes offline",
                     type: "boolean",
                     default: false,
-                    sortRank: 4
+                    sortRank: 5
                 },
                 streamOnline: {
                     title: "Stream Started",
                     tip: "Trigger the 'Twitch:Stream Started' event when the Kick stream goes online",
                     type: "boolean",
                     default: false,
-                    sortRank: 5
+                    sortRank: 6
                 },
                 sub: {
                     title: "Sub",
                     tip: "Trigger the 'Twitch:Sub' event when someone subscribes or resubscribes on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 6
+                    sortRank: 7
                 },
                 subCommunityGift: {
                     title: "Sub Community Gift",
                     tip: "Trigger the 'Twitch:Community Subs Gifted' event when someone gifts community subscriptions on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 7
+                    sortRank: 8
                 },
                 subGift: {
                     title: "Sub Gifted",
                     tip: "Trigger the 'Twitch:Sub Gifted' event when someone gifts a subscription on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 8
+                    sortRank: 9
                 },
                 titleChanged: {
                     title: "Title Changed",
                     tip: "Trigger the 'Twitch:Title Changed' event when the Kick stream title changes",
                     type: "boolean",
                     default: false,
-                    sortRank: 9
+                    sortRank: 10
                 },
                 viewerArrived: {
                     title: "Viewer Arrived",
                     tip: "Trigger the 'Twitch:Viewer Arrived' event when a viewer arrives on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 10
+                    sortRank: 11
                 },
                 viewerBanned: {
                     title: "Viewer Banned",
                     tip: "Trigger the 'Twitch:Viewer Banned' event when a viewer is banned on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 11
+                    sortRank: 12
                 },
                 viewerTimeout: {
                     title: "Viewer Timeout",
                     tip: "Trigger the 'Twitch:Viewer Timeout' event when a viewer is timed out on Kick",
                     type: "boolean",
                     default: false,
-                    sortRank: 12
+                    sortRank: 13
                 }
             }
         },

--- a/src/internal/pusher/__tests__/pusher.parsers.test.ts
+++ b/src/internal/pusher/__tests__/pusher.parsers.test.ts
@@ -1,5 +1,5 @@
 import { KickUser } from "../../../shared/types";
-import { parseChatMessageEvent, parseRewardRedeemedEvent, parseStreamHostedEvent } from "../pusher-parsers";
+import { parseChatMessageEvent, parseRewardRedeemedEvent, parseStreamHostedEvent, parseChatMoveToSupportedChannelEvent } from "../pusher-parsers";
 
 describe('KickPusher.parseChatMessageEvent', () => {
     const broadcaster: KickUser = {
@@ -172,6 +172,25 @@ describe('KickPusher.parseStreamHostedEvent', () => {
             numberOfViewers: 32,
             optionalMessage: "",
             createdAt: new Date("2025-08-20T20:26:31.231698Z")
+        });
+    });
+});
+
+describe('parseChatMoveToSupportedChannelEvent', () => {
+    it('parses a valid move-to-supported-channel event', () => {
+        const jsonInput = `{"channel":{"id":12345678,"user_id":23456789,"slug":"slug","is_banned":false,"playback_url":"https://playback_url","name_updated_at":null,"vod_enabled":true,"subscription_enabled":true,"is_affiliate":true,"can_host":false,"current_livestream":{"id":3456789,"slug":"stream-slug","channel_id":12345678,"created_at":"2025-08-21 17:06:41","session_title":"Title of my stream","is_live":true,"risk_level_id":null,"start_time":"2025-08-21 17:06:40","source":null,"twitch_channel":null,"duration":0,"language":"English","is_mature":false,"viewer_count":14}},"slug":"target-slug","hosted":{"id":87654321,"username":"Target_User","slug":"target-slug","viewers_count":19,"is_live":true,"profile_pic":"https://profile_pic","category":"Games","preview_thumbnail":{"srcset":"https://thumbnail_srcset","src":"https://thumbnail_src"}}}`;
+        const result = parseChatMoveToSupportedChannelEvent(JSON.parse(jsonInput));
+        expect(result).toEqual({
+            targetUser: {
+                userId: 'k87654321',
+                username: 'Target_User@kick',
+                displayName: 'Target_User',
+                profilePicture: 'https://profile_pic',
+                isVerified: false,
+                channelSlug: 'target-slug'
+            },
+            targetSlug: 'target-slug',
+            numberOfViewers: 19
         });
     });
 });

--- a/src/internal/pusher/chat-moved-to-supported-channel-event-payload.d.ts
+++ b/src/internal/pusher/chat-moved-to-supported-channel-event-payload.d.ts
@@ -1,0 +1,44 @@
+interface ChatMoveToSupportedChannelEventPayload {
+    channel: {
+        id: number;
+        user_id: number;
+        slug: string;
+        is_banned: boolean;
+        playback_url: string;
+        name_updated_at: string | null;
+        vod_enabled: boolean;
+        subscription_enabled: boolean;
+        is_affiliate: boolean;
+        can_host: boolean;
+        current_livestream: {
+            id: number;
+            slug: string;
+            channel_id: number;
+            created_at: boolean;
+            session_title: string;
+            is_live: boolean;
+            risk_level_id: number | null;
+            start_time: boolean;
+            source: string | null;
+            twitch_channel: string | null;
+            duration: number;
+            language: string;
+            is_mature: boolean;
+            viewer_count: number;
+        };
+    };
+    slug: string;
+    hosted: {
+        id: number;
+        username: string;
+        slug: string;
+        viewers_count: number;
+        is_live: boolean;
+        profile_pic: string;
+        category: string;
+        preview_thumbnail: {
+            srcset: string;
+            src: string;
+        };
+    };
+}

--- a/src/internal/pusher/pusher-parsers.ts
+++ b/src/internal/pusher/pusher-parsers.ts
@@ -1,5 +1,5 @@
-import { ChatMessage, KickUser, RewardRedeemedEvent, StreamHostedEvent } from "../../shared/types";
-import { parseDate } from "../util";
+import { ChatMessage, KickUser, RaidSentOffEvent, RewardRedeemedEvent, StreamHostedEvent } from "../../shared/types";
+import { kickifyUserId, kickifyUsername, parseDate, unkickifyUsername } from "../util";
 
 export function parseChatMessageEvent(data: any, broadcaster: KickUser): ChatMessage {
     const d = data as ChatMessageEvent;
@@ -65,5 +65,21 @@ export function parseStreamHostedEvent(data: any): StreamHostedEvent {
         numberOfViewers: d.message.numberOfViewers,
         optionalMessage: d.message.optionalMessage,
         createdAt: parseDate(d.message.createdAt)
+    };
+}
+
+export function parseChatMoveToSupportedChannelEvent(data: any): RaidSentOffEvent {
+    const d = data as ChatMoveToSupportedChannelEventPayload;
+    return {
+        targetUser: {
+            userId: kickifyUserId(d.hosted.id.toString()),
+            username: kickifyUsername(d.hosted.username),
+            displayName: unkickifyUsername(d.hosted.username),
+            profilePicture: d.hosted.profile_pic,
+            isVerified: false, // Not provided in event
+            channelSlug: d.hosted.slug
+        },
+        targetSlug: d.slug,
+        numberOfViewers: d.hosted.viewers_count
     };
 }

--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -1,10 +1,11 @@
 import { handleChatMessageSentEvent } from "../../events/chat-message-sent";
+import { handleRaidSentOffEvent } from "../../events/raid-sent-off-event";
 import { handleRewardRedeemedEvent } from "../../events/reward-redeemed-event";
 import { handleStreamHostedEvent } from "../../events/stream-hosted-event";
 import { integration } from "../../integration";
 import { logger } from "../../main";
 import { KickUser } from "../../shared/types";
-import { parseChatMessageEvent, parseRewardRedeemedEvent, parseStreamHostedEvent } from "./pusher-parsers";
+import { parseChatMessageEvent, parseChatMoveToSupportedChannelEvent, parseRewardRedeemedEvent, parseStreamHostedEvent } from "./pusher-parsers";
 
 const Pusher = require('pusher-js');
 
@@ -77,6 +78,9 @@ export class KickPusher {
     private async dispatchChannelEvent(event: string, data: any): Promise<void> {
         try {
             switch (event) {
+                case "App\\Events\\ChatMoveToSupportedChannelEvent":
+                    await handleRaidSentOffEvent(parseChatMoveToSupportedChannelEvent(data));
+                    break;
                 case 'pusher:subscription_succeeded':
                     logger.info("Pusher subscribed successfully to channel events.");
                     break;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -162,3 +162,9 @@ export interface KickSubscription {
     createdAt: Date,
     expiresAt: Date
 }
+
+export interface RaidSentOffEvent {
+    targetUser: KickUser
+    targetSlug: string
+    numberOfViewers: number;
+}

--- a/src/util/__tests__/getNumberFromUnknown.test.ts
+++ b/src/util/__tests__/getNumberFromUnknown.test.ts
@@ -1,0 +1,27 @@
+import { getNumberFromUnknown } from '../util';
+
+describe('getNumberFromUnknown', () => {
+    it('returns string for valid number input', () => {
+        expect(getNumberFromUnknown(42, 'default')).toBe('42');
+        expect(getNumberFromUnknown(0, 'default')).toBe('0');
+        expect(getNumberFromUnknown(-5, 'default')).toBe('-5');
+    });
+
+    it('returns string for valid numeric string input', () => {
+        expect(getNumberFromUnknown('123', 'default')).toBe('123');
+        expect(getNumberFromUnknown('0', 'default')).toBe('0');
+        expect(getNumberFromUnknown('-7', 'default')).toBe('-7');
+    });
+
+    it('returns default for NaN, non-numeric string, or undefined', () => {
+        expect(getNumberFromUnknown(NaN, 'default')).toBe('default');
+        expect(getNumberFromUnknown('abc', 'default')).toBe('default');
+        expect(getNumberFromUnknown(undefined, 'default')).toBe('default');
+        expect(getNumberFromUnknown(null, 'default')).toBe('default');
+        expect(getNumberFromUnknown({}, 'default')).toBe('default');
+    });
+
+    it('returns default for empty string', () => {
+        expect(getNumberFromUnknown('', 'default')).toBe('default');
+    });
+});

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,0 +1,12 @@
+export function getNumberFromUnknown(input: unknown, defaultValue: string): string {
+    if (typeof input === "number" && !isNaN(input)) {
+        return input.toString();
+    }
+    if (typeof input === "string") {
+        const parsed = parseInt(input, 10);
+        if (!isNaN(parsed)) {
+            return parsed.toString();
+        }
+    }
+    return defaultValue;
+}

--- a/src/variables/host-target-user-display-name.ts
+++ b/src/variables/host-target-user-display-name.ts
@@ -1,23 +1,21 @@
 import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
 import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
 
-export const hostViewerCount: ReplaceVariable = {
+export const hostTargetUserDisplayName: ReplaceVariable = {
     definition: {
-        handle: "hostViewerCount",
-        description: "Outputs the number of viewers in the Kick host or the Twitch raid.",
+        handle: "hostTargetUserDisplayName",
+        description: "Outputs the display name of the person you are hosting (or raiding).",
         triggers: {
             "manual": true,
             "event": [
-                "mage-kick-integration:raid",
                 "mage-kick-integration:raid-sent-off",
-                "twitch:raid",
                 "twitch:raid-sent-off"
             ]
         },
         categories: ["common"],
-        possibleDataOutput: ["number"]
+        possibleDataOutput: ["text"]
     },
     evaluator: (trigger: Effects.Trigger) => {
-        return trigger.metadata.eventData?.viewerCount || 0;
+        return trigger.metadata.eventData?.raidTargetUserDisplayName ?? "";
     }
 };

--- a/src/variables/host-target-user-id.ts
+++ b/src/variables/host-target-user-id.ts
@@ -1,23 +1,21 @@
 import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
 import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
 
-export const hostViewerCount: ReplaceVariable = {
+export const hostTargetUserId: ReplaceVariable = {
     definition: {
-        handle: "hostViewerCount",
-        description: "Outputs the number of viewers in the Kick host or the Twitch raid.",
+        handle: "hostTargetUserId",
+        description: "Outputs the user ID of the person you are hosting (or raiding).",
         triggers: {
             "manual": true,
             "event": [
-                "mage-kick-integration:raid",
                 "mage-kick-integration:raid-sent-off",
-                "twitch:raid",
                 "twitch:raid-sent-off"
             ]
         },
         categories: ["common"],
-        possibleDataOutput: ["number"]
+        possibleDataOutput: ["text"]
     },
     evaluator: (trigger: Effects.Trigger) => {
-        return trigger.metadata.eventData?.viewerCount || 0;
+        return trigger.metadata.eventData?.raidTargetUserId ?? "";
     }
 };

--- a/src/variables/host-target-username.ts
+++ b/src/variables/host-target-username.ts
@@ -1,23 +1,21 @@
 import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
 import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
 
-export const hostViewerCount: ReplaceVariable = {
+export const hostTargetUsername: ReplaceVariable = {
     definition: {
-        handle: "hostViewerCount",
-        description: "Outputs the number of viewers in the Kick host or the Twitch raid.",
+        handle: "hostTargetUsername",
+        description: "Outputs the username of the person you are hosting (or raiding).",
         triggers: {
             "manual": true,
             "event": [
-                "mage-kick-integration:raid",
                 "mage-kick-integration:raid-sent-off",
-                "twitch:raid",
                 "twitch:raid-sent-off"
             ]
         },
         categories: ["common"],
-        possibleDataOutput: ["number"]
+        possibleDataOutput: ["text"]
     },
     evaluator: (trigger: Effects.Trigger) => {
-        return trigger.metadata.eventData?.viewerCount || 0;
+        return trigger.metadata.eventData?.raidTargetUsername ?? "";
     }
 };


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds an event for outgoing host, which can be optionally forwarded to the "Outgoing Raid" event for Twitch in Firebot.

### Motivation
Feature addition.

### Testing
Covered by end-to-end test. Also tested this via webhook test event injection.
