### PR TITLE
Add webhook-received event, filters, variables

### DIFF
--- a/src/__tests__/gift-subscription.e2e.test.ts
+++ b/src/__tests__/gift-subscription.e2e.test.ts
@@ -254,7 +254,7 @@ describe('e2e gift subscription events', () => {
                 expect(mockRecordSubscription).toHaveBeenCalledTimes(2); // 2 giftees
                 expect(mockRecordGift).toHaveBeenCalledTimes(2); // 2 gifts recorded
 
-                expect(triggerEventMock).toHaveBeenCalledTimes(3); // 1 community + 2 individual
+                expect(triggerEventMock).toHaveBeenCalledTimes(4); // 1 community + 2 individual + 1 webhook-received
             });
         });
 
@@ -302,7 +302,7 @@ describe('e2e gift subscription events', () => {
                     expectedIndividualKickMetadata2
                 );
 
-                expect(triggerEventMock).toHaveBeenCalledTimes(5); // 1 community + 2 kick individual + 2 twitch individual
+                expect(triggerEventMock).toHaveBeenCalledTimes(6); // 1 community + 2 kick individual + 2 twitch individual + 1 webhook-received
             });
         });
     });
@@ -577,7 +577,7 @@ describe('e2e gift subscription events', () => {
             // Verify both events were processed
             const subGiftedCalls = triggerEventMock.mock.calls.filter(call => call[1] === "subs-gifted");
             expect(subGiftedCalls).toHaveLength(1);
-            expect(triggerEventMock).toHaveBeenCalledTimes(1); // Only webhook should trigger
+            expect(triggerEventMock).toHaveBeenCalledTimes(2); // Only webhook should trigger + 1 webhook-received
             const hasWebhookEvent = subGiftedCalls.some(call =>
                 call[2].gifteeUsername === 'recipient1@kick');
             expect(hasWebhookEvent).toBe(true);
@@ -690,7 +690,7 @@ describe('e2e gift subscription events', () => {
             expect(hasWebhookEvent).toBe(true);
 
             // This test verifies that different events can be processed separately
-            expect(triggerEventMock).toHaveBeenCalledTimes(subGiftedCalls.length);
+            expect(triggerEventMock).toHaveBeenCalledTimes(subGiftedCalls.length + 1); // +1 for webhook-received
         });
     });
 });

--- a/src/__tests__/moderation.test.ts
+++ b/src/__tests__/moderation.test.ts
@@ -2,7 +2,14 @@ export const triggerEventMock = jest.fn();
 
 jest.mock('../integration', () => ({
     integration: {
-        getSettings: jest.fn()
+        getSettings: jest.fn(),
+        kick: {
+            broadcaster: {
+                name: "You",
+                profilePicture: "https://your-profile-pic",
+                userId: 1234567890
+            }
+        }
     }
 }));
 
@@ -380,7 +387,7 @@ describe('e2e moderation banned', () => {
 
             it('triggers all expected events', async () => {
                 await expect(webhookHandler.handleWebhook(webhookTimeoutPayload)).resolves.not.toThrow();
-                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledTimes(3); // 1 integration + 1 twitch + 1 webhook-received
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "timeout", expectedWebhookTimeoutMetadata);
                 expect(triggerEventMock).toHaveBeenCalledWith("twitch", "timeout", expectedWebhookTimeoutMetadata);
             });
@@ -412,7 +419,7 @@ describe('e2e moderation banned', () => {
                     platform: 'kick'
                 };
                 await expect(webhookHandler.handleWebhook(webhookTimeoutPayloadDisabled)).resolves.not.toThrow();
-                expect(triggerEventMock).toHaveBeenCalledTimes(1);
+                expect(triggerEventMock).toHaveBeenCalledTimes(2); // 1 integration + 1 webhook-received
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "timeout", expectedWebhookTimeoutMetadataDisabled);
             });
         });
