### PR TITLE
Banned and timeout support for Pusher

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ This [Firebot](https://firebot.app) integration provides chat feed integration, 
 | Sub (Community Gifted) | :white_check_mark: | ? | Not yet evaluated for use without webhook proxy |
 | Sub (Gifted) | :white_check_mark: | ? | Not yet evaluated for use without webhook proxy |
 | Viewer arrived | :white_check_mark: | :white_check_mark: &#42; |  |
-| Viewer banned | :white_check_mark: | Planned | |
-| Viewer timed out | :white_check_mark: | Planned | |
+| Viewer banned | :white_check_mark: | :white_check_mark: &#42; | |
+| Viewer timed out | :white_check_mark: | :white_check_mark: &#42; | |
 | Viewer unbanned | :white_check_mark: &#42; | :white_check_mark: &#42; | Also handles un-timeout |
 
 &#42; = Depends on undocumented "Pusher" functionality

--- a/src/__tests__/moderation.test.ts
+++ b/src/__tests__/moderation.test.ts
@@ -2,7 +2,7 @@ export const triggerEventMock = jest.fn();
 
 jest.mock('../integration', () => ({
     integration: {
-        getSettings: () => null
+        getSettings: jest.fn()
     }
 }));
 
@@ -11,6 +11,9 @@ jest.mock('../main', () => ({
         modules: {
             eventManager: {
                 triggerEvent: triggerEventMock
+            },
+            frontendCommunicator: {
+                send: jest.fn()
             }
         }
     },
@@ -24,6 +27,7 @@ jest.mock('../main', () => ({
 
 import { IntegrationConstants } from '../constants';
 import { KickPusher } from '../internal/pusher/pusher';
+import { handleWebhook } from '../internal/webhook-handler/webhook-handler';
 
 describe('e2e moderation unbanned', () => {
     let pusher: KickPusher;
@@ -109,6 +113,373 @@ describe('e2e moderation unbanned', () => {
                 await expect((pusher as any).dispatchChatroomEvent(event, payloadPermanent)).resolves.not.toThrow();
                 expect(triggerEventMock).toHaveBeenCalledTimes(1);
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "unbanned", expectedMetadataPermanent);
+            });
+        });
+    });
+});
+
+describe('e2e moderation banned', () => {
+    let pusher: KickPusher;
+
+    beforeEach(() => {
+        pusher = new KickPusher();
+        jest.clearAllMocks();
+    });
+
+    // Pusher timeout payload - temporary ban with expiration
+    const pusherTimeoutPayload = JSON.parse(`{"id":"0207bd89-e15c-4bf9-ba1e-129f937639a7","user":{"id":23498234,"username":"timeoutuser","slug":"timeoutuser"},"banned_by":{"id":0,"username":"TheStaticMage","slug":"thestaticmage"},"permanent":false,"duration":5,"expires_at":"2025-09-01T18:16:58+00:00"}`);
+    const pusherTimeoutEvent = 'App\\Events\\UserBannedEvent';
+
+    // Different payload for disabled test to avoid cache conflicts
+    const pusherTimeoutPayloadDisabled = JSON.parse(`{"id":"0207bd89-e15c-4bf9-ba1e-129f937639a8","user":{"id":23498235,"username":"timeoutuser2","slug":"timeoutuser2"},"banned_by":{"id":0,"username":"TheStaticMage","slug":"thestaticmage"},"permanent":false,"duration":5,"expires_at":"2025-09-01T18:16:58+00:00"}`);
+
+    // Pusher permanent ban payload - permanent ban with no expiration
+    const pusherBanPayload = JSON.parse(`{"id":"517e2dcb-7637-4482-af68-1bfba32ba2a7","user":{"id":23498234,"username":"timeoutuser","slug":"timeoutuser"},"banned_by":{"id":0,"username":"TheStaticMage","slug":"thestaticmage"},"permanent":true}`);
+    const pusherBanEvent = 'App\\Events\\UserBannedEvent';
+
+    // Different payload for disabled test to avoid cache conflicts
+    const pusherBanPayloadDisabled = JSON.parse(`{"id":"517e2dcb-7637-4482-af68-1bfba32ba2a8","user":{"id":23498236,"username":"timeoutuser3","slug":"timeoutuser3"},"banned_by":{"id":0,"username":"TheStaticMage","slug":"thestaticmage"},"permanent":true}`);
+
+    // Webhook timeout payload - base64 encoded JSON
+    const webhookTimeoutData = Buffer.from(JSON.stringify({
+        "broadcaster": { "user_id": 2346570, "username": "thestaticmage", "is_verified": false, "profile_picture": "pic.jpg", "channel_slug": "thestaticmage" },
+        "moderator": { "user_id": 2408714, "username": "TheStaticMage", "is_verified": false, "profile_picture": "mod_pic.jpg", "channel_slug": "thestaticmage" },
+        "banned_user": { "user_id": 23498234, "username": "timeoutuser", "is_verified": false, "profile_picture": "user_pic.jpg", "channel_slug": "timeoutuser" },
+        "metadata": { "reason": "Timeout reason", "created_at": "2025-09-01T18:11:58+00:00", "expires_at": "2025-09-01T18:16:58+00:00" }
+    })).toString('base64');
+
+    /* eslint-disable camelcase */
+    const webhookTimeoutPayload: InboundWebhook = {
+        kick_event_message_id: "msg-123",
+        kick_event_subscription_id: "sub-456",
+        kick_event_message_timestamp: "1693589518",
+        kick_event_type: "moderation.banned",
+        kick_event_version: "1",
+        is_test_event: false,
+        raw_data: webhookTimeoutData
+    };
+    /* eslint-enable camelcase */
+
+    // Webhook timeout payload for disabled test - different user to avoid cache conflicts
+    const webhookTimeoutDataDisabled = Buffer.from(JSON.stringify({
+        "broadcaster": { "user_id": 2346570, "username": "thestaticmage", "is_verified": false, "profile_picture": "pic.jpg", "channel_slug": "thestaticmage" },
+        "moderator": { "user_id": 2408714, "username": "TheStaticMage", "is_verified": false, "profile_picture": "mod_pic.jpg", "channel_slug": "thestaticmage" },
+        "banned_user": { "user_id": 23498237, "username": "timeoutuser4", "is_verified": false, "profile_picture": "user_pic.jpg", "channel_slug": "timeoutuser4" },
+        "metadata": { "reason": "Timeout reason disabled", "created_at": "2025-09-01T18:11:58+00:00", "expires_at": "2025-09-01T18:16:58+00:00" }
+    })).toString('base64');
+
+    /* eslint-disable camelcase */
+    const webhookTimeoutPayloadDisabled: InboundWebhook = {
+        kick_event_message_id: "msg-123-disabled",
+        kick_event_subscription_id: "sub-456-disabled",
+        kick_event_message_timestamp: "1693589519",
+        kick_event_type: "moderation.banned",
+        kick_event_version: "1",
+        is_test_event: false,
+        raw_data: webhookTimeoutDataDisabled
+    };
+    /* eslint-enable camelcase */
+
+    // Webhook permanent ban payload - base64 encoded JSON
+    const webhookBanData = Buffer.from(JSON.stringify({
+        "broadcaster": { "user_id": 2346570, "username": "thestaticmage", "is_verified": false, "profile_picture": "pic.jpg", "channel_slug": "thestaticmage" },
+        "moderator": { "user_id": 2408714, "username": "TheStaticMage", "is_verified": false, "profile_picture": "mod_pic.jpg", "channel_slug": "thestaticmage" },
+        "banned_user": { "user_id": 23498234, "username": "timeoutuser", "is_verified": false, "profile_picture": "user_pic.jpg", "channel_slug": "timeoutuser" },
+        "metadata": { "reason": "Ban reason", "created_at": "2025-09-01T18:11:58+00:00" }
+    })).toString('base64');
+
+    /* eslint-disable camelcase */
+    const webhookBanPayload: InboundWebhook = {
+        kick_event_message_id: "msg-789",
+        kick_event_subscription_id: "sub-101",
+        kick_event_message_timestamp: "1693589518",
+        kick_event_type: "moderation.banned",
+        kick_event_version: "1",
+        is_test_event: false,
+        raw_data: webhookBanData
+    };
+    /* eslint-enable camelcase */
+
+    // Webhook permanent ban payload for disabled test - different user to avoid cache conflicts
+    const webhookBanDataDisabled = Buffer.from(JSON.stringify({
+        "broadcaster": { "user_id": 2346570, "username": "thestaticmage", "is_verified": false, "profile_picture": "pic.jpg", "channel_slug": "thestaticmage" },
+        "moderator": { "user_id": 2408714, "username": "TheStaticMage", "is_verified": false, "profile_picture": "mod_pic.jpg", "channel_slug": "thestaticmage" },
+        "banned_user": { "user_id": 23498238, "username": "timeoutuser5", "is_verified": false, "profile_picture": "user_pic.jpg", "channel_slug": "timeoutuser5" },
+        "metadata": { "reason": "Ban reason disabled", "created_at": "2025-09-01T18:11:58+00:00" }
+    })).toString('base64');
+
+    /* eslint-disable camelcase */
+    const webhookBanPayloadDisabled: InboundWebhook = {
+        kick_event_message_id: "msg-789-disabled",
+        kick_event_subscription_id: "sub-101-disabled",
+        kick_event_message_timestamp: "1693589519",
+        kick_event_type: "moderation.banned",
+        kick_event_version: "1",
+        is_test_event: false,
+        raw_data: webhookBanDataDisabled
+    };
+    /* eslint-enable camelcase */
+
+    describe('timeout via pusher', () => {
+        const expectedTimeoutMetadata = {
+            username: 'timeoutuser@kick',
+            userId: 'k23498234',
+            userDisplayName: 'timeoutuser',
+            moderatorUsername: 'TheStaticMage@kick',
+            moderatorId: 'k0',
+            moderatorDisplayName: 'TheStaticMage',
+            modReason: 'No reason provided',
+            moderator: 'TheStaticMage',
+            timeoutDuration: expect.any(Number),
+            platform: 'kick'
+        };
+
+        describe('twitch forwarding enabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        viewerBanned: false,
+                        viewerTimeout: true
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers all expected events', async () => {
+                await expect((pusher as any).dispatchChatroomEvent(pusherTimeoutEvent, pusherTimeoutPayload)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "timeout", expectedTimeoutMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "timeout", expectedTimeoutMetadata);
+            });
+        });
+
+        describe('twitch forwarding disabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        viewerBanned: false,
+                        viewerTimeout: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers integration event only', async () => {
+                const expectedTimeoutMetadataDisabled = {
+                    username: 'timeoutuser2@kick',
+                    userId: 'k23498235',
+                    userDisplayName: 'timeoutuser2',
+                    moderatorUsername: 'TheStaticMage@kick',
+                    moderatorId: 'k0',
+                    moderatorDisplayName: 'TheStaticMage',
+                    modReason: 'No reason provided',
+                    moderator: 'TheStaticMage',
+                    timeoutDuration: expect.any(Number),
+                    platform: 'kick'
+                };
+                await expect((pusher as any).dispatchChatroomEvent(pusherTimeoutEvent, pusherTimeoutPayloadDisabled)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(1);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "timeout", expectedTimeoutMetadataDisabled);
+            });
+        });
+    });
+
+    describe('permanent ban via pusher', () => {
+        const expectedBanMetadata = {
+            username: 'timeoutuser@kick',
+            userId: 'k23498234',
+            userDisplayName: 'timeoutuser',
+            moderatorUsername: 'TheStaticMage@kick',
+            moderatorId: 'k0',
+            moderatorDisplayName: 'TheStaticMage',
+            modReason: 'No reason provided',
+            moderator: 'TheStaticMage',
+            timeoutDuration: undefined,
+            platform: 'kick'
+        };
+
+        describe('twitch forwarding enabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        viewerBanned: true,
+                        viewerTimeout: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers all expected events', async () => {
+                await expect((pusher as any).dispatchChatroomEvent(pusherBanEvent, pusherBanPayload)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "banned", expectedBanMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "banned", expectedBanMetadata);
+            });
+        });
+
+        describe('twitch forwarding disabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        viewerBanned: false,
+                        viewerTimeout: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers integration event only', async () => {
+                const expectedBanMetadataDisabled = {
+                    username: 'timeoutuser3@kick',
+                    userId: 'k23498236',
+                    userDisplayName: 'timeoutuser3',
+                    moderatorUsername: 'TheStaticMage@kick',
+                    moderatorId: 'k0',
+                    moderatorDisplayName: 'TheStaticMage',
+                    modReason: 'No reason provided',
+                    moderator: 'TheStaticMage',
+                    timeoutDuration: undefined,
+                    platform: 'kick'
+                };
+                await expect((pusher as any).dispatchChatroomEvent(pusherBanEvent, pusherBanPayloadDisabled)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(1);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "banned", expectedBanMetadataDisabled);
+            });
+        });
+    });
+
+    describe('timeout via webhook', () => {
+        const expectedWebhookTimeoutMetadata = {
+            username: 'timeoutuser@kick',
+            userId: 'k23498234',
+            userDisplayName: 'timeoutuser',
+            moderatorUsername: 'TheStaticMage@kick',
+            moderatorId: 'k2408714',
+            moderatorDisplayName: 'TheStaticMage',
+            modReason: 'Timeout reason',
+            moderator: 'TheStaticMage',
+            timeoutDuration: expect.any(Number),
+            platform: 'kick'
+        };
+
+        describe('twitch forwarding enabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        viewerBanned: false,
+                        viewerTimeout: true
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers all expected events', async () => {
+                await expect(handleWebhook(webhookTimeoutPayload)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "timeout", expectedWebhookTimeoutMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "timeout", expectedWebhookTimeoutMetadata);
+            });
+        });
+
+        describe('twitch forwarding disabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        viewerBanned: false,
+                        viewerTimeout: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers integration event only', async () => {
+                const expectedWebhookTimeoutMetadataDisabled = {
+                    username: 'timeoutuser4@kick',
+                    userId: 'k23498237',
+                    userDisplayName: 'timeoutuser4',
+                    moderatorUsername: 'TheStaticMage@kick',
+                    moderatorId: 'k2408714',
+                    moderatorDisplayName: 'TheStaticMage',
+                    modReason: 'Timeout reason disabled',
+                    moderator: 'TheStaticMage',
+                    timeoutDuration: expect.any(Number),
+                    platform: 'kick'
+                };
+                await expect(handleWebhook(webhookTimeoutPayloadDisabled)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(1);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "timeout", expectedWebhookTimeoutMetadataDisabled);
+            });
+        });
+    });
+
+    describe('permanent ban via webhook', () => {
+        const expectedWebhookBanMetadata = {
+            username: 'timeoutuser@kick',
+            userId: 'k23498234',
+            userDisplayName: 'timeoutuser',
+            moderatorUsername: 'TheStaticMage@kick',
+            moderatorId: 'k2408714',
+            moderatorDisplayName: 'TheStaticMage',
+            modReason: 'Ban reason',
+            moderator: 'TheStaticMage',
+            timeoutDuration: undefined,
+            platform: 'kick'
+        };
+
+        describe('twitch forwarding enabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        viewerBanned: true,
+                        viewerTimeout: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers all expected events', async () => {
+                await expect(handleWebhook(webhookBanPayload)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "banned", expectedWebhookBanMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "banned", expectedWebhookBanMetadata);
+            });
+        });
+
+        describe('twitch forwarding disabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        viewerBanned: false,
+                        viewerTimeout: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers integration event only', async () => {
+                const expectedWebhookBanMetadataDisabled = {
+                    username: 'timeoutuser5@kick',
+                    userId: 'k23498238',
+                    userDisplayName: 'timeoutuser5',
+                    moderatorUsername: 'TheStaticMage@kick',
+                    moderatorId: 'k2408714',
+                    moderatorDisplayName: 'TheStaticMage',
+                    modReason: 'Ban reason disabled',
+                    moderator: 'TheStaticMage',
+                    timeoutDuration: undefined,
+                    platform: 'kick'
+                };
+                await expect(handleWebhook(webhookBanPayloadDisabled)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(1);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "banned", expectedWebhookBanMetadataDisabled);
             });
         });
     });

