### PR TITLE
Fix timer leak in HTTP redirect logic

### DIFF
--- a/src/internal/__tests__/poll.test.ts
+++ b/src/internal/__tests__/poll.test.ts
@@ -313,7 +313,8 @@ describe('Poller', () => {
                     'X-Instance-ID': 'test-instance',
                     'X-Request-ID': expect.any(String)
                 },
-                userAgent: 'firebot-mage-kick-integration/1.0.0 (+https://github.com/TheStaticMage/firebot-mage-kick-integration)'
+                userAgent: 'firebot-mage-kick-integration/1.0.0 (+https://github.com/TheStaticMage/firebot-mage-kick-integration)',
+                maxRedirects: 1000
             });
         });
     });

--- a/src/internal/http.ts
+++ b/src/internal/http.ts
@@ -10,11 +10,13 @@ export interface HttpCallRequest {
     userAgent?: string
     headers?: Record<string, string>
     contentType?: string
+    maxRedirects?: number
 }
 
 export async function httpCallWithTimeout<T = any>(req: HttpCallRequest): Promise<T> {
-    const { url, method, authToken, body, signal, timeout, userAgent, headers, contentType } = req;
+    const { url, method, authToken, body, signal, timeout, userAgent, headers, contentType, maxRedirects } = req;
     const effectiveTimeout = typeof timeout === "number" && timeout > 0 ? timeout : 10000;
+    const effectiveMaxRedirects = typeof maxRedirects === "number" && maxRedirects >= 0 ? maxRedirects : 10;
 
     if (signal && signal.aborted) {
         logger.warn("API request aborted due to previous disconnection.");
@@ -22,7 +24,7 @@ export async function httpCallWithTimeout<T = any>(req: HttpCallRequest): Promis
     }
 
     const timeoutController = new AbortController();
-    const timer = setTimeout(() => {
+    let timer = setTimeout(() => {
         timeoutController.abort();
     }, effectiveTimeout);
 
@@ -60,49 +62,82 @@ export async function httpCallWithTimeout<T = any>(req: HttpCallRequest): Promis
     const startTime = performance.now();
     let backOff = 500;
     let counter = 0;
+    let redirectCount = 0;
+    let currentUrl = url;
+
     while (true) {
         try {
             counter++;
             const requestStart = performance.now();
-            const response = await fetch(url, fetchOptions);
+            const response = await fetch(currentUrl, fetchOptions);
             const duration = performance.now() - requestStart;
             if (response.status === 429) {
-                logger.debug(`[${counter}] HTTP ${method} ${url} completed in ${duration}ms with status ${response.status}`);
+                logger.debug(`[${counter}] HTTP ${method} ${currentUrl} completed in ${duration}ms with status ${response.status}`);
                 const elapsedTime = performance.now() - startTime;
                 if (elapsedTime + backOff > effectiveTimeout) {
-                    logger.warn(`Rate limit retry would exceed timeout for ${url}. Aborting after ${elapsedTime}ms.`);
-                    const error: any = new Error(`Request timeout exceeded during rate limit retries (URL: ${url})`);
+                    logger.warn(`Rate limit retry would exceed timeout for ${currentUrl}. Aborting after ${elapsedTime}ms.`);
+                    const error: any = new Error(`Request timeout exceeded during rate limit retries (URL: ${currentUrl})`);
                     error.status = 408; // Request Timeout
+                    clearTimeout(timer);
                     throw error;
                 }
-                logger.warn(`Rate limit exceeded for ${url}. Retrying in ${backOff}ms...`);
+                logger.warn(`Rate limit exceeded for ${currentUrl}. Retrying in ${backOff}ms...`);
                 await new Promise(res => setTimeout(res, backOff));
                 backOff = Math.min(backOff * 2, 5000);
                 continue;
             }
-            logger.debug(`HTTP ${method} ${url} completed in ${duration}ms with status ${response.status}`);
+            logger.debug(`HTTP ${method} ${currentUrl} completed in ${duration}ms with status ${response.status}`);
             if (response.status === 301 || response.status === 302) {
-                logger.debug(`HTTP request to ${url} was redirected to ${response.url}`);
+                redirectCount++;
+                if (redirectCount > effectiveMaxRedirects) {
+                    const error: any = new Error(`Too many redirects (${redirectCount}). Last redirect from ${currentUrl} to ${response.url}`);
+                    error.status = 310; // Too Many Redirects (non-standard but descriptive)
+                    clearTimeout(timer);
+                    throw error;
+                }
+                if (!response.url) {
+                    const error: any = new Error(`Redirect response missing Location header. Status: ${response.status} (URL: ${currentUrl})`);
+                    error.status = response.status;
+                    clearTimeout(timer);
+                    throw error;
+                }
+                logger.debug(`HTTP request to ${currentUrl} was redirected to ${response.url}`);
+                currentUrl = response.url;
+
+                // Reset timeout for the redirected request
+                clearTimeout(timer);
+                const newTimer = setTimeout(() => {
+                    timeoutController.abort();
+                }, effectiveTimeout);
+                // Update timer reference for cleanup
+                timer = newTimer;
+
                 continue;
             }
             if (!response.ok) {
                 const errorBody = await response.text();
-                const error: any = new Error(`HTTP error! Status: ${response.status} (URL: ${url}, payload: ${body}, response: ${errorBody})`);
+                const error: any = new Error(`HTTP error! Status: ${response.status} (URL: ${currentUrl}, payload: ${body}, response: ${errorBody})`);
                 error.status = response.status;
+                clearTimeout(timer);
                 throw error;
             }
             if (response.status === 204) {
+                clearTimeout(timer);
+                if (counter > 1) {
+                    const duration = performance.now() - startTime;
+                    logger.debug(`HTTP ${method} ${currentUrl} completed in ${duration}ms after ${counter} attempt(s)`);
+                }
                 return {} as T;
             }
-            return (await response.json()) as T;
-        } finally {
-            if (timer) {
-                clearTimeout(timer);
-            }
+            clearTimeout(timer);
             if (counter > 1) {
                 const duration = performance.now() - startTime;
-                logger.debug(`HTTP ${method} ${url} completed in ${duration}ms after ${counter} attempt(s)`);
+                logger.debug(`HTTP ${method} ${currentUrl} completed in ${duration}ms after ${counter} attempt(s)`);
             }
+            return (await response.json()) as T;
+        } catch (error) {
+            clearTimeout(timer);
+            throw error;
         }
     }
 }

--- a/src/internal/poll.ts
+++ b/src/internal/poll.ts
@@ -149,7 +149,8 @@ export class Poller {
                     "X-Instance-ID": this.instanceId,
                     "X-Request-ID": crypto.randomUUID()
                 },
-                userAgent: `firebot-mage-kick-integration/${scriptVersion} (+https://github.com/TheStaticMage/firebot-mage-kick-integration)`
+                userAgent: `firebot-mage-kick-integration/${scriptVersion} (+https://github.com/TheStaticMage/firebot-mage-kick-integration)`,
+                maxRedirects: 1000
             };
             httpCallWithTimeout(req)
                 .then((response): InboundWebhook[] => {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Fixes the creation of multiple timer objects during redirects of the poller. This could cause a memory leak.

### Motivation
Memory leaks = bad.

### Testing
Added tests to cover these cases and checked basic polling and other operations with HTTP calls to Kick and the webhook proxy.
