### PR TITLE
Optimize webhook subscriptions

### DIFF
--- a/src/internal/__tests__/webhook-subscription-manager.reconcile.test.ts
+++ b/src/internal/__tests__/webhook-subscription-manager.reconcile.test.ts
@@ -1,0 +1,91 @@
+import { WebhookSubscriptionManager } from '../webhook-subscription-manager';
+
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+    }
+}));
+
+describe('WebhookSubscriptionManager.reconcileSubscriptions', () => {
+    let manager: WebhookSubscriptionManager;
+    let reconcile: (current: any[]) => any;
+
+    beforeEach(() => {
+        const kick = {} as any;
+        manager = new WebhookSubscriptionManager(kick);
+        reconcile = (current: any[]) => (manager as any).reconcileSubscriptions(current);
+    });
+
+    it('creates all when none exist', () => {
+        const result = reconcile([]);
+        expect(result.create.length).toBe(8);
+        expect(result.delete).toEqual([]);
+    });
+
+    it('preserves one of each, deletes extras', () => {
+        const current = [
+            { id: '1', event: 'chat.message.sent', version: 1 },
+            { id: '2', event: 'chat.message.sent', version: 1 }, // duplicate
+            { id: '3', event: 'channel.followed', version: 1 },
+            { id: '4', event: 'channel.subscription.gifts', version: 1 },
+            { id: '5', event: 'not-needed', version: 1 }
+        ];
+        const result = reconcile(current);
+        expect(result.create.length).toBe(5); // 8 total - 3 present
+        expect(result.delete).toContain('2'); // duplicate
+        expect(result.delete).toContain('5'); // not-needed
+        expect(result.create.some((e: any) => e.name === 'livestream.metadata.updated')).toBe(true);
+    });
+
+    it('deletes all if none are needed', () => {
+        const current = [
+            { id: '1', event: 'foo', version: 1 },
+            { id: '2', event: 'bar', version: 1 }
+        ];
+        const result = reconcile(current);
+        expect(result.create.length).toBe(8);
+        expect(result.delete).toEqual(['1', '2']);
+    });
+
+    it('preserves correct subscriptions, creates and deletes as needed', () => {
+        const current = [
+            { id: '1', event: 'chat.message.sent', version: 1 },
+            { id: '2', event: 'channel.followed', version: 1 },
+            { id: '3', event: 'channel.subscription.gifts', version: 1 },
+            { id: '4', event: 'extra', version: 1 }
+        ];
+        const result = reconcile(current);
+        expect(result.create.length).toBe(5); // 8 total - 3 present
+        expect(result.delete).toContain('4'); // extra
+        expect(result.create.some((e: any) => e.name === 'livestream.status.updated')).toBe(true);
+    });
+
+    it('handles empty id fields gracefully', () => {
+        const current = [
+            { id: undefined, event: 'chat.message.sent', version: 1 },
+            { id: null, event: 'channel.followed', version: 1 }
+        ];
+        const result = reconcile(current);
+        expect(result.create.length).toBe(6); // 8 total - 2 present
+        expect(result.delete).toEqual([]); // no duplicates or extras with id
+    });
+
+    it('returns no create or delete when all subscriptions are present and unique', () => {
+        const current = [
+            { id: '1', event: 'chat.message.sent', version: 1 },
+            { id: '2', event: 'channel.followed', version: 1 },
+            { id: '3', event: 'livestream.metadata.updated', version: 1 },
+            { id: '4', event: 'livestream.status.updated', version: 1 },
+            { id: '5', event: 'channel.subscription.renewal', version: 1 },
+            { id: '6', event: 'channel.subscription.gifts', version: 1 },
+            { id: '7', event: 'channel.subscription.new', version: 1 },
+            { id: '8', event: 'moderation.banned', version: 1 }
+        ];
+        const result = reconcile(current);
+        expect(result.create).toEqual([]);
+        expect(result.delete).toEqual([]);
+    });
+});

