### PR TITLE
Fix timeout validation in timeout effect

### DIFF
--- a/src/effects/__tests__/moderator-timeout.test.ts
+++ b/src/effects/__tests__/moderator-timeout.test.ts
@@ -1,0 +1,236 @@
+import { moderatorTimeoutEffect } from '../moderator-timeout';
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+
+type ModeratorTimeoutEffectParams = {
+    username: string;
+    time: string | number;
+    reason: string;
+};
+
+// Mock the integration and logger
+jest.mock('../../integration', () => ({
+    integration: {
+        kick: {
+            userApi: {
+                banUserByUsername: jest.fn()
+            }
+        }
+    }
+}));
+
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        error: jest.fn()
+    }
+}));
+
+const { integration } = require('../../integration');
+const { logger } = require('../../main');
+
+describe('moderatorTimeoutEffect.onTriggerEvent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('successfully times out a user with valid parameters', async () => {
+        const effect: ModeratorTimeoutEffectParams = {
+            username: 'testuser',
+            time: '300', // 5 minutes in seconds
+            reason: 'Test timeout reason'
+        };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+
+        integration.kick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        const result = await moderatorTimeoutEffect.onTriggerEvent({ trigger, effect } as any);
+
+        expect(integration.kick.userApi.banUserByUsername).toHaveBeenCalledWith(
+            'testuser',
+            5, // 300 seconds = 5 minutes
+            true, // temporary ban (timeout)
+            'Test timeout reason'
+        );
+        expect(logger.debug).toHaveBeenCalledWith('testuser was timed out via the Timeout effect (duration=5 minutes).');
+        expect(result).toBe(true);
+    });
+
+    it('uses default reason when no reason provided', async () => {
+        const effect: ModeratorTimeoutEffectParams = {
+            username: 'testuser',
+            time: '120',
+            reason: ''
+        };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+
+        integration.kick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        await moderatorTimeoutEffect.onTriggerEvent({ trigger, effect } as any);
+
+        expect(integration.kick.userApi.banUserByUsername).toHaveBeenCalledWith(
+            'testuser',
+            2, // 120 seconds = 2 minutes
+            true,
+            'Timed out via Firebot'
+        );
+    });
+
+    it('rounds time to nearest minute with minimum of 1 minute', async () => {
+        const effect: ModeratorTimeoutEffectParams = {
+            username: 'testuser',
+            time: '30', // 30 seconds, should round to 1 minute minimum
+            reason: 'Short timeout'
+        };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+
+        integration.kick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        await moderatorTimeoutEffect.onTriggerEvent({ trigger, effect } as any);
+
+        expect(integration.kick.userApi.banUserByUsername).toHaveBeenCalledWith(
+            'testuser',
+            1, // Minimum 1 minute
+            true,
+            'Short timeout'
+        );
+    });
+
+    it('caps time to maximum of 10080 minutes (7 days)', async () => {
+        const effect: ModeratorTimeoutEffectParams = {
+            username: 'testuser',
+            time: '999999', // Very large number, should cap to 10080 minutes
+            reason: 'Long timeout'
+        };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+
+        integration.kick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        await moderatorTimeoutEffect.onTriggerEvent({ trigger, effect } as any);
+
+        expect(integration.kick.userApi.banUserByUsername).toHaveBeenCalledWith(
+            'testuser',
+            10080, // Maximum 10080 minutes (7 days)
+            true,
+            'Long timeout'
+        );
+    });
+
+    it('rounds fractional minutes correctly', async () => {
+        const effect: ModeratorTimeoutEffectParams = {
+            username: 'testuser',
+            time: '150', // 2.5 minutes, should round to 3 minutes
+            reason: 'Fractional timeout'
+        };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+
+        integration.kick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        await moderatorTimeoutEffect.onTriggerEvent({ trigger, effect } as any);
+
+        expect(integration.kick.userApi.banUserByUsername).toHaveBeenCalledWith(
+            'testuser',
+            3, // 150 seconds = 2.5 minutes, rounded to 3
+            true,
+            'Fractional timeout'
+        );
+    });
+
+    it('returns false and logs error when time is not a valid number', async () => {
+        const effect: ModeratorTimeoutEffectParams = {
+            username: 'testuser',
+            time: 'invalid',
+            reason: 'Test reason'
+        };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+
+        const result = await moderatorTimeoutEffect.onTriggerEvent({ trigger, effect } as any);
+
+        expect(logger.error).toHaveBeenCalledWith('Invalid timeout time provided: invalid');
+        expect(integration.kick.userApi.banUserByUsername).not.toHaveBeenCalled();
+        expect(result).toBe(false);
+    });
+
+    it('returns false and logs error when API call fails', async () => {
+        const effect: ModeratorTimeoutEffectParams = {
+            username: 'testuser',
+            time: '300',
+            reason: 'Test reason'
+        };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+
+        integration.kick.userApi.banUserByUsername.mockResolvedValue(false);
+
+        const result = await moderatorTimeoutEffect.onTriggerEvent({ trigger, effect } as any);
+
+        expect(integration.kick.userApi.banUserByUsername).toHaveBeenCalledWith(
+            'testuser',
+            5,
+            true,
+            'Test reason'
+        );
+        expect(logger.error).toHaveBeenCalledWith('testuser was unable to be timed out via the Timeout effect (duration=5 minutes).');
+        expect(result).toBe(false);
+    });
+
+    it('handles zero time correctly (should use minimum 1 minute)', async () => {
+        const effect: ModeratorTimeoutEffectParams = {
+            username: 'testuser',
+            time: '0',
+            reason: 'Zero timeout'
+        };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+
+        integration.kick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        await moderatorTimeoutEffect.onTriggerEvent({ trigger, effect } as any);
+
+        expect(integration.kick.userApi.banUserByUsername).toHaveBeenCalledWith(
+            'testuser',
+            1, // Zero should become 1 minute minimum
+            true,
+            'Zero timeout'
+        );
+    });
+
+    it('handles negative time correctly (should use minimum 1 minute)', async () => {
+        const effect: ModeratorTimeoutEffectParams = {
+            username: 'testuser',
+            time: '-100',
+            reason: 'Negative timeout'
+        };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+
+        integration.kick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        await moderatorTimeoutEffect.onTriggerEvent({ trigger, effect } as any);
+
+        expect(integration.kick.userApi.banUserByUsername).toHaveBeenCalledWith(
+            'testuser',
+            1, // Negative should become 1 minute minimum
+            true,
+            'Negative timeout'
+        );
+    });
+
+    it('handles numeric time parameter (backward compatibility)', async () => {
+        const effect: ModeratorTimeoutEffectParams = {
+            username: 'testuser',
+            time: 300, // Number instead of string
+            reason: 'Numeric timeout'
+        };
+        const trigger: Effects.Trigger = { type: 'command', metadata: {} } as any;
+
+        integration.kick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        const result = await moderatorTimeoutEffect.onTriggerEvent({ trigger, effect } as any);
+
+        expect(integration.kick.userApi.banUserByUsername).toHaveBeenCalledWith(
+            'testuser',
+            5, // 300 seconds = 5 minutes
+            true,
+            'Numeric timeout'
+        );
+        expect(logger.debug).toHaveBeenCalledWith('testuser was timed out via the Timeout effect (duration=5 minutes).');
+        expect(result).toBe(true);
+    });
+});