@@ -446,7 +453,7 @@ describe('e2e moderation banned', () => {
 
             it('triggers all expected events', async () => {
                 await expect(webhookHandler.handleWebhook(webhookBanPayload)).resolves.not.toThrow();
-                expect(triggerEventMock).toHaveBeenCalledTimes(2);
+                expect(triggerEventMock).toHaveBeenCalledTimes(3); // 1 integration + 1 twitch + 1 webhook-received
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "banned", expectedWebhookBanMetadata);
                 expect(triggerEventMock).toHaveBeenCalledWith("twitch", "banned", expectedWebhookBanMetadata);
             });
@@ -478,7 +485,7 @@ describe('e2e moderation banned', () => {
                     platform: 'kick'
                 };
                 await expect(webhookHandler.handleWebhook(webhookBanPayloadDisabled)).resolves.not.toThrow();
-                expect(triggerEventMock).toHaveBeenCalledTimes(1);
+                expect(triggerEventMock).toHaveBeenCalledTimes(2); // 1 integration + 1 webhook-received
                 expect(triggerEventMock).toHaveBeenCalledWith(IntegrationConstants.INTEGRATION_ID, "banned", expectedWebhookBanMetadataDisabled);
             });
         });

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -348,6 +348,17 @@ export const eventSource: EventSource = {
                     return `**${userDisplayName}** was **${action}** by **${moderator}**.`;
                 }
             }
+        },
+        {
+            id: "webhook-received",
+            name: "Kick Webhook Received",
+            description: "When a Kick webhook is received (this event is for advanced users looking to profile response time or debug webhook connectivity issues)",
+            cached: false,
+            manualMetadata: {
+                timestamp: new Date().toISOString(),
+                webhookType: "chat.message.sent",
+                webhookVersion: "1"
+            }
         }
     ]
 };

--- a/src/events/webhook-received.ts
+++ b/src/events/webhook-received.ts
@@ -1,0 +1,28 @@
+import { IntegrationConstants } from "../constants";
+import { integration } from "../integration";
+import { kickifyUserId, kickifyUsername, unkickifyUsername } from "../internal/util";
+import { firebot, logger } from "../main";
+import { WebhookReceivedEvent } from "../shared/types";
+
+export async function handleWebhookReceivedEvent(payload: WebhookReceivedEvent): Promise<void> {
+    const broadcaster = integration.kick.broadcaster;
+    let latencyMs = 0;
+    if (payload.timestamp) {
+        latencyMs = Date.now() - payload.timestamp.getTime();
+    }
+
+    const metadata = {
+        username: kickifyUsername(broadcaster?.name || "unknown"),
+        userId: kickifyUserId(broadcaster?.userId || "0"),
+        userDisplayName: unkickifyUsername(broadcaster?.name || "unknown"),
+        webhookType: payload.kickEventType,
+        webhookVersion: payload.kickEventVersion,
+        latencyMs: latencyMs,
+        platform: "kick"
+    };
+
+    // Trigger the webhook received event
+    const { eventManager } = firebot.modules;
+    eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "webhook-received", metadata);
+    logger.debug(`handleWebhookReceivedEvent: type=${payload.kickEventType}, version=${payload.kickEventVersion}, latency=${latencyMs}ms`);
+}

