### PR TITLE
Move webhook handler into its own class

### DIFF
--- a/src/__tests__/livestream-status-updated.ts
+++ b/src/__tests__/livestream-status-updated.ts
@@ -37,7 +37,7 @@ jest.mock('../main', () => ({
 
 import { IntegrationConstants } from '../constants';
 import { KickPusher } from '../internal/pusher/pusher';
-import { handleWebhook } from '../internal/webhook-handler/webhook-handler';
+import { webhookHandler } from '../internal/webhook-handler/webhook-handler';
 
 describe('e2e livestream status updated', () => {
     let pusher: KickPusher;
@@ -315,7 +315,7 @@ describe('e2e livestream status updated', () => {
             });
 
             it('triggers all expected events', async () => {
-                await expect(handleWebhook(webhookStreamStartPayload)).resolves.not.toThrow();
+                await expect(webhookHandler.handleWebhook(webhookStreamStartPayload)).resolves.not.toThrow();
                 expect(triggerEventMock).toHaveBeenCalledTimes(2);
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "stream-online", expectedStreamOnlineMetadata);
                 expect(triggerEventMock).toHaveBeenCalledWith("twitch", "stream-online", expectedStreamOnlineMetadata);
@@ -335,7 +335,7 @@ describe('e2e livestream status updated', () => {
             });
 
             it('triggers only kick events', async () => {
-                await expect(handleWebhook(webhookStreamStartPayloadDisabled)).resolves.not.toThrow();
+                await expect(webhookHandler.handleWebhook(webhookStreamStartPayloadDisabled)).resolves.not.toThrow();
                 const expectedMetadata = {
                     username: 'teststreamer2@kick',
                     userId: 'k123457',
@@ -369,7 +369,7 @@ describe('e2e livestream status updated', () => {
             });
 
             it('triggers all expected events', async () => {
-                await expect(handleWebhook(webhookStreamStopPayload)).resolves.not.toThrow();
+                await expect(webhookHandler.handleWebhook(webhookStreamStopPayload)).resolves.not.toThrow();
                 expect(triggerEventMock).toHaveBeenCalledTimes(2);
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "stream-offline", expectedStreamOfflineMetadata);
                 expect(triggerEventMock).toHaveBeenCalledWith("twitch", "stream-offline", expectedStreamOfflineMetadata);
@@ -389,7 +389,7 @@ describe('e2e livestream status updated', () => {
             });
 
             it('triggers only kick events', async () => {
-                await expect(handleWebhook(webhookStreamStopPayloadDisabled)).resolves.not.toThrow();
+                await expect(webhookHandler.handleWebhook(webhookStreamStopPayloadDisabled)).resolves.not.toThrow();
                 const expectedMetadata = {
                     username: 'teststreamer3@kick',
                     userId: 'k123458',
@@ -427,12 +427,12 @@ describe('e2e livestream status updated', () => {
         });
 
         it('does not trigger events when status unchanged via webhook stream start', async () => {
-            await expect(handleWebhook(webhookStreamStartPayload)).resolves.not.toThrow();
+            await expect(webhookHandler.handleWebhook(webhookStreamStartPayload)).resolves.not.toThrow();
             expect(triggerEventMock).not.toHaveBeenCalled();
         });
 
         it('does not trigger events when status unchanged via webhook stream stop', async () => {
-            await expect(handleWebhook(webhookStreamStopPayload)).resolves.not.toThrow();
+            await expect(webhookHandler.handleWebhook(webhookStreamStopPayload)).resolves.not.toThrow();
             expect(triggerEventMock).not.toHaveBeenCalled();
         });
     });

--- a/src/__tests__/moderation.test.ts
+++ b/src/__tests__/moderation.test.ts
@@ -27,7 +27,7 @@ jest.mock('../main', () => ({
 
 import { IntegrationConstants } from '../constants';
 import { KickPusher } from '../internal/pusher/pusher';
-import { handleWebhook } from '../internal/webhook-handler/webhook-handler';
+import { webhookHandler } from '../internal/webhook-handler/webhook-handler';
 
 describe('e2e moderation unbanned', () => {
     let pusher: KickPusher;
@@ -379,7 +379,7 @@ describe('e2e moderation banned', () => {
             });
 
             it('triggers all expected events', async () => {
-                await expect(handleWebhook(webhookTimeoutPayload)).resolves.not.toThrow();
+                await expect(webhookHandler.handleWebhook(webhookTimeoutPayload)).resolves.not.toThrow();
                 expect(triggerEventMock).toHaveBeenCalledTimes(2);
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "timeout", expectedWebhookTimeoutMetadata);
                 expect(triggerEventMock).toHaveBeenCalledWith("twitch", "timeout", expectedWebhookTimeoutMetadata);
@@ -411,7 +411,7 @@ describe('e2e moderation banned', () => {
                     timeoutDuration: expect.any(Number),
                     platform: 'kick'
                 };
-                await expect(handleWebhook(webhookTimeoutPayloadDisabled)).resolves.not.toThrow();
+                await expect(webhookHandler.handleWebhook(webhookTimeoutPayloadDisabled)).resolves.not.toThrow();
                 expect(triggerEventMock).toHaveBeenCalledTimes(1);
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "timeout", expectedWebhookTimeoutMetadataDisabled);
             });
@@ -445,7 +445,7 @@ describe('e2e moderation banned', () => {
             });
 
             it('triggers all expected events', async () => {
-                await expect(handleWebhook(webhookBanPayload)).resolves.not.toThrow();
+                await expect(webhookHandler.handleWebhook(webhookBanPayload)).resolves.not.toThrow();
                 expect(triggerEventMock).toHaveBeenCalledTimes(2);
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "banned", expectedWebhookBanMetadata);
                 expect(triggerEventMock).toHaveBeenCalledWith("twitch", "banned", expectedWebhookBanMetadata);
@@ -477,7 +477,7 @@ describe('e2e moderation banned', () => {
                     timeoutDuration: undefined,
                     platform: 'kick'
                 };
-                await expect(handleWebhook(webhookBanPayloadDisabled)).resolves.not.toThrow();
+                await expect(webhookHandler.handleWebhook(webhookBanPayloadDisabled)).resolves.not.toThrow();
                 expect(triggerEventMock).toHaveBeenCalledTimes(1);
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "banned", expectedWebhookBanMetadataDisabled);
             });

--- a/src/internal/poll.ts
+++ b/src/internal/poll.ts
@@ -2,7 +2,7 @@ import { IntegrationConstants } from "../constants";
 import { integration } from "../integration";
 import { logger, scriptVersion } from "../main";
 import { HttpCallRequest, httpCallWithTimeout } from "./http";
-import { handleWebhook } from "./webhook-handler/webhook-handler";
+import { webhookHandler } from "./webhook-handler/webhook-handler";
 
 export class Poller {
     private isConnected = false;
@@ -180,7 +180,7 @@ export class Poller {
 
     private async handleResponse(response: InboundWebhook): Promise<void> {
         try {
-            await handleWebhook(response);
+            await webhookHandler.handleWebhook(response);
         } catch (error) {
             logger.error(`Error parsing webhook: ${error}`);
             return;

--- a/src/internal/webhook-handler/webhook-handler.ts
+++ b/src/internal/webhook-handler/webhook-handler.ts
@@ -9,91 +9,95 @@ import { logger } from "../../main";
 import { parseChannelSubscriptionGiftsEvent, parseChannelSubscriptionNewEvent, parseChannelSubscriptionRenewalEvent, parseChatMessageEvent, parseFollowEvent, parseLivestreamMetadataUpdatedEvent, parseLivestreamStatusUpdatedEvent, parseModerationBannedEvent, parsePusherTestWebhook } from "./webhook-parsers";
 import NodeCache from 'node-cache';
 
-const webhookCache = new NodeCache({ stdTTL: 300, checkperiod: 60 }); // Cache for 5 minutes
+export class WebhookHandler {
+    private webhookCache = new NodeCache({ stdTTL: 300, checkperiod: 60 }); // Cache for 5 minutes
 
-export async function handleWebhook(webhook: InboundWebhook): Promise<void> {
-    if (integration.getSettings().logging.logWebhooks) {
-        logger.debug(`Received webhook: ${JSON.stringify(webhook)}`);
-    }
+    public async handleWebhook(webhook: InboundWebhook): Promise<void> {
+        if (integration.getSettings().logging.logWebhooks) {
+            logger.debug(`Received webhook: ${JSON.stringify(webhook)}`);
+        }
 
-    if (!webhook.kick_event_message_id || !webhook.kick_event_subscription_id || !webhook.kick_event_message_timestamp ||
+        if (!webhook.kick_event_message_id || !webhook.kick_event_subscription_id || !webhook.kick_event_message_timestamp ||
         !webhook.kick_event_type || !webhook.kick_event_version || !webhook.raw_data) {
-        throw new Error("Invalid webhook data");
-    }
+            throw new Error("Invalid webhook data");
+        }
 
-    // When Kick subscriptions get messed up, it can send the same payload
-    // multiple times under different subscription IDs and message IDs. So here
-    // we hash the payload (raw_data) and then check it against a cache so that
-    // we can reject duplicate payloads.
-    const crypto = await import('crypto');
-    const payloadHash = crypto.createHash('sha256').update(webhook.raw_data).digest('hex');
+        // When Kick subscriptions get messed up, it can send the same payload
+        // multiple times under different subscription IDs and message IDs. So here
+        // we hash the payload (raw_data) and then check it against a cache so that
+        // we can reject duplicate payloads.
+        const crypto = await import('crypto');
+        const payloadHash = crypto.createHash('sha256').update(webhook.raw_data).digest('hex');
 
-    if (webhookCache.has(payloadHash)) {
-        logger.warn(`Duplicate webhook payload detected (id: ${webhook.kick_event_message_id}, type: ${webhook.kick_event_type}, version: ${webhook.kick_event_version}, hash: ${payloadHash}), ignoring.`);
-        return;
-    }
-    webhookCache.set(payloadHash, true);
+        if (this.webhookCache.has(payloadHash)) {
+            logger.warn(`Duplicate webhook payload detected (id: ${webhook.kick_event_message_id}, type: ${webhook.kick_event_type}, version: ${webhook.kick_event_version}, hash: ${payloadHash}), ignoring.`);
+            return;
+        }
+        this.webhookCache.set(payloadHash, true);
 
-    // This is NOT intended to be for security, since you are implicitly
-    // trusting the proxy owner and they could just send you fake data. Rather,
-    // it's meant to protect you against innocent mistakes (e.g. developer
-    // accidentally sending test webhooks with the wrong key).
-    if (webhook.is_test_event && !integration.getSettings().advanced.allowTestWebhooks) {
-        logger.warn(`Received test webhook but test webhooks are disabled: ${JSON.stringify(webhook)}`);
-        return;
-    }
+        // This is NOT intended to be for security, since you are implicitly
+        // trusting the proxy owner and they could just send you fake data. Rather,
+        // it's meant to protect you against innocent mistakes (e.g. developer
+        // accidentally sending test webhooks with the wrong key).
+        if (webhook.is_test_event && !integration.getSettings().advanced.allowTestWebhooks) {
+            logger.warn(`Received test webhook but test webhooks are disabled: ${JSON.stringify(webhook)}`);
+            return;
+        }
 
-    // This is not a real event from Kick, but is rather used for testing.
-    if (webhook.is_test_event && webhook.kick_event_type === "pusher.test") {
-        const payload = parsePusherTestWebhook(webhook.raw_data);
-        await integration.pusher.dispatchTestEvent(payload);
-        return;
-    }
+        // This is not a real event from Kick, but is rather used for testing.
+        if (webhook.is_test_event && webhook.kick_event_type === "pusher.test") {
+            const payload = parsePusherTestWebhook(webhook.raw_data);
+            await integration.pusher.dispatchTestEvent(payload);
+            return;
+        }
 
-    // Handle real webhooks
-    switch (webhook.kick_event_type) {
-        case "chat.message.sent": {
-            const event = parseChatMessageEvent(webhook.raw_data);
-            handleChatMessageSentEvent(event);
-            break;
-        }
-        case "channel.followed": {
-            const event = parseFollowEvent(webhook.raw_data);
-            handleFollowerEvent(event);
-            break;
-        }
-        case "channel.subscription.renewal": {
-            const event = parseChannelSubscriptionRenewalEvent(webhook.raw_data);
-            handleChannelSubscriptionEvent(event);
-            break;
-        }
-        case "channel.subscription.gifts": {
-            const event = parseChannelSubscriptionGiftsEvent(webhook.raw_data);
-            handleChannelSubscriptionGiftsEvent(event);
-            break;
-        }
-        case "channel.subscription.new": {
-            const event = parseChannelSubscriptionNewEvent(webhook.raw_data);
-            handleChannelSubscriptionEvent(event);
-            break;
-        }
-        case "livestream.metadata.updated": {
-            const event = parseLivestreamMetadataUpdatedEvent(webhook.raw_data);
-            handleLivestreamMetadataUpdatedEvent(event);
-            break;
-        }
-        case "livestream.status.updated": {
-            const event = parseLivestreamStatusUpdatedEvent(webhook.raw_data);
-            livestreamStatusUpdatedHandler.handleLivestreamStatusUpdatedEvent(event);
-            break;
-        }
-        case "moderation.banned": {
-            const event = parseModerationBannedEvent(webhook.raw_data);
-            moderationBannedEventHandler.handleModerationBannedEvent(event);
-            break;
-        }
-        default: {
-            throw new Error(`Unsupported event type: ${webhook.kick_event_type}`);
+        // Handle real webhooks
+        switch (webhook.kick_event_type) {
+            case "chat.message.sent": {
+                const event = parseChatMessageEvent(webhook.raw_data);
+                handleChatMessageSentEvent(event);
+                break;
+            }
+            case "channel.followed": {
+                const event = parseFollowEvent(webhook.raw_data);
+                handleFollowerEvent(event);
+                break;
+            }
+            case "channel.subscription.renewal": {
+                const event = parseChannelSubscriptionRenewalEvent(webhook.raw_data);
+                handleChannelSubscriptionEvent(event);
+                break;
+            }
+            case "channel.subscription.gifts": {
+                const event = parseChannelSubscriptionGiftsEvent(webhook.raw_data);
+                await handleChannelSubscriptionGiftsEvent(event);
+                break;
+            }
+            case "channel.subscription.new": {
+                const event = parseChannelSubscriptionNewEvent(webhook.raw_data);
+                handleChannelSubscriptionEvent(event);
+                break;
+            }
+            case "livestream.metadata.updated": {
+                const event = parseLivestreamMetadataUpdatedEvent(webhook.raw_data);
+                handleLivestreamMetadataUpdatedEvent(event);
+                break;
+            }
+            case "livestream.status.updated": {
+                const event = parseLivestreamStatusUpdatedEvent(webhook.raw_data);
+                livestreamStatusUpdatedHandler.handleLivestreamStatusUpdatedEvent(event);
+                break;
+            }
+            case "moderation.banned": {
+                const event = parseModerationBannedEvent(webhook.raw_data);
+                moderationBannedEventHandler.handleModerationBannedEvent(event);
+                break;
+            }
+            default: {
+                throw new Error(`Unsupported event type: ${webhook.kick_event_type}`);
+            }
         }
     }
 }
+
+export const webhookHandler = new WebhookHandler();


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Internal refactor to move the webhook handler into its own class.

### Motivation
Will make it easier to mock in end-to-end tests.

### Testing
Continued compilation and passing CI.