--- a/src/effects/moderator-timeout.ts
+++ b/src/effects/moderator-timeout.ts
@@ -5,7 +5,7 @@ import { IntegrationConstants } from "../constants";
 
 export const moderatorTimeoutEffect: Firebot.EffectType<{
     username: string;
-    time: number;
+    time: string | number;
     reason: string;
 }> = {
     definition: {
@@ -24,7 +24,7 @@ export const moderatorTimeoutEffect: Firebot.EffectType<{
             </div>
         </eos-container>
         <eos-container header="Time" pad-top="true">
-            <p class="muted">Due to API limitations, the minimum timeout duration is 1 minute, and the time you specify here will be rounded to the nearest minute.</p>
+            <p class="muted">Due to API limitations, the permitted range is 60-604800 seconds (1 minute-7 days). The seconds you specify here will be rounded to the nearest minute.</p>
             <div class="input-group">
                 <span class="input-group-addon" id="time-type">Time (Seconds)</span>
                 <input ng-model="effect.time" type="text" class="form-control" id="list-username-setting" aria-describedby="list-time-type" placeholder="Seconds" replace-variables="number">
@@ -46,7 +46,9 @@ export const moderatorTimeoutEffect: Firebot.EffectType<{
         if (effect.username == null || effect.username === "") {
             errors.push("Please enter a username.");
         }
-        if (effect.time == null) {
+        if (effect.time == null || effect.time === "") {
+            // We can't check for a number here or do numeric comparisons
+            // because the value could be a replace variable.
             errors.push("Please enter an amount of time.");
         }
         return errors;
@@ -55,17 +57,21 @@ export const moderatorTimeoutEffect: Firebot.EffectType<{
         return `${effect.time} sec timeout for ${effect.username}`;
     },
     onTriggerEvent: async (event) => {
-        const duration = Math.round(event.effect.time / 60);
-        if (duration < 1 || duration > 10080) {
-            logger.error(`Invalid timeout duration: ${duration}`);
+        // Here the time should be a number since all variables should have been
+        // resolved.
+        const timeAsNumber = Number(event.effect.time);
+        if (isNaN(timeAsNumber)) {
+            logger.error(`Invalid timeout time provided: ${event.effect.time}`);
             return false;
         }
 
+        // Range to the Kick API is 1-10080 minutes (7 days)
+        const duration = Math.max(1, Math.min(10080, Math.round(timeAsNumber / 60)));
         const isTimedOut = await integration.kick.userApi.banUserByUsername(event.effect.username, duration, true, event.effect.reason || "Timed out via Firebot");
         if (isTimedOut) {
-            logger.debug(`${event.effect.username} was timed out via the Timeout effect.`);
+            logger.debug(`${event.effect.username} was timed out via the Timeout effect (duration=${duration} minutes).`);
         } else {
-            logger.error(`${event.effect.username} was unable to be timed out via the Timeout effect.`);
+            logger.error(`${event.effect.username} was unable to be timed out via the Timeout effect (duration=${duration} minutes).`);
             return false;
         }
         return true;


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This makes the checking for an empty timeout value actually work as intended. Additionally, if the value is out of range, this puts it in range so the effect can still work.

### Motivation
Make this effect work as much as possible.

### Testing
Comprehensive unit test + tested in actual connected Firebot instance.