--- a/src/filters/webhook-received.ts
+++ b/src/filters/webhook-received.ts
@@ -1,0 +1,59 @@
+import { EventData, EventFilter, PresetValue } from "@crowbartools/firebot-custom-scripts-types/types/modules/event-filter-manager";
+import { IntegrationConstants } from "../constants";
+import { compareValue, ComparisonType } from "./common";
+
+export const webhookReceivedEventTypeFilter: EventFilter = {
+    id: `${IntegrationConstants.INTEGRATION_ID}:webhook-received-event-type`,
+    name: "Event Type",
+    description: "Checks if the event type of the received webhook matches the provided value.",
+    events: [
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "webhook-received" }
+    ],
+    comparisonTypes: ["is", "is not"],
+    valueType: "preset",
+    presetValues(): PresetValue[] {
+        return [
+            { value: "chat.message.sent", display: "chat.message.sent" },
+            { value: "channel.followed", display: "channel.followed" },
+            { value: "channel.subscription.renewal", display: "channel.subscription.renewal" },
+            { value: "channel.subscription.gifts", display: "channel.subscription.gifts" },
+            { value: "channel.subscription.new", display: "channel.subscription.new" },
+            { value: "livestream.metadata.updated", display: "livestream.metadata.updated" },
+            { value: "livestream.status.updated", display: "livestream.status.updated" },
+            { value: "moderation.banned", display: "moderation.banned" }
+        ];
+    },
+    predicate: async (
+        filterSettings,
+        eventData: EventData
+    ): Promise<boolean> => {
+        const { comparisonType, value } = filterSettings;
+        const match = eventData.eventMeta?.webhookType === String(value);
+        return (comparisonType === ComparisonType.IS as any) ? match : !match;
+    }
+};
+
+export const webhookReceivedLatencyFilter: EventFilter = {
+    id: `${IntegrationConstants.INTEGRATION_ID}:webhook-received-latency`,
+    name: "Latency (ms)",
+    description: "Checks the latency of the received webhook (in milliseconds).",
+    events: [
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "webhook-received" }
+    ],
+    comparisonTypes: [
+        ComparisonType.LESS_THAN,
+        ComparisonType.LESS_THAN_OR_EQUAL_TO,
+        ComparisonType.GREATER_THAN,
+        ComparisonType.GREATER_THAN_OR_EQUAL_TO
+    ],
+    valueType: "number",
+    predicate: async (
+        filterSettings,
+        eventData: EventData
+    ): Promise<boolean> => {
+        const { comparisonType, value } = filterSettings;
+        const latencyNumber = Number(eventData.eventMeta.latencyMs);
+        const latency = isNaN(latencyNumber) ? 0 : latencyNumber;
+        return compareValue("webhookReceivedLatencyFilter", comparisonType as ComparisonType, value, latency);
+    }
+};

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -55,6 +55,8 @@ import { kickTimeoutDurationVariable } from "./variables/timeout-duration";
 import { kickUnbanTypeVariable } from "./variables/unban-type";
 import { kickUptimeVariable } from "./variables/uptime";
 import { kickUserDisplayNameVariable } from "./variables/user-display-name";
