### PR TITLE
Auto reconnect on Pusher error

### DIFF
--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -39,7 +39,6 @@ export class KickPusher {
 
         this.pusher.connection.bind('error', (err: any) => {
             logger.error(`Pusher error: ${JSON.stringify(err)}`);
-            this.disconnect();
         });
 
         if (chatroomId) {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This removes the disconnect if Pusher hits an error. That disconnects thing and breaks remaining Pusher events until the rest of the integration reconnects. The pusher JS client that we're using has retries built in.

### Motivation
Let Pusher reconnect if it disconnects for some reason.

### Testing
Mostly reading through the Pusher JS code to confirm it has reconnect built in. I did use `tcpkill` to reset a connection to Pusher and saw it reconnect as well.