--- a/src/internal/__tests__/webhook-subscription-manager.subscribe.test.ts
+++ b/src/internal/__tests__/webhook-subscription-manager.subscribe.test.ts
@@ -1,0 +1,69 @@
+/* eslint-disable camelcase */
+import { WebhookSubscriptionManager } from '../webhook-subscription-manager';
+
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+    }
+}));
+
+describe('WebhookSubscriptionManager.subscribeToEvents', () => {
+    let manager: WebhookSubscriptionManager;
+    let kick: any;
+
+    beforeEach(() => {
+        kick = {
+            broadcaster: { userId: 42 },
+            httpCallWithTimeout: jest.fn()
+        };
+        manager = new WebhookSubscriptionManager(kick);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('creates subscriptions if needed', async () => {
+        jest.spyOn(manager as any, 'getSubscriptions').mockResolvedValue([]);
+        kick.httpCallWithTimeout.mockResolvedValue({ data: [{ subscription_id: 'sub1' }], message: 'ok' });
+        await expect(manager.subscribeToEvents()).resolves.toBeUndefined();
+        expect(kick.httpCallWithTimeout).toHaveBeenCalledWith(
+            '/public/v1/events/subscriptions',
+            'POST',
+            expect.stringContaining('chat.message.sent')
+        );
+    });
+
+    it('deletes subscriptions if needed', async () => {
+        jest.spyOn(manager as any, 'getSubscriptions').mockResolvedValue([]);
+        // Simulate a reconciliation with delete
+        jest.spyOn(manager as any, 'reconcileSubscriptions').mockReturnValue({ create: [], delete: ['sub1', 'sub2'] });
+        kick.httpCallWithTimeout.mockResolvedValue({});
+        await expect(manager.subscribeToEvents()).resolves.toBeUndefined();
+        expect(kick.httpCallWithTimeout).toHaveBeenCalledWith(
+            '/public/v1/events/subscriptions?id=sub1',
+            'DELETE'
+        );
+        expect(kick.httpCallWithTimeout).toHaveBeenCalledWith(
+            '/public/v1/events/subscriptions?id=sub2',
+            'DELETE'
+        );
+    });
+
+    it('does nothing if no create or delete needed', async () => {
+        jest.spyOn(manager as any, 'getSubscriptions').mockResolvedValue([]);
+        jest.spyOn(manager as any, 'reconcileSubscriptions').mockReturnValue({ create: [], delete: [] });
+        await expect(manager.subscribeToEvents()).resolves.toBeUndefined();
+        expect(kick.httpCallWithTimeout).not.toHaveBeenCalled();
+    });
+
+    it('logs and rejects on error', async () => {
+        jest.spyOn(manager as any, 'getSubscriptions').mockResolvedValue([]);
+        jest.spyOn(manager as any, 'reconcileSubscriptions').mockReturnValue({ create: [{ name: 'foo', version: 1 }], delete: [] });
+        kick.httpCallWithTimeout.mockRejectedValue(new Error('fail'));
+        await expect(manager.subscribeToEvents()).rejects.toThrow('fail');
+    });
+});

--- a/src/internal/__tests__/webhook-subscription-manager.unsubscribe.test.ts
+++ b/src/internal/__tests__/webhook-subscription-manager.unsubscribe.test.ts
@@ -1,0 +1,49 @@
+import { WebhookSubscriptionManager } from '../webhook-subscription-manager';
+
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+    }
+}));
+
+describe('WebhookSubscriptionManager.unsubscribeFromEvents', () => {
+    let manager: WebhookSubscriptionManager;
+    let kick: any;
+
+    beforeEach(() => {
+        kick = {
+            httpCallWithTimeout: jest.fn()
+        };
+        manager = new WebhookSubscriptionManager(kick);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('unsubscribes from all subscriptions', async () => {
+        const subs = [
+            { id: '1', event: 'foo', version: 1 },
+            { id: '2', event: 'bar', version: 1 }
+        ];
+        jest.spyOn(manager as any, 'getSubscriptions').mockResolvedValue(subs);
+        kick.httpCallWithTimeout.mockResolvedValue({});
+        await expect(manager.unsubscribeFromEvents()).resolves.toBeUndefined();
+        expect(kick.httpCallWithTimeout).toHaveBeenCalledWith(
+            '/public/v1/events/subscriptions?id=1',
+            'DELETE'
+        );
+        expect(kick.httpCallWithTimeout).toHaveBeenCalledWith(
+            '/public/v1/events/subscriptions?id=2',
+            'DELETE'
+        );
+    });
+
+    it('logs error if unsubscribe fails', async () => {
+        jest.spyOn(manager as any, 'getSubscriptions').mockRejectedValue(new Error('fail'));
+        await manager.unsubscribeFromEvents();
+    });
+});

--- a/src/internal/webhook-subscription-manager.ts
+++ b/src/internal/webhook-subscription-manager.ts
@@ -1,0 +1,228 @@
+import { IKick } from "./kick-interface";
+import { logger } from "../main";
+
+const subscriptionsToRequest = [
+    {
+        name: "chat.message.sent",
+        version: 1
+    },
+    {
+        name: "channel.followed",
+        version: 1
+    },
+    {
+        name: "livestream.metadata.updated",
+        version: 1
+    },
+    {
+        name: "livestream.status.updated",
+        version: 1
+    },
+    {
+        name: "channel.subscription.renewal",
+        version: 1
+    },
+    {
+        name: "channel.subscription.gifts",
+        version: 1
+    },
+    {
+        name: "channel.subscription.new",
+        version: 1
+    },
+    {
+        name: "moderation.banned",
+        version: 1
+    }
+];
+
+export class WebhookSubscriptionManager {
+    private kick: IKick;
+
+    constructor(kick: IKick) {
+        this.kick = kick;
+    }
+
+    async subscribeToEvents(): Promise<void> {
+        const reconciliation = this.reconcileSubscriptions(await this.getSubscriptions());
+        const promises: Promise<any>[] = [];
+
+        if (reconciliation.create.length > 0) {
+            const createPromise = new Promise((resolve, reject) => {
+                const createPayload: WebhookSubscriptionCreatePayload = {
+                    // eslint-disable-next-line camelcase
+                    broadcaster_user_id: this.kick.broadcaster?.userId || 0,
+                    events: reconciliation.create,
+                    method: "webhook"
+                };
+                this.kick.httpCallWithTimeout('/public/v1/events/subscriptions', "POST", JSON.stringify(createPayload))
+                    .then((response) => {
+                        const parsed: SubscriptionResponse = response as SubscriptionResponse;
+                        const subscriptionIds = parsed.data.map(sub => sub.subscription_id);
+                        logger.debug(`Successfully created Kick event subscriptions: ${JSON.stringify(subscriptionIds)}`);
+                        resolve(subscriptionIds);
+                    })
+                    .catch((error) => {
+                        reject(error);
+                    });
+            });
+            promises.push(createPromise);
+        }
+
+        if (reconciliation.delete.length > 0) {
+            const deletePromises = reconciliation.delete.map((subscriptionId) => {
+                const params = new URLSearchParams({ id: subscriptionId });
+                logger.debug(`Unsubscribing from event subscription with ID: ${subscriptionId}`);
+                return this.kick.httpCallWithTimeout(`/public/v1/events/subscriptions?${params.toString()}`, "DELETE");
+            });
+            promises.push(...deletePromises);
+        }
+
+        return new Promise((resolve, reject) => {
+            Promise.all(promises)
+                .then(() => {
+                    logger.info("Event subscription reconciliation complete.");
+                    resolve();
+                })
+                .catch((error) => {
+                    logger.error(`Failed to reconcile event subscriptions: ${error}`);
+                    reject(error);
+                });
+        });
+    }
+
+    async unsubscribeFromEvents(): Promise<void> {
+        try {
+            const subscriptions = await this.getSubscriptions();
+            const unsubscribePromises = subscriptions.map((subscription) => {
+                const params = new URLSearchParams({ id: subscription.id });
+                logger.debug(`Unsubscribing from event subscription with ID: ${subscription.id} (${subscription.event}:${subscription.version})`);
+                return this.kick.httpCallWithTimeout(`/public/v1/events/subscriptions?${params.toString()}`, "DELETE");
+            });
+
+            await Promise.all(unsubscribePromises);
+            logger.info("Successfully deleted existing event subscriptions.");
+        } catch (error) {
+            logger.error(`Failed to delete existing event subscriptions: ${error}`);
+        }
+    }
+
+    private async getSubscriptions(): Promise<WebhookSubscription[]> {
+        try {
+            const response = await this.kick.httpCallWithTimeout('/public/v1/events/subscriptions', "GET");
+            return response.data;
+        } catch (error) {
+            logger.error(`Failed to retrieve event subscriptions: ${error}`);
+            return [];
+        }
+    }
+
+    private reconcileSubscriptions(current: WebhookSubscription[]): WebhookSubscriptionReconcileResponse {
+        const create: WebhookSubscriptionToCreate[] = [];
+        const deleteSubs: string[] = [];
+
+        for (const subToRequest of subscriptionsToRequest) {
+            const matching = current.filter(
+                cur => cur.event === subToRequest.name && cur.version === subToRequest.version
+            );
+            if (matching.length === 0) {
+                create.push(subToRequest);
+            } else if (matching.length > 1) {
+                // Keep one, delete the rest
+                deleteSubs.push(
+                    ...matching
+                        .slice(1)
+                        .map(sub => sub.id)
+                        .filter((id): id is string => typeof id === "string" && !!id)
+                );
+            }
+        }
+
+        for (const cur of current) {
+            const found = subscriptionsToRequest.some(
+                req => req.name === cur.event && req.version === cur.version
+            );
+            if (!found && cur.id) {
+                deleteSubs.push(cur.id);
+            }
+        }
+
+        if (create.length > 0) {
+            logger.debug(
+                `Subscriptions to create: ${create
+                    .map(sub => `${sub.name} (v${sub.version})`)
+                    .join(", ")}`
+            );
+        } else {
+            logger.debug("No subscriptions to create.");
+        }
+
+        if (deleteSubs.length > 0) {
+            logger.debug(
+                `Subscriptions to delete: ${current
+                    .filter(sub => deleteSubs.includes(sub.id ?? ""))
+                    .map(sub => `${sub.id ?? "unknown-id"}: ${sub.event} (v${sub.version})`)
+                    .join(", ")}`
+            );
+        } else {
+            logger.debug("No subscriptions to delete.");
+        }
+
+        const preserved = current.filter(cur =>
+            !deleteSubs.includes(cur.id ?? "") &&
+            subscriptionsToRequest.some(req => req.name === cur.event && req.version === cur.version)
+        );
+
+        if (preserved.length > 0) {
+            logger.debug(
+                `Subscriptions preserved: ${preserved
+                    .map(sub => `${sub.id ?? "unknown-id"}: ${sub.event} (v${sub.version})`)
+                    .join(", ")}`
+            );
+        } else {
+            logger.debug("No subscriptions preserved.");
+        }
+
+        return { create, delete: deleteSubs };
+    }
+}
+
+
+interface WebhookSubscription {
+    app_id: string,
+    broadcaster_user_id: string,
+    created_at: string,
+    event: string,
+    id: string,
+    method: string,
+    updated_at: string,
+    version: number
+}
+
+interface WebhookSubscriptionCreatePayload {
+    broadcaster_user_id: number,
+    events: WebhookSubscriptionToCreate[],
+    method: string
+}
+
+interface WebhookSubscriptionToCreate {
+    name: string,
+    version: number
+}
+
+interface WebhookSubscriptionReconcileResponse {
+    create: WebhookSubscriptionToCreate[],
+    delete: string[]
+}
+
+interface SubscriptionRecord {
+    error: string;
+    name: string;
+    subscription_id: string;
+    version: number;
+}
+
+interface SubscriptionResponse {
+    data: SubscriptionRecord[];
+    message: string;
+}


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This will reuse webhook subscriptions if they're still active instead of deleting and recreating them all the time. This saves a few seconds at startup and should be more friendly with rate limits on the Kick side.

### Motivation
<!-- Please describe WHY you are making this change. This may include links to GitHub issues if relevant. -->

### Testing
Unit tests for the new code and made sure it works upon Firebot restart (preserving subscriptions) and connect/disconnect (deletes and creates subscriptions).