+import { webhookReceivedEventTypeVariable, webhookReceivedEventVersionVariable, webhookReceivedLatencyVariable } from "./variables/webhook-received";
+import { webhookReceivedEventTypeFilter, webhookReceivedLatencyFilter } from "./filters/webhook-received";
 
 type IntegrationParameters = {
     connectivity: {
@@ -228,6 +230,8 @@ export class KickIntegration extends EventEmitter {
         eventFilterManager.registerFilter(rewardTitleFilter);
         eventFilterManager.registerFilter(streamerOrBotFilter);
         eventFilterManager.registerFilter(usernameFilter);
+        eventFilterManager.registerFilter(webhookReceivedEventTypeFilter);
+        eventFilterManager.registerFilter(webhookReceivedLatencyFilter);
 
         const { replaceVariableManager } = firebot.modules;
 
@@ -281,6 +285,11 @@ export class KickIntegration extends EventEmitter {
         replaceVariableManager.registerReplaceVariable(kickSubMonthsVariable);
         replaceVariableManager.registerReplaceVariable(kickSubStreakVariable);
         replaceVariableManager.registerReplaceVariable(kickSubTypeVariable);
+
+        // Webhook received and latency variables
+        replaceVariableManager.registerReplaceVariable(webhookReceivedEventTypeVariable);
+        replaceVariableManager.registerReplaceVariable(webhookReceivedEventVersionVariable);
+        replaceVariableManager.registerReplaceVariable(webhookReceivedLatencyVariable);
 
         // Miscellaneous variables
         replaceVariableManager.registerReplaceVariable(platformVariable);

--- a/src/internal/webhook-handler/webhook-handler.ts
+++ b/src/internal/webhook-handler/webhook-handler.ts
@@ -4,8 +4,10 @@ import { handleLivestreamMetadataUpdatedEvent } from "../../events/livestream-me
 import { livestreamStatusUpdatedHandler } from "../../events/livestream-status-updated";
 import { moderationBannedEventHandler } from "../../events/moderation-banned";
 import { handleChannelSubscriptionEvent, handleChannelSubscriptionGiftsEvent } from "../../events/sub-events";
+import { handleWebhookReceivedEvent } from "../../events/webhook-received";
 import { integration } from "../../integration";
 import { logger } from "../../main";
+import { parseDate } from "../util";
 import { parseChannelSubscriptionGiftsEvent, parseChannelSubscriptionNewEvent, parseChannelSubscriptionRenewalEvent, parseChatMessageEvent, parseFollowEvent, parseLivestreamMetadataUpdatedEvent, parseLivestreamStatusUpdatedEvent, parseModerationBannedEvent, parsePusherTestWebhook } from "./webhook-parsers";
 import NodeCache from 'node-cache';
 
@@ -34,6 +36,15 @@ export class WebhookHandler {
             return;
         }
         this.webhookCache.set(payloadHash, true);
+
+        // For performance checks and other debugging on webhooks
+        const webhookReceivedEvent = {
+            kickEventType: webhook.kick_event_type,
+            kickEventVersion: webhook.kick_event_version,
+            isTestEvent: webhook.is_test_event || false,
+            timestamp: parseDate(webhook.kick_event_message_timestamp) || null
+        };
+        handleWebhookReceivedEvent(webhookReceivedEvent);
 
         // This is NOT intended to be for security, since you are implicitly
         // trusting the proxy owner and they could just send you fake data. Rather,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -174,3 +174,10 @@ export interface ModerationUnbannedEvent {
     moderator: KickUser;
     banType: "timeout" | "permanent";
 }
+
+export interface WebhookReceivedEvent {
+    kickEventType: string;
+    kickEventVersion: string;
+    isTestEvent: boolean;
+    timestamp: Date | null;
+}

--- a/src/variables/webhook-received.ts
+++ b/src/variables/webhook-received.ts
@@ -1,0 +1,69 @@
+import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { IntegrationConstants } from "../constants";
+
+export const webhookReceivedEventTypeVariable: ReplaceVariable = {
+    definition: {
+        handle: "webhookReceivedEventType",
+        description: "Outputs the event type of the received webhook.",
+        examples: [
+            {
+                usage: "webhookReceivedEventType",
+                description: "The type of the received webhook event."
+            }
+        ],
+        categories: ["common"],
+        possibleDataOutput: ["text"],
+        triggers: {
+            "manual": true,
+            "event": [`${IntegrationConstants.INTEGRATION_ID}:webhook-received`]
+        }
+    },
+    evaluator: (trigger: Effects.Trigger) => {
+        return trigger.metadata.eventData?.webhookType || "";
+    }
+};
+
+export const webhookReceivedEventVersionVariable: ReplaceVariable = {
+    definition: {
+        handle: "webhookReceivedEventVersion",
+        description: "Outputs the event version of the received webhook.",
+        examples: [
+            {
+                usage: "webhookReceivedEventVersion",
+                description: "The version of the received webhook event."
+            }
+        ],
+        categories: ["common"],
+        possibleDataOutput: ["text"],
+        triggers: {
+            "manual": true,
+            "event": [`${IntegrationConstants.INTEGRATION_ID}:webhook-received`]
+        }
+    },
+    evaluator: (trigger: Effects.Trigger) => {
+        return trigger.metadata?.eventData?.webhookVersion || "";
+    }
+};
+
+export const webhookReceivedLatencyVariable: ReplaceVariable = {
+    definition: {
+        handle: "webhookReceivedLatency",
+        description: "Outputs the latency of the received webhook event (in milliseconds).",
+        examples: [
+            {
+                usage: "webhookReceivedLatency",
+                description: "The latency of the received webhook event (in milliseconds)."
+            }
+        ],
+        categories: ["common"],
+        possibleDataOutput: ["number"],
+        triggers: {
+            "manual": true,
+            "event": [`${IntegrationConstants.INTEGRATION_ID}:webhook-received`]
+        }
+    },
+    evaluator: (trigger: Effects.Trigger) => {
+        return trigger.metadata?.eventData?.latencyMs || 0;
+    }
+};


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Add a "webhook received" event and corresponding variables (including latency) and filters (on event type and latency).

### Motivation
Kick webhooks are _frequently_ delayed, sometimes by several minutes or more. This event, plus a filter, will allow a streamer to know when webhooks are delayed, so they can adjust their attention accordingly.

### Testing
1. Tested with several events including a filter
2. Added this to the end-to-end test for the stream-online and stream-offline events (these are simple events so we snuck in the test here rather than creating a dedicated test, which would have had to call one of the real events anyway)