--- a/src/events/moderation-banned.ts
+++ b/src/events/moderation-banned.ts
@@ -1,33 +1,63 @@
 import { IntegrationConstants } from "../constants";
 import { integration } from "../integration";
 import { kickifyUserId, kickifyUsername, unkickifyUsername } from "../internal/util";
-import { firebot } from "../main";
+import { firebot, logger } from "../main";
 import { ModerationBannedEvent } from "../shared/types";
+import NodeCache from "node-cache";
 
-export async function handleModerationBannedEvent(payload: ModerationBannedEvent): Promise<void> {
+export class ModerationBannedEventHandler {
+    private banTimeoutCache = new NodeCache({ stdTTL: 5 * 60 });
+
+    public async handleModerationBannedEvent(payload: ModerationBannedEvent): Promise<void> {
     // This event is triggered for bans and timeouts. The difference is that a
     // ban has no expiration time.
-    const { frontendCommunicator } = firebot.modules;
-    frontendCommunicator.send("twitch:chat:user:delete-messages", kickifyUsername(payload.bannedUser.username));
+        const eventName = payload.metadata.expiresAt ? "timeout" : "banned";
+        const metadata = {
+            username: kickifyUsername(payload.bannedUser.username),
+            userId: kickifyUserId(payload.bannedUser.userId.toString()),
+            userDisplayName: unkickifyUsername(payload.bannedUser.username),
+            moderatorUsername: kickifyUsername(payload.moderator.username),
+            moderatorId: kickifyUserId(payload.moderator.userId.toString()),
+            moderatorDisplayName: unkickifyUsername(payload.moderator.username),
+            modReason: payload.metadata.reason || "",
+            moderator: unkickifyUsername(payload.moderator.username),
+            timeoutDuration: payload.metadata.expiresAt ? Math.floor((payload.metadata.expiresAt.getTime() - Date.now()) / 1000) : undefined, // Convert to seconds
+            platform: "kick"
+        };
 
-    const eventName = payload.metadata.expiresAt ? "timeout" : "banned";
-    const metadata = {
-        username: kickifyUsername(payload.bannedUser.username),
-        userId: kickifyUserId(payload.bannedUser.userId.toString()),
-        userDisplayName: unkickifyUsername(payload.bannedUser.username),
-        moderatorUsername: kickifyUsername(payload.moderator.username),
-        moderatorId: kickifyUserId(payload.moderator.userId.toString()),
-        moderatorDisplayName: unkickifyUsername(payload.moderator.username),
-        modReason: payload.metadata.reason || "",
-        moderator: unkickifyUsername(payload.moderator.username),
-        timeoutDuration: payload.metadata.expiresAt ? Math.floor((payload.metadata.expiresAt.getTime() - Date.now()) / 1000) : undefined, // Convert to seconds
-        platform: "kick"
-    };
+        // Since this is reported by pusher and webhook, avoid processing duplicates
+        // for a while. (Set to 5 minutes to accommodate webhook delays, balanced
+        // with reasonableness.) Create metadata for key computation using expiresAt
+        // instead of timeoutDuration and removing the moderatorId which is not
+        // correctly reported in the Pusher payload.
+        const crypto = await import("crypto");
+        const metadataForKey = {
+            ...metadata,
+            expiresAt: payload.metadata.expiresAt ? payload.metadata.expiresAt.toISOString() : undefined,
+            timeoutDuration: undefined, // Remove timeoutDuration from key computation
+            moderatorId: "" // Remove moderatorId from key computation
+        };
+        delete metadataForKey.timeoutDuration;
 
-    const { eventManager } = firebot.modules;
-    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, eventName, metadata);
+        const metadataKey = `${eventName}|${crypto.createHash("sha256").update(JSON.stringify(metadataForKey)).digest("hex")}`;
+        if (this.banTimeoutCache.has(metadataKey)) {
+            logger.debug(`Duplicate ${eventName} event detected (username=${metadata.username}), ignoring.`);
+            return; // Duplicate event detected, ignore
+        }
+        this.banTimeoutCache.set(metadataKey, true);
 
-    if ((eventName === "timeout" && integration.getSettings().triggerTwitchEvents.viewerTimeout) || (eventName === "banned" && integration.getSettings().triggerTwitchEvents.viewerBanned)) {
-        eventManager.triggerEvent("twitch", eventName, metadata);
+        // Clear messages posted by the banned user from the chat feed.
+        const { frontendCommunicator } = firebot.modules;
+        frontendCommunicator.send("twitch:chat:user:delete-messages", kickifyUsername(payload.bannedUser.username));
+
+        // Actually send the event.
+        const { eventManager } = firebot.modules;
+        eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, eventName, metadata);
+
+        if ((eventName === "timeout" && integration.getSettings().triggerTwitchEvents.viewerTimeout) || (eventName === "banned" && integration.getSettings().triggerTwitchEvents.viewerBanned)) {
+            eventManager.triggerEvent("twitch", eventName, metadata);
+        }
     }
 }
