### PR TITLE
Clean up user ID and name in pusher events

### DIFF
--- a/src/__tests__/livestream-status-updated.ts
+++ b/src/__tests__/livestream-status-updated.ts
@@ -202,7 +202,7 @@ describe('e2e livestream status updated', () => {
         const expectedStreamOnlineMetadata = {
             username: 'teststreamer@kick',
             userId: 'k123456',
-            userDisplayName: 'teststreamer@kick',
+            userDisplayName: 'teststreamer',
             platform: 'kick'
         };
 
@@ -250,7 +250,7 @@ describe('e2e livestream status updated', () => {
         const expectedStreamOfflineMetadata = {
             username: 'teststreamer@kick',
             userId: 'k123456',
-            userDisplayName: 'teststreamer@kick',
+            userDisplayName: 'teststreamer',
             platform: 'kick'
         };
 

--- a/src/events/chat-message-sent.ts
+++ b/src/events/chat-message-sent.ts
@@ -11,7 +11,7 @@ interface chatBadge {
     url: string;
 }
 
-export async function handleChatMessageSentEvent(payload: ChatMessage, delay = 0): Promise<void> {
+export async function handleChatMessageSentEvent(payload: ChatMessage): Promise<void> {
     // Basic message parsing
     const helpers = new FirebotChatHelpers();
     const firebotChatMessage = await helpers.buildFirebotChatMessage(payload, payload.content);
@@ -24,19 +24,6 @@ export async function handleChatMessageSentEvent(payload: ChatMessage, delay = 0
     const viewer = await integration.kick.userManager.getOrCreateViewer(payload.sender, [], true);
     if (viewer) {
         await integration.kick.userManager.syncViewerRoles(viewer._id, badgeRoles, possibleBadges);
-    }
-
-    // This might be delayed -- the webhook contains more information than
-    // pusher (e.g. badges) but the pusher message usually comes first. However
-    // the webhooks are sometimes delayed, so we don't want to wait too long for
-    // the webhook to come either. This tries to make the best operational
-    // choice.
-    //
-    if (delay > 0) {
-        logger.debug(`handleChatMessageSentEvent: Message processing delay is currently disabled (request: ${delay} seconds)`);
-        // Currently commented out: The pusher events do seem to have badges. We can
-        // add this back if we have future dependencies on fields only in webhooks.
-        // await new Promise(resolve => setTimeout(resolve, delay * 1000));
     }
 
     // Skip duplicate messages here

--- a/src/internal/pusher/__tests__/pusher.parsers.test.ts
+++ b/src/internal/pusher/__tests__/pusher.parsers.test.ts
@@ -2,15 +2,28 @@ import { KickUser } from "../../../shared/types";
 import { parseChatMessageEvent, parseChatMoveToSupportedChannelEvent, parseRewardRedeemedEvent, parseStopStreamBroadcast, parseStreamHostedEvent, parseStreamerIsLiveEvent, parseViewerBannedOrTimedOutEvent, parseViewerUnbannedEvent } from "../pusher-parsers";
 
 // Mock the integration module
-jest.mock("../../../integration", () => ({
-    integration: {
-        kick: {
-            broadcaster: {
-                userId: "123456",
-                name: "teststreamer",
-                profilePicture: "https://example.com/profile.jpg"
+jest.mock("../../../integration", () => {
+    const mockGetViewerByUsername = jest.fn();
+    return {
+        integration: {
+            kick: {
+                broadcaster: {
+                    userId: "123456",
+                    name: "teststreamer",
+                    profilePicture: "https://example.com/profile.jpg"
+                },
+                userManager: {
+                    getViewerByUsername: mockGetViewerByUsername
+                }
             }
         }
+    };
+});
+
+// Mock the logger
+jest.mock("../../../main", () => ({
+    logger: {
+        error: jest.fn()
     }
 }));
 
@@ -21,16 +34,16 @@ describe('parseViewerUnbannedEvent', () => {
         const result = parseViewerUnbannedEvent(input);
         expect(result).toEqual({
             user: {
-                userId: "k111",
-                username: "unbanneduser@kick",
+                userId: "111",
+                username: "unbanneduser",
                 displayName: "unbanneduser",
                 profilePicture: '',
                 isVerified: false,
                 channelSlug: ''
             },
             moderator: {
-                userId: "k222",
-                username: "moduser@kick",
+                userId: "222",
+                username: "moduser",
                 displayName: "moduser",
                 profilePicture: '',
                 isVerified: false,
@@ -46,16 +59,16 @@ describe('parseViewerUnbannedEvent', () => {
         const result = parseViewerUnbannedEvent(input);
         expect(result).toEqual({
             user: {
-                userId: "k333",
-                username: "timeoutuser@kick",
+                userId: "333",
+                username: "timeoutuser",
                 displayName: "timeoutuser",
                 profilePicture: '',
                 isVerified: false,
                 channelSlug: ''
             },
             moderator: {
-                userId: "k444",
-                username: "mod2@kick",
+                userId: "444",
+                username: "mod2",
                 displayName: "mod2",
                 profilePicture: '',
                 isVerified: false,
@@ -247,8 +260,8 @@ describe('parseChatMoveToSupportedChannelEvent', () => {
         const result = parseChatMoveToSupportedChannelEvent(JSON.parse(jsonInput));
         expect(result).toEqual({
             targetUser: {
-                userId: 'k87654321',
-                username: 'Target_User@kick',
+                userId: '87654321',
+                username: 'Target_User',
                 displayName: 'Target_User',
                 profilePicture: 'https://profile_pic',
                 isVerified: false,
@@ -271,16 +284,16 @@ describe('parseViewerBannedOrTimedOutEvent', () => {
 
         expect(result).toEqual({
             bannedUser: {
-                userId: "k23498234",
-                username: "timeoutuser@kick",
+                userId: "23498234",
+                username: "timeoutuser",
                 displayName: "timeoutuser",
                 profilePicture: '',
                 isVerified: false,
                 channelSlug: 'timeoutuser'
             },
             moderator: {
-                userId: "k0",
-                username: "TheStaticMage@kick",
+                userId: "0",
+                username: "TheStaticMage",
                 displayName: "TheStaticMage",
                 profilePicture: '',
                 isVerified: false,
@@ -301,16 +314,16 @@ describe('parseViewerBannedOrTimedOutEvent', () => {
 
         expect(result).toEqual({
             bannedUser: {
-                userId: "k23498234",
-                username: "timeoutuser@kick",
+                userId: "23498234",
+                username: "timeoutuser",
                 displayName: "timeoutuser",
                 profilePicture: '',
                 isVerified: false,
                 channelSlug: 'timeoutuser'
             },
             moderator: {
-                userId: "k0",
-                username: "TheStaticMage@kick",
+                userId: "0",
+                username: "TheStaticMage",
                 displayName: "TheStaticMage",
                 profilePicture: '',
                 isVerified: false,
@@ -342,8 +355,8 @@ describe('parseStreamerIsLiveEvent', () => {
         expect(result).toEqual({
             isLive: true,
             broadcaster: {
-                userId: "k123456",
-                username: "teststreamer@kick",
+                userId: "123456",
+                username: "teststreamer",
                 displayName: "teststreamer",
                 profilePicture: "https://example.com/profile.jpg",
                 isVerified: false,
@@ -371,8 +384,8 @@ describe('parseStreamerIsLiveEvent', () => {
         expect(result).toEqual({
             isLive: true,
             broadcaster: {
-                userId: "k123456",
-                username: "teststreamer@kick",
+                userId: "123456",
+                username: "teststreamer",
                 displayName: "teststreamer",
                 profilePicture: "https://example.com/profile.jpg",
                 isVerified: false,
@@ -400,8 +413,8 @@ describe('parseStreamerIsLiveEvent', () => {
         expect(result).toEqual({
             isLive: true,
             broadcaster: {
-                userId: "k123456",
-                username: "teststreamer@kick",
+                userId: "123456",
+                username: "teststreamer",
                 displayName: "teststreamer",
                 profilePicture: "https://example.com/profile.jpg",
                 isVerified: false,
@@ -474,8 +487,8 @@ describe('parseStreamerIsLiveEvent', () => {
         expect(result).toEqual({
             isLive: true,
             broadcaster: {
-                userId: "k123456",
-                username: "teststreamer@kick",
+                userId: "123456",
+                username: "teststreamer",
                 displayName: "teststreamer",
                 profilePicture: "https://example.com/profile.jpg",
                 isVerified: false,
@@ -506,8 +519,8 @@ describe('parseStopStreamBroadcast', () => {
         expect(result).toEqual({
             isLive: false,
             broadcaster: {
-                userId: "k123456",
-                username: "teststreamer@kick",
+                userId: "123456",
+                username: "teststreamer",
                 displayName: "teststreamer",
                 profilePicture: "https://example.com/profile.jpg",
                 isVerified: false,
@@ -561,8 +574,8 @@ describe('parseStopStreamBroadcast', () => {
         expect(result).toEqual({
             isLive: false,
             broadcaster: {
-                userId: "k789012",
-                username: "nopicstreamer@kick",
+                userId: "789012",
+                username: "nopicstreamer",
                 displayName: "nopicstreamer",
                 profilePicture: "",
                 isVerified: false,

--- a/src/internal/pusher/pusher-parsers.ts
+++ b/src/internal/pusher/pusher-parsers.ts
@@ -1,6 +1,6 @@
 import { integration } from "../../integration";
 import { ChatMessage, KickUser, LivestreamStatusUpdated, ModerationBannedEvent, ModerationUnbannedEvent, RaidSentOffEvent, RewardRedeemedEvent, StreamHostedEvent } from "../../shared/types";
-import { kickifyUserId, kickifyUsername, parseDate, unkickifyUsername } from "../util";
+import { parseDate } from "../util";
 
 export function parseChatMessageEvent(data: any, broadcaster: KickUser): ChatMessage {
     const d = data as ChatMessageEvent;
@@ -73,9 +73,9 @@ export function parseChatMoveToSupportedChannelEvent(data: any): RaidSentOffEven
     const d = data as ChatMoveToSupportedChannelEventPayload;
     return {
         targetUser: {
-            userId: kickifyUserId(d.hosted.id.toString()),
-            username: kickifyUsername(d.hosted.username),
-            displayName: unkickifyUsername(d.hosted.username),
+            userId: d.hosted.id.toString(),
+            username: d.hosted.username,
+            displayName: d.hosted.username,
             profilePicture: d.hosted.profile_pic,
             isVerified: false, // Not provided in event
             channelSlug: d.hosted.slug
@@ -89,17 +89,17 @@ export function parseViewerUnbannedEvent(data: any): ModerationUnbannedEvent {
     const d = data as ViewerUnbannedEventData;
     return {
         user: {
-            userId: kickifyUserId(d.user.id.toString()),
-            username: kickifyUsername(d.user.username),
-            displayName: unkickifyUsername(d.user.username),
+            userId: String(d.user.id),
+            username: d.user.username,
+            displayName: d.user.username,
             profilePicture: '', // Not provided in event
             isVerified: false, // Not provided in event
             channelSlug: '' // Not provided in event
         },
         moderator: {
-            userId: kickifyUserId(d.unbanned_by.id.toString()),
-            username: kickifyUsername(d.unbanned_by.username),
-            displayName: unkickifyUsername(d.unbanned_by.username),
+            userId: String(d.unbanned_by.id),
+            username: d.unbanned_by.username,
+            displayName: d.unbanned_by.username,
             profilePicture: '', // Not provided in event
             isVerified: false, // Not provided in event
             channelSlug: '' // Not provided in event
@@ -112,17 +112,17 @@ export function parseViewerBannedOrTimedOutEvent(data: any): ModerationBannedEve
     const d = data as ViewerBannedEventData;
     return {
         bannedUser: {
-            userId: kickifyUserId(d.user.id.toString()),
-            username: kickifyUsername(d.user.username),
-            displayName: unkickifyUsername(d.user.username),
+            userId: String(d.user.id),
+            username: d.user.username,
+            displayName: d.user.username,
             profilePicture: '', // Not provided in event
             isVerified: false, // Not provided in event
             channelSlug: d.user.slug
         },
         moderator: {
-            userId: kickifyUserId(d.banned_by.id.toString()),
-            username: kickifyUsername(d.banned_by.username),
-            displayName: unkickifyUsername(d.banned_by.username),
+            userId: String(d.banned_by.id),
+            username: d.banned_by.username,
+            displayName: d.banned_by.username,
             profilePicture: '', // Not provided in event
             isVerified: false, // Not provided in event
             channelSlug: d.banned_by.slug
@@ -141,9 +141,9 @@ export function parseStreamerIsLiveEvent(data: any): LivestreamStatusUpdated {
     return {
         isLive: true,
         broadcaster: {
-            userId: kickifyUserId(b?.userId),
-            username: kickifyUsername(b?.name),
-            displayName: unkickifyUsername(b?.name),
+            userId: b?.userId ? String(b.userId) : "",
+            username: b?.name || "",
+            displayName: b?.name || '',
             profilePicture: b?.profilePicture || '',
             isVerified: false, // Not set in event
             channelSlug: '' // Not set in event
@@ -159,12 +159,12 @@ export function parseStopStreamBroadcast(): LivestreamStatusUpdated {
     return {
         isLive: false,
         broadcaster: {
-            userId: kickifyUserId(b?.userId),
-            username: kickifyUsername(b?.name),
-            displayName: unkickifyUsername(b?.name),
-            profilePicture: b?.profilePicture || '',
+            userId: b?.userId ? String(b.userId) : "",
+            username: b?.name || "",
+            displayName: b?.name || "",
+            profilePicture: b?.profilePicture || "",
             isVerified: false, // Not set in event
-            channelSlug: '' // Not set in event
+            channelSlug: "" // Not set in event
         },
         title: '',
         startedAt: undefined, // Not set in event

--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -107,7 +107,7 @@ export class KickPusher {
                 case 'App\\Events\\ChatMessageEvent': {
                     const broadcaster = this.getBroadcaster();
                     if (broadcaster) {
-                        await handleChatMessageSentEvent(parseChatMessageEvent(data, broadcaster), 2); // Delay by 2 seconds in hopes webhook arrives first
+                        await handleChatMessageSentEvent(parseChatMessageEvent(data, broadcaster));
                     } else {
                         logger.warn("Skipping chat message event: broadcaster information not available");
                     }


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
There's inconsistency between our webhooks and pusher implementation for raw user ID and username. This stops the pusher from "kickifying" the user ID and username so events can be consistent. There were some follow-on updates throughout the code base to account for this.

### Motivation
Consistency makes it easier to develop.

### Testing
Passing tests and it works on a real instance.
