### PR TITLE
Add stream online / stream offline pusher event

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ This [Firebot](https://firebot.app) integration provides chat feed integration, 
 | Host (raid) (outgoing) | :white_check_mark: &#42; | :white_check_mark: &#42; | |
 | Message deleted | Planned | Planned | |
 | Stream category (game) updated | :white_check_mark: | ? | Not yet evaluated for use without webhook proxy |
-| Stream ended | :white_check_mark: | Planned |  |
-| Stream started | :white_check_mark: | Planned |  |
+| Stream ended | :white_check_mark: | :white_check_mark: &#42; |  |
+| Stream started | :white_check_mark: | :white_check_mark: &#42; |  |
 | Stream title updated | :white_check_mark: | ? | Not yet evaluated for use without webhook proxy |
 | Sub | :white_check_mark: | Planned | |
 | Sub (Community Gifted) | :white_check_mark: | ? | Not yet evaluated for use without webhook proxy |

--- a/src/__tests__/livestream-status-updated.ts
+++ b/src/__tests__/livestream-status-updated.ts
@@ -1,0 +1,439 @@
+export const triggerEventMock = jest.fn();
+
+jest.mock('../integration', () => ({
+    integration: {
+        getSettings: jest.fn(),
+        kick: {
+            channelManager: {
+                updateLiveStatus: jest.fn()
+            },
+            broadcaster: {
+                userId: "123456",
+                name: "teststreamer",
+                profilePicture: "https://example.com/avatar.jpg"
+            }
+        }
+    }
+}));
+
+jest.mock('../main', () => ({
+    firebot: {
+        modules: {
+            eventManager: {
+                triggerEvent: triggerEventMock
+            },
+            frontendCommunicator: {
+                send: jest.fn()
+            }
+        }
+    },
+    logger: {
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn()
+    }
+}));
+
+import { IntegrationConstants } from '../constants';
+import { KickPusher } from '../internal/pusher/pusher';
+import { handleWebhook } from '../internal/webhook-handler/webhook-handler';
+
+describe('e2e livestream status updated', () => {
+    let pusher: KickPusher;
+
+    beforeEach(() => {
+        pusher = new KickPusher();
+        jest.clearAllMocks();
+
+        // Set default integration settings
+        const integration = require('../integration').integration;
+        integration.kick.channelManager.updateLiveStatus.mockReturnValue(true);
+        integration.getSettings = () => ({
+            triggerTwitchEvents: {
+                streamOnline: true,
+                streamOffline: true
+            },
+            logging: { logWebhooks: false }
+        });
+    });
+
+    // Pusher stream start payload (StreamerIsLiveEvent)
+    /* eslint-disable camelcase */
+    const pusherStreamStartPayload = {
+        livestream: {
+            session_title: "Testing Stream Title",
+            created_at: "2025-09-02T10:00:00+00:00"
+        }
+    };
+    /* eslint-enable camelcase */
+    const pusherStreamStartEvent = 'App\\Events\\StreamerIsLiveEvent';
+
+    // Different payload for disabled test to avoid any potential conflicts
+    /* eslint-disable camelcase */
+    const pusherStreamStartPayloadDisabled = {
+        livestream: {
+            session_title: "Testing Stream Title Disabled",
+            created_at: "2025-09-02T10:01:00+00:00"
+        }
+    };
+    /* eslint-enable camelcase */
+
+    // Pusher stream stop payload (StopStreamBroadcast) - no data payload
+    const pusherStreamStopEvent = 'App\\Events\\StopStreamBroadcast';
+
+    // Webhook stream start payload - base64 encoded JSON
+    const webhookStreamStartData = Buffer.from(JSON.stringify({
+        "eventType": "livestream.status.updated",
+        "eventVersion": "1",
+        "broadcaster": {
+            "user_id": 123456,
+            "username": "teststreamer",
+            "is_verified": false,
+            "profile_picture": "https://example.com/avatar.jpg",
+            "channel_slug": "teststreamer"
+        },
+        "is_live": true,
+        "title": "Live Stream from Webhook",
+        "started_at": "2025-09-02T10:05:00+00:00",
+        "ended_at": null
+    })).toString('base64');
+
+    /* eslint-disable camelcase */
+    const webhookStreamStartPayload: InboundWebhook = {
+        kick_event_message_id: "msg-stream-start-123",
+        kick_event_subscription_id: "sub-livestream-456",
+        kick_event_message_timestamp: "1693589518",
+        kick_event_type: "livestream.status.updated",
+        kick_event_version: "1",
+        is_test_event: false,
+        raw_data: webhookStreamStartData
+    };
+    /* eslint-enable camelcase */
+
+    // Webhook stream start payload for disabled test - different content to avoid conflicts
+    const webhookStreamStartDataDisabled = Buffer.from(JSON.stringify({
+        "eventType": "livestream.status.updated",
+        "eventVersion": "1",
+        "broadcaster": {
+            "user_id": 123457,
+            "username": "teststreamer2",
+            "is_verified": false,
+            "profile_picture": "https://example.com/avatar2.jpg",
+            "channel_slug": "teststreamer2"
+        },
+        "is_live": true,
+        "title": "Live Stream from Webhook Disabled",
+        "started_at": "2025-09-02T10:06:00+00:00",
+        "ended_at": null
+    })).toString('base64');
+
+    /* eslint-disable camelcase */
+    const webhookStreamStartPayloadDisabled: InboundWebhook = {
+        kick_event_message_id: "msg-stream-start-disabled-123",
+        kick_event_subscription_id: "sub-livestream-disabled-456",
+        kick_event_message_timestamp: "1693589519",
+        kick_event_type: "livestream.status.updated",
+        kick_event_version: "1",
+        is_test_event: false,
+        raw_data: webhookStreamStartDataDisabled
+    };
+    /* eslint-enable camelcase */
+
+    // Webhook stream stop payload - base64 encoded JSON
+    const webhookStreamStopData = Buffer.from(JSON.stringify({
+        "eventType": "livestream.status.updated",
+        "eventVersion": "1",
+        "broadcaster": {
+            "user_id": 123456,
+            "username": "teststreamer",
+            "is_verified": false,
+            "profile_picture": "https://example.com/avatar.jpg",
+            "channel_slug": "teststreamer"
+        },
+        "is_live": false,
+        "title": "Stream Ended",
+        "started_at": "2025-09-02T10:05:00+00:00",
+        "ended_at": "2025-09-02T12:05:00+00:00"
+    })).toString('base64');
+
+    /* eslint-disable camelcase */
+    const webhookStreamStopPayload: InboundWebhook = {
+        kick_event_message_id: "msg-stream-stop-789",
+        kick_event_subscription_id: "sub-livestream-101",
+        kick_event_message_timestamp: "1693589518",
+        kick_event_type: "livestream.status.updated",
+        kick_event_version: "1",
+        is_test_event: false,
+        raw_data: webhookStreamStopData
+    };
+    /* eslint-enable camelcase */
+
+    // Webhook stream stop payload for disabled test - different content to avoid conflicts
+    const webhookStreamStopDataDisabled = Buffer.from(JSON.stringify({
+        "eventType": "livestream.status.updated",
+        "eventVersion": "1",
+        "broadcaster": {
+            "user_id": 123458,
+            "username": "teststreamer3",
+            "is_verified": false,
+            "profile_picture": "https://example.com/avatar3.jpg",
+            "channel_slug": "teststreamer3"
+        },
+        "is_live": false,
+        "title": "Stream Ended Disabled",
+        "started_at": "2025-09-02T10:07:00+00:00",
+        "ended_at": "2025-09-02T12:07:00+00:00"
+    })).toString('base64');
+
+    /* eslint-disable camelcase */
+    const webhookStreamStopPayloadDisabled: InboundWebhook = {
+        kick_event_message_id: "msg-stream-stop-disabled-789",
+        kick_event_subscription_id: "sub-livestream-disabled-101",
+        kick_event_message_timestamp: "1693589519",
+        kick_event_type: "livestream.status.updated",
+        kick_event_version: "1",
+        is_test_event: false,
+        raw_data: webhookStreamStopDataDisabled
+    };
+    /* eslint-enable camelcase */
+
+    describe('stream start via pusher', () => {
+        const expectedStreamOnlineMetadata = {
+            username: 'teststreamer@kick',
+            userId: 'k123456',
+            userDisplayName: 'teststreamer@kick',
+            platform: 'kick'
+        };
+
+        describe('twitch forwarding enabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        streamOnline: true,
+                        streamOffline: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers all expected events', async () => {
+                await expect((pusher as any).dispatchChannelEvent(pusherStreamStartEvent, pusherStreamStartPayload)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "stream-online", expectedStreamOnlineMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "stream-online", expectedStreamOnlineMetadata);
+            });
+        });
+
+        describe('twitch forwarding disabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        streamOnline: false,
+                        streamOffline: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers only kick events', async () => {
+                await expect((pusher as any).dispatchChannelEvent(pusherStreamStartEvent, pusherStreamStartPayloadDisabled)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(1);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "stream-online", expectedStreamOnlineMetadata);
+            });
+        });
+    });
+
+    describe('stream stop via pusher', () => {
+        const expectedStreamOfflineMetadata = {
+            username: 'teststreamer@kick',
+            userId: 'k123456',
+            userDisplayName: 'teststreamer@kick',
+            platform: 'kick'
+        };
+
+        describe('twitch forwarding enabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        streamOnline: false,
+                        streamOffline: true
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers all expected events', async () => {
+                await expect((pusher as any).dispatchChannelEvent(pusherStreamStopEvent, {})).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "stream-offline", expectedStreamOfflineMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "stream-offline", expectedStreamOfflineMetadata);
+            });
+        });
+
+        describe('twitch forwarding disabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        streamOnline: false,
+                        streamOffline: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers only kick events', async () => {
+                await expect((pusher as any).dispatchChannelEvent(pusherStreamStopEvent, {})).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(1);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "stream-offline", expectedStreamOfflineMetadata);
+            });
+        });
+    });
+
+    describe('stream start via webhook', () => {
+        const expectedStreamOnlineMetadata = {
+            username: 'teststreamer@kick',
+            userId: 'k123456',
+            userDisplayName: 'teststreamer',
+            platform: 'kick'
+        };
+
+        describe('twitch forwarding enabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        streamOnline: true,
+                        streamOffline: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers all expected events', async () => {
+                await expect(handleWebhook(webhookStreamStartPayload)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "stream-online", expectedStreamOnlineMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "stream-online", expectedStreamOnlineMetadata);
+            });
+        });
+
+        describe('twitch forwarding disabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        streamOnline: false,
+                        streamOffline: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers only kick events', async () => {
+                await expect(handleWebhook(webhookStreamStartPayloadDisabled)).resolves.not.toThrow();
+                const expectedMetadata = {
+                    username: 'teststreamer2@kick',
+                    userId: 'k123457',
+                    userDisplayName: 'teststreamer2',
+                    platform: 'kick'
+                };
+                expect(triggerEventMock).toHaveBeenCalledTimes(1);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "stream-online", expectedMetadata);
+            });
+        });
+    });
+
+    describe('stream stop via webhook', () => {
+        const expectedStreamOfflineMetadata = {
+            username: 'teststreamer@kick',
+            userId: 'k123456',
+            userDisplayName: 'teststreamer',
+            platform: 'kick'
+        };
+
+        describe('twitch forwarding enabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        streamOnline: false,
+                        streamOffline: true
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers all expected events', async () => {
+                await expect(handleWebhook(webhookStreamStopPayload)).resolves.not.toThrow();
+                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "stream-offline", expectedStreamOfflineMetadata);
+                expect(triggerEventMock).toHaveBeenCalledWith("twitch", "stream-offline", expectedStreamOfflineMetadata);
+            });
+        });
+
+        describe('twitch forwarding disabled', () => {
+            beforeEach(() => {
+                const integration = require('../integration').integration;
+                integration.getSettings = () => ({
+                    triggerTwitchEvents: {
+                        streamOnline: false,
+                        streamOffline: false
+                    },
+                    logging: { logWebhooks: false }
+                });
+            });
+
+            it('triggers only kick events', async () => {
+                await expect(handleWebhook(webhookStreamStopPayloadDisabled)).resolves.not.toThrow();
+                const expectedMetadata = {
+                    username: 'teststreamer3@kick',
+                    userId: 'k123458',
+                    userDisplayName: 'teststreamer3',
+                    platform: 'kick'
+                };
+                expect(triggerEventMock).toHaveBeenCalledTimes(1);
+                expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "stream-offline", expectedMetadata);
+            });
+        });
+    });
+
+    describe('no status change scenarios', () => {
+        beforeEach(() => {
+            const integration = require('../integration').integration;
+            // Mock updateLiveStatus to return false (no change)
+            integration.kick.channelManager.updateLiveStatus.mockReturnValue(false);
+            integration.getSettings = () => ({
+                triggerTwitchEvents: {
+                    streamOnline: true,
+                    streamOffline: true
+                },
+                logging: { logWebhooks: false }
+            });
+        });
+
+        it('does not trigger events when status unchanged via pusher stream start', async () => {
+            await expect((pusher as any).dispatchChannelEvent(pusherStreamStartEvent, pusherStreamStartPayload)).resolves.not.toThrow();
+            expect(triggerEventMock).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger events when status unchanged via pusher stream stop', async () => {
+            await expect((pusher as any).dispatchChannelEvent(pusherStreamStopEvent, {})).resolves.not.toThrow();
+            expect(triggerEventMock).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger events when status unchanged via webhook stream start', async () => {
+            await expect(handleWebhook(webhookStreamStartPayload)).resolves.not.toThrow();
+            expect(triggerEventMock).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger events when status unchanged via webhook stream stop', async () => {
+            await expect(handleWebhook(webhookStreamStopPayload)).resolves.not.toThrow();
+            expect(triggerEventMock).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/events/livestream-status-updated.ts
+++ b/src/events/livestream-status-updated.ts
@@ -4,54 +4,62 @@ import { kickifyUserId, kickifyUsername, unkickifyUsername } from "../internal/u
 import { firebot } from "../main";
 import { LivestreamStatusUpdated } from "../shared/types";
 
-export async function handleLivestreamStatusUpdatedEvent(payload: LivestreamStatusUpdated): Promise<void> {
-    const update = integration.kick.channelManager.updateLiveStatus(payload.isLive);
-    const userId = kickifyUserId(payload.broadcaster.userId.toString());
-    const username = kickifyUsername(payload.broadcaster.username);
-    const displayName = payload.broadcaster.username; // Kick does not have display names
-    if (update) {
-        if (payload.isLive) {
-            triggerStreamOnline(username, userId, displayName);
-        } else {
-            triggerStreamOffline(username, userId, displayName);
+class LivestreamStatusUpdatedHandler {
+    // This can be triggered by pusher and webhook, probably in close proximity.
+    // However since the firing of events is idempotent here, there will not be
+    // duplicate events triggered assuming the webhook arrives before the state
+    // of the stream changes.
+    async handleLivestreamStatusUpdatedEvent(payload: LivestreamStatusUpdated): Promise<void> {
+        const update = integration.kick.channelManager.updateLiveStatus(payload.isLive);
+        const userId = kickifyUserId(payload.broadcaster.userId.toString());
+        const username = kickifyUsername(payload.broadcaster.username);
+        const displayName = payload.broadcaster.username; // Kick does not have display names
+        if (update) {
+            if (payload.isLive) {
+                this.triggerStreamOnline(username, userId, displayName);
+            } else {
+                this.triggerStreamOffline(username, userId, displayName);
+            }
+        }
+    }
+
+    private triggerStreamOnline(
+        username: string,
+        userId: string,
+        userDisplayName: string
+    ) {
+        const { eventManager } = firebot.modules;
+        const metadata = {
+            username: kickifyUsername(username),
+            userId: kickifyUserId(userId),
+            userDisplayName: userDisplayName || unkickifyUsername(username),
+            platform: "kick"
+        };
+        eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "stream-online", metadata);
+
+        if (integration.getSettings().triggerTwitchEvents.streamOnline) {
+            eventManager.triggerEvent("twitch", "stream-online", metadata);
+        }
+    }
+
+    private triggerStreamOffline(
+        username: string,
+        userId: string,
+        userDisplayName: string
+    ) {
+        const { eventManager } = firebot.modules;
+        const metadata = {
+            username: kickifyUsername(username),
+            userId: kickifyUserId(userId),
+            userDisplayName: userDisplayName || unkickifyUsername(username),
+            platform: "kick"
+        };
+        eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "stream-offline", metadata);
+
+        if (integration.getSettings().triggerTwitchEvents.streamOffline) {
+            eventManager.triggerEvent("twitch", "stream-offline", metadata);
         }
     }
 }
 
-function triggerStreamOnline(
-    username: string,
-    userId: string,
-    userDisplayName: string
-) {
-    const { eventManager } = firebot.modules;
-    const metadata = {
-        username: kickifyUsername(username),
-        userId: kickifyUserId(userId),
-        userDisplayName: userDisplayName || unkickifyUsername(username),
-        platform: "kick"
-    };
-    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "stream-online", metadata);
-
-    if (integration.getSettings().triggerTwitchEvents.streamOnline) {
-        eventManager.triggerEvent("twitch", "stream-online", metadata);
-    }
-}
-
-function triggerStreamOffline(
-    username: string,
-    userId: string,
-    userDisplayName: string
-) {
-    const { eventManager } = firebot.modules;
-    const metadata = {
-        username: kickifyUsername(username),
-        userId: kickifyUserId(userId),
-        userDisplayName: userDisplayName || unkickifyUsername(username),
-        platform: "kick"
-    };
-    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "stream-offline", metadata);
-
-    if (integration.getSettings().triggerTwitchEvents.streamOffline) {
-        eventManager.triggerEvent("twitch", "stream-offline", metadata);
-    }
-}
+export const livestreamStatusUpdatedHandler = new LivestreamStatusUpdatedHandler();

--- a/src/internal/pusher/offline.d.ts
+++ b/src/internal/pusher/offline.d.ts
@@ -1,0 +1,9 @@
+interface StopStreamBroadcastEvent {
+    livestream: {
+        id: number;
+        channel: {
+            id: number;
+            is_banned?: boolean;
+        };
+    };
+}

--- a/src/internal/pusher/online.d.ts
+++ b/src/internal/pusher/online.d.ts
@@ -1,0 +1,9 @@
+interface StreamerIsLiveEvent {
+    livestream: {
+        id: number;
+        channel_id: number;
+        session_title: string;
+        source: string | null;
+        created_at: string;
+    };
+}

--- a/src/internal/pusher/pusher-parsers.ts
+++ b/src/internal/pusher/pusher-parsers.ts
@@ -1,4 +1,5 @@
-import { ChatMessage, KickUser, ModerationBannedEvent, ModerationUnbannedEvent, RaidSentOffEvent, RewardRedeemedEvent, StreamHostedEvent } from "../../shared/types";
+import { integration } from "../../integration";
+import { ChatMessage, KickUser, LivestreamStatusUpdated, ModerationBannedEvent, ModerationUnbannedEvent, RaidSentOffEvent, RewardRedeemedEvent, StreamHostedEvent } from "../../shared/types";
 import { kickifyUserId, kickifyUsername, parseDate, unkickifyUsername } from "../util";
 
 export function parseChatMessageEvent(data: any, broadcaster: KickUser): ChatMessage {
@@ -131,5 +132,42 @@ export function parseViewerBannedOrTimedOutEvent(data: any): ModerationBannedEve
             createdAt: new Date(),
             expiresAt: parseDate(d.expires_at) || undefined
         }
+    };
+}
+
+export function parseStreamerIsLiveEvent(data: any): LivestreamStatusUpdated {
+    const d = data as StreamerIsLiveEvent;
+    const b = integration.kick.broadcaster;
+    return {
+        isLive: true,
+        broadcaster: {
+            userId: kickifyUserId(b?.userId),
+            username: kickifyUsername(b?.name),
+            displayName: unkickifyUsername(b?.name),
+            profilePicture: b?.profilePicture || '',
+            isVerified: false, // Not set in event
+            channelSlug: '' // Not set in event
+        },
+        title: d.livestream.session_title,
+        startedAt: parseDate(d.livestream.created_at) || undefined,
+        endedAt: undefined
+    };
+}
+
+export function parseStopStreamBroadcast(): LivestreamStatusUpdated {
+    const b = integration.kick.broadcaster;
+    return {
+        isLive: false,
+        broadcaster: {
+            userId: kickifyUserId(b?.userId),
+            username: kickifyUsername(b?.name),
+            displayName: unkickifyUsername(b?.name),
+            profilePicture: b?.profilePicture || '',
+            isVerified: false, // Not set in event
+            channelSlug: '' // Not set in event
+        },
+        title: '',
+        startedAt: undefined, // Not set in event
+        endedAt: new Date()
     };
 }

--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -1,4 +1,5 @@
 import { handleChatMessageSentEvent } from "../../events/chat-message-sent";
+import { livestreamStatusUpdatedHandler } from "../../events/livestream-status-updated";
 import { moderationBannedEventHandler } from "../../events/moderation-banned";
 import { handleModerationUnbannedEvent } from "../../events/moderation-unbanned";
 import { handleRaidSentOffEvent } from "../../events/raid-sent-off-event";
@@ -7,7 +8,7 @@ import { handleStreamHostedEvent } from "../../events/stream-hosted-event";
 import { integration } from "../../integration";
 import { logger } from "../../main";
 import { KickUser } from "../../shared/types";
-import { parseChatMessageEvent, parseChatMoveToSupportedChannelEvent, parseRewardRedeemedEvent, parseStreamHostedEvent, parseViewerBannedOrTimedOutEvent, parseViewerUnbannedEvent } from "./pusher-parsers";
+import { parseChatMessageEvent, parseChatMoveToSupportedChannelEvent, parseRewardRedeemedEvent, parseStopStreamBroadcast, parseStreamerIsLiveEvent, parseStreamHostedEvent, parseViewerBannedOrTimedOutEvent, parseViewerUnbannedEvent } from "./pusher-parsers";
 
 const Pusher = require('pusher-js');
 
@@ -81,6 +82,12 @@ export class KickPusher {
             switch (event) {
                 case "App\\Events\\ChatMoveToSupportedChannelEvent":
                     await handleRaidSentOffEvent(parseChatMoveToSupportedChannelEvent(data));
+                    break;
+                case "App\\Events\\StopStreamBroadcast":
+                    await livestreamStatusUpdatedHandler.handleLivestreamStatusUpdatedEvent(parseStopStreamBroadcast());
+                    break;
+                case "App\\Events\\StreamerIsLiveEvent":
+                    await livestreamStatusUpdatedHandler.handleLivestreamStatusUpdatedEvent(parseStreamerIsLiveEvent(data));
                     break;
                 case 'pusher:subscription_succeeded':
                     logger.info("Pusher subscribed successfully to channel events.");

--- a/src/internal/webhook-handler/webhook-handler.ts
+++ b/src/internal/webhook-handler/webhook-handler.ts
@@ -1,7 +1,7 @@
 import { handleChatMessageSentEvent } from "../../events/chat-message-sent";
 import { handleFollowerEvent } from "../../events/follower";
 import { handleLivestreamMetadataUpdatedEvent } from "../../events/livestream-metadata-updated";
-import { handleLivestreamStatusUpdatedEvent } from "../../events/livestream-status-updated";
+import { livestreamStatusUpdatedHandler } from "../../events/livestream-status-updated";
 import { moderationBannedEventHandler } from "../../events/moderation-banned";
 import { handleChannelSubscriptionEvent, handleChannelSubscriptionGiftsEvent } from "../../events/sub-events";
 import { integration } from "../../integration";
@@ -84,7 +84,7 @@ export async function handleWebhook(webhook: InboundWebhook): Promise<void> {
         }
         case "livestream.status.updated": {
             const event = parseLivestreamStatusUpdatedEvent(webhook.raw_data);
-            handleLivestreamStatusUpdatedEvent(event);
+            livestreamStatusUpdatedHandler.handleLivestreamStatusUpdatedEvent(event);
             break;
         }
         case "moderation.banned": {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Now supports the online (`App\Events\StreamerIsLive`) and offline (`App\Events\StopStreamBroadcast`) events from Pusher. These trigger the existing event handlers with the same logic as for the webhook.

### Motivation
Support Pusher for those without webhook proxy, and as a backup mechanism for when webhooks are broken or delayed.

### Testing
Tested by injecting replayed pusher payloads and also added tests including an end-to-end test.