+
+export const moderationBannedEventHandler = new ModerationBannedEventHandler();

--- a/src/internal/pusher/banned.d.ts
+++ b/src/internal/pusher/banned.d.ts
@@ -1,0 +1,16 @@
+interface ViewerBannedEventData {
+    id: string;
+    user: {
+        id: number;
+        username: string;
+        slug: string;
+    };
+    banned_by: {
+        id: number;
+        username: string;
+        slug: string;
+    };
+    permanent: boolean;
+    duration?: number; // Set for timeout events, unset for permanent bans
+    expires_at?: string; // Set for timeout events, unset for permanent bans
+}

--- a/src/internal/pusher/pusher-parsers.ts
+++ b/src/internal/pusher/pusher-parsers.ts
@@ -1,4 +1,4 @@
-import { ChatMessage, KickUser, ModerationUnbannedEvent, RaidSentOffEvent, RewardRedeemedEvent, StreamHostedEvent } from "../../shared/types";
+import { ChatMessage, KickUser, ModerationBannedEvent, ModerationUnbannedEvent, RaidSentOffEvent, RewardRedeemedEvent, StreamHostedEvent } from "../../shared/types";
 import { kickifyUserId, kickifyUsername, parseDate, unkickifyUsername } from "../util";
 
 export function parseChatMessageEvent(data: any, broadcaster: KickUser): ChatMessage {
@@ -104,5 +104,32 @@ export function parseViewerUnbannedEvent(data: any): ModerationUnbannedEvent {
             channelSlug: '' // Not provided in event
         },
         banType: d.permanent ? "permanent" : "timeout"
+    };
+}
+
+export function parseViewerBannedOrTimedOutEvent(data: any): ModerationBannedEvent {
+    const d = data as ViewerBannedEventData;
+    return {
+        bannedUser: {
+            userId: kickifyUserId(d.user.id.toString()),
+            username: kickifyUsername(d.user.username),
+            displayName: unkickifyUsername(d.user.username),
+            profilePicture: '', // Not provided in event
+            isVerified: false, // Not provided in event
+            channelSlug: d.user.slug
+        },
+        moderator: {
+            userId: kickifyUserId(d.banned_by.id.toString()),
+            username: kickifyUsername(d.banned_by.username),
+            displayName: unkickifyUsername(d.banned_by.username),
+            profilePicture: '', // Not provided in event
+            isVerified: false, // Not provided in event
+            channelSlug: d.banned_by.slug
+        },
+        metadata: {
+            reason: 'No reason provided', // Not provided in event
+            createdAt: new Date(),
+            expiresAt: parseDate(d.expires_at) || undefined
+        }
     };
 }

--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -1,4 +1,5 @@
 import { handleChatMessageSentEvent } from "../../events/chat-message-sent";
+import { moderationBannedEventHandler } from "../../events/moderation-banned";
 import { handleModerationUnbannedEvent } from "../../events/moderation-unbanned";
 import { handleRaidSentOffEvent } from "../../events/raid-sent-off-event";
 import { handleRewardRedeemedEvent } from "../../events/reward-redeemed-event";
@@ -6,7 +7,7 @@ import { handleStreamHostedEvent } from "../../events/stream-hosted-event";
 import { integration } from "../../integration";
 import { logger } from "../../main";
 import { KickUser } from "../../shared/types";
-import { parseChatMessageEvent, parseChatMoveToSupportedChannelEvent, parseRewardRedeemedEvent, parseStreamHostedEvent, parseViewerUnbannedEvent } from "./pusher-parsers";
+import { parseChatMessageEvent, parseChatMoveToSupportedChannelEvent, parseRewardRedeemedEvent, parseStreamHostedEvent, parseViewerBannedOrTimedOutEvent, parseViewerUnbannedEvent } from "./pusher-parsers";
 
 const Pusher = require('pusher-js');
 
@@ -101,6 +102,9 @@ export class KickPusher {
                     break;
                 case 'App\\Events\\StreamHostedEvent':
                     await handleStreamHostedEvent(parseStreamHostedEvent(data));
+                    break;
+                case 'App\\Events\\UserBannedEvent':
+                    await moderationBannedEventHandler.handleModerationBannedEvent(parseViewerBannedOrTimedOutEvent(data));
                     break;
                 case 'App\\Events\\UserUnbannedEvent':
                     await handleModerationUnbannedEvent(parseViewerUnbannedEvent(data));

--- a/src/internal/webhook-handler/webhook-handler.ts
+++ b/src/internal/webhook-handler/webhook-handler.ts
@@ -2,7 +2,7 @@ import { handleChatMessageSentEvent } from "../../events/chat-message-sent";
 import { handleFollowerEvent } from "../../events/follower";
 import { handleLivestreamMetadataUpdatedEvent } from "../../events/livestream-metadata-updated";
 import { handleLivestreamStatusUpdatedEvent } from "../../events/livestream-status-updated";
-import { handleModerationBannedEvent } from "../../events/moderation-banned";
+import { moderationBannedEventHandler } from "../../events/moderation-banned";
 import { handleChannelSubscriptionEvent, handleChannelSubscriptionGiftsEvent } from "../../events/sub-events";
 import { integration } from "../../integration";
 import { logger } from "../../main";
@@ -89,7 +89,7 @@ export async function handleWebhook(webhook: InboundWebhook): Promise<void> {
         }
         case "moderation.banned": {
             const event = parseModerationBannedEvent(webhook.raw_data);
-            handleModerationBannedEvent(event);
+            moderationBannedEventHandler.handleModerationBannedEvent(event);
             break;
         }
         default: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -108,7 +108,7 @@ export interface ModerationBannedMetadata {
 }
 
 export interface ModerationBannedEvent {
-    broadcaster: KickUser;
+    broadcaster?: KickUser;
     moderator: KickUser;
     bannedUser: KickUser;
     metadata: ModerationBannedMetadata;


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Supports receiving banned / timed out events via Pusher in addition to web hooks.

### Motivation
This will allow ban/timeout events to work for people not using a webhook proxy. Also, when Kick webhooks are not working correctly for any reason, this also lets events be triggered for proxy users via Pusher too.

### Testing
Tested with actual events and handlers and observed logs. Also lots of tests were added.
