### PR TITLE
Platform-independent role condition looks up in real time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "GNU3",
             "dependencies": {
                 "@seald-io/nedb": "^4.1.2",
+                "@twurple/api": "^7.4.0",
                 "node-cache": "^5.1.2",
                 "node-json-db": "^1.6.0",
                 "pusher-js": "^8.4.0"
@@ -1002,7 +1003,7 @@
         },
         "node_modules/@crowbartools/firebot-custom-scripts-types": {
             "version": "5.64.0",
-            "resolved": "git+ssh://git@github.com/TheStaticMage/firebot-custom-scripts-types.git#9f2a4fd4aadd32281e4c3259dbebce83856435e5",
+            "resolved": "git+ssh://git@github.com/TheStaticMage/firebot-custom-scripts-types.git#fca17ac74418297c65883c065c13be5179a4f1ae",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1019,7 +1020,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-4.0.1.tgz",
             "integrity": "sha512-HNYLBLWs/t28GFZZeqdIBqq8f37mqDIFO6xNPof94VjpKvuP6ROqCZGafx88dk5zZUlBfViV9jD8iNNlXfc4CA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@d-fischer/shared-utils": "^3.6.3",
@@ -1030,7 +1030,6 @@
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/@d-fischer/cross-fetch/-/cross-fetch-5.0.5.tgz",
             "integrity": "sha512-symjDUPInTrkfIsZc2n2mo9hiAJLcTJsZkNICjZajEWnWpJ3s3zn50/FY8xpNUAf5w3eFuQii2wxztTGpvG1Xg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "node-fetch": "^2.6.12"
@@ -1040,14 +1039,12 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@d-fischer/detect-node/-/detect-node-3.0.1.tgz",
             "integrity": "sha512-0Rf3XwTzuTh8+oPZW9SfxTIiL+26RRJ0BRPwj5oVjZFyFKmsj9RGfN2zuTRjOuA3FCK/jYm06HOhwNK+8Pfv8w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@d-fischer/logger": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.2.3.tgz",
             "integrity": "sha512-mJUx9OgjrNVLQa4od/+bqnmD164VTCKnK5B4WOW8TX5y/3w2i58p+PMRE45gUuFjk2BVtOZUg55JQM3d619fdw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@d-fischer/detect-node": "^3.0.1",
@@ -1062,7 +1059,6 @@
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/@d-fischer/qs/-/qs-7.0.2.tgz",
             "integrity": "sha512-yAu3xDooiL+ef84Jo8nLjDjWBRk7RXk163Y6aTvRB7FauYd3spQD/dWvgT7R4CrN54Juhrrc3dMY7mc+jZGurQ==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.6"
@@ -1075,7 +1071,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@d-fischer/rate-limiter/-/rate-limiter-1.1.0.tgz",
             "integrity": "sha512-O5HgACwApyCZhp4JTEBEtbv/W3eAwEkrARFvgWnEsDmXgCMWjIHwohWoHre5BW6IYXFSHBGsuZB/EvNL3942kQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@d-fischer/logger": "^4.2.3",
@@ -1090,7 +1085,6 @@
             "version": "3.6.4",
             "resolved": "https://registry.npmjs.org/@d-fischer/shared-utils/-/shared-utils-3.6.4.tgz",
             "integrity": "sha512-BPkVLHfn2Lbyo/ENDBwtEB8JVQ+9OzkjJhUunLaxkw4k59YFlQxUUwlDBejVSFcpQT0t+D3CQlX+ySZnQj0wxw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.4.1"
@@ -1103,7 +1097,6 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/@d-fischer/typed-event-emitter/-/typed-event-emitter-3.3.3.tgz",
             "integrity": "sha512-OvSEOa8icfdWDqcRtjSEZtgJTFOFNgTjje7zaL0+nAtu2/kZtRCSK5wUMrI/aXtCH8o0Qz2vA8UqkhWUTARFQQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.4.0"
@@ -2188,10 +2181,9 @@
             }
         },
         "node_modules/@twurple/api": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@twurple/api/-/api-7.3.0.tgz",
-            "integrity": "sha512-QtaVgYi50E3AB/Nxivjou/u6w1cuQ6g4R8lzQawYDaQNtlP2Ue8vvYuSp2PfxSpe8vNiKhgV8hZAs+j4V29sxQ==",
-            "dev": true,
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@twurple/api/-/api-7.4.0.tgz",
+            "integrity": "sha512-RlXLs4ZvS8n0+iIk7YyVDwrjhlwpn+N+h7fX5Q61HoxlmzoCShmnnFo03abYw9i8Cc3deGpbQATOSVmigXM4qg==",
             "license": "MIT",
             "dependencies": {
                 "@d-fischer/cache-decorators": "^4.0.0",
@@ -2201,8 +2193,8 @@
                 "@d-fischer/rate-limiter": "^1.1.0",
                 "@d-fischer/shared-utils": "^3.6.1",
                 "@d-fischer/typed-event-emitter": "^3.3.1",
-                "@twurple/api-call": "7.3.0",
-                "@twurple/common": "7.3.0",
+                "@twurple/api-call": "7.4.0",
+                "@twurple/common": "7.4.0",
                 "retry": "^0.13.1",
                 "tslib": "^2.0.3"
             },
@@ -2210,20 +2202,19 @@
                 "url": "https://github.com/sponsors/d-fischer"
             },
             "peerDependencies": {
-                "@twurple/auth": "7.3.0"
+                "@twurple/auth": "7.4.0"
             }
         },
         "node_modules/@twurple/api-call": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@twurple/api-call/-/api-call-7.3.0.tgz",
-            "integrity": "sha512-nx389kXjVphAeR3RfnzkRRf7Qa45wqHla067/mr3YxnUICCg4YOFv0Jb5UohQGHkj5h18mDZ3iUu/x2J49c1lA==",
-            "dev": true,
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@twurple/api-call/-/api-call-7.4.0.tgz",
+            "integrity": "sha512-WNxvjp/hMqZREElbvE4rHMyUIrHdGY5cbG8xbqgSM9CESFvJ1wm5BubhyANOyKd1TxABacLddbfbO//Fz9YHgA==",
             "license": "MIT",
             "dependencies": {
                 "@d-fischer/cross-fetch": "^5.0.1",
                 "@d-fischer/qs": "^7.0.2",
                 "@d-fischer/shared-utils": "^3.6.1",
-                "@twurple/common": "7.3.0",
+                "@twurple/common": "7.4.0",
                 "tslib": "^2.0.3"
             },
             "funding": {
@@ -2231,17 +2222,16 @@
             }
         },
         "node_modules/@twurple/auth": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-7.3.0.tgz",
-            "integrity": "sha512-K68nFbQswfaEVCWP2MEPcxhHRR/N8kIHBP6AnRXzgSpmvWxhjOitz9oyP04di5DI1rJE+2NRauv1qFDyYia/qg==",
-            "dev": true,
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-7.4.0.tgz",
+            "integrity": "sha512-WAQV6nJGkfY7r2BkRYhnzUpdfozLvjNsCxkyNVprl4dCWdJzccnTvqkKTdDRJc5ZJxDVaB9Drzwx9/fCp/gRDA==",
             "license": "MIT",
             "dependencies": {
                 "@d-fischer/logger": "^4.2.1",
                 "@d-fischer/shared-utils": "^3.6.1",
                 "@d-fischer/typed-event-emitter": "^3.3.1",
-                "@twurple/api-call": "7.3.0",
-                "@twurple/common": "7.3.0",
+                "@twurple/api-call": "7.4.0",
+                "@twurple/common": "7.4.0",
                 "tslib": "^2.0.3"
             },
             "funding": {
@@ -2249,10 +2239,9 @@
             }
         },
         "node_modules/@twurple/common": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@twurple/common/-/common-7.3.0.tgz",
-            "integrity": "sha512-BGNniY7PBIohxfpRQ1bsOxUaktZcXZOExq8ojCtnsNBVDlchNEX2fYsere03ZwTLd48XBtxsdaUaeQXbx1aXLw==",
-            "dev": true,
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@twurple/common/-/common-7.4.0.tgz",
+            "integrity": "sha512-lX5cVkYar6jGvni6iLmMYjhxH1oPSl2v7XVeZ4C7U1GbLz/Jwk0L0uldQNGUIf9gpRHPY+TXRlk0UIpz2yo8DA==",
             "license": "MIT",
             "dependencies": {
                 "@d-fischer/shared-utils": "^3.6.1",
@@ -7175,7 +7164,6 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
             "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -8483,7 +8471,6 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
@@ -9273,7 +9260,6 @@
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
             "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -10058,7 +10044,6 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/ts-api-utils": {
@@ -10198,7 +10183,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tweetnacl": {
@@ -10516,7 +10500,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
@@ -10674,7 +10657,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     },
     "dependencies": {
         "@seald-io/nedb": "^4.1.2",
+        "@twurple/api": "^7.4.0",
         "node-cache": "^5.1.2",
         "node-json-db": "^1.6.0",
         "pusher-js": "^8.4.0"

--- a/src/conditions/viewer-roles.ts
+++ b/src/conditions/viewer-roles.ts
@@ -1,9 +1,7 @@
 import { ConditionType } from "@crowbartools/firebot-custom-scripts-types/types/modules/condition-manager";
-import { FirebotViewer } from "@crowbartools/firebot-custom-scripts-types/types/modules/viewer-database";
 import { IntegrationConstants } from "../constants";
 import { integration } from "../integration-singleton";
-import { kickifyUserId, unkickifyUserId, unkickifyUsername } from "../internal/util";
-import { firebot, logger } from "../main";
+import { logger } from "../main";
 import { platformVariable } from "../variables/platform";
 
 export const viewerRolesCondition: ConditionType<any, any, any> = {
@@ -15,25 +13,43 @@ export const viewerRolesCondition: ConditionType<any, any, any> = {
     leftSideTextPlaceholder: "Enter username",
     rightSideValueType: "preset",
     getRightSidePresetValues: (viewerRolesService: any) => {
-        return viewerRolesService.getAllRoles()
+        return [
+            { value: "broadcaster", display: "Broadcaster [Platform Aware]" },
+            { value: "bot", display: "Stream Bot [Platform Aware]" },
+            { value: "mod", display: "Moderator [Platform Aware]" },
+            { value: "vip", display: "VIP [Platform Aware]" },
+            { value: "sub", display: "Subscriber [Platform Aware]" }
+        ].concat(viewerRolesService.getCustomRoles()
             .map((r: { id: any; name: any; }) => ({
                 value: r.id,
                 display: r.name
-            }));
+            })));
     },
     valueIsStillValid: (condition, viewerRolesService: any) => {
-        const role = viewerRolesService.getAllRoles()
-            .find((r: { id: string | number; }) => r.id === condition.rightSideValue);
-
-        return role != null && role.name != null;
+        if (typeof condition.rightSideValue === "string" && condition.rightSideValue.length === 36) {
+            return viewerRolesService.getCustomRoles()
+                .some((r: { id: any; name: any; }) => r.id === condition.rightSideValue);
+        }
+        return true;
     },
     getRightSideValueDisplay: (condition, viewerRolesService: any) => {
-        const role = viewerRolesService.getAllRoles()
-            .find((r: { id: string | number; }) => r.id === condition.rightSideValue);
-        if (role && role.name != null) {
-            return `${role.name} [Platform Aware]`;
+        const v = [
+            { value: "broadcaster", display: "Broadcaster [Platform Aware]" },
+            { value: "bot", display: "Stream Bot [Platform Aware]" },
+            { value: "mod", display: "Moderator [Platform Aware]" },
+            { value: "vip", display: "VIP [Platform Aware]" },
+            { value: "sub", display: "Subscriber [Platform Aware]" }
+        ].concat(viewerRolesService.getCustomRoles()
+            .map((r: { id: any; name: any; }) => ({
+                value: r.id,
+                display: r.name
+            })));
+
+        const preset = v.find(vv => vv.value === condition.rightSideValue);
+        if (preset) {
+            return String(preset.display);
         }
-        return `${String(condition.rightSideValue)} [Platform Aware]`;
+        return String(condition.rightSideValue);
     },
     predicate: async (conditionSettings, trigger) => {
         const { comparisonType, leftSideValue, rightSideValue } = conditionSettings;
@@ -52,76 +68,12 @@ export const viewerRolesCondition: ConditionType<any, any, any> = {
             platform = "";
         }
 
-        // Attempt to guess platform if not provided
-        if (platform === "unknown" || platform === "") {
-            if (typeof userNameOrId === "string" && isNaN(Number(unkickifyUserId(userNameOrId))) && unkickifyUsername(userNameOrId) !== userNameOrId) {
-                platform = "kick";
-            } else if (typeof userNameOrId === "string" && !isNaN(Number(unkickifyUserId(userNameOrId))) && unkickifyUserId(userNameOrId) !== userNameOrId) {
-                platform = "kick";
-            } else {
-                platform = "twitch";
-            }
-        }
-
-        logger.debug(`viewerroles condition: Checking viewer roles condition for: ${userNameOrId} for role ${rightSideValue} with comparison ${comparisonType} on platform ${platform}`);
-        let userId = "";
-        let viewer: FirebotViewer | undefined;
-
-        try {
-            if (platform === "kick") {
-                if (typeof userNameOrId === "string" && isNaN(Number(unkickifyUserId(userNameOrId)))) {
-                    logger.debug(`viewerroles condition: Looking up Kick viewer by username: ${userNameOrId}`);
-                    viewer = await integration.kick.userManager.getViewerByUsername(userNameOrId);
-                } else {
-                    logger.debug(`viewerroles condition: Looking up Kick viewer by userId: ${userNameOrId}`);
-                    viewer = await integration.kick.userManager.getViewerById(unkickifyUserId(userNameOrId));
-                }
-                if (viewer) {
-                    userId = kickifyUserId(viewer._id);
-                }
-            } else {
-                const { viewerDatabase } = firebot.modules;
-                if (typeof userNameOrId === "string" && isNaN(Number(userNameOrId))) {
-                    logger.debug(`viewerroles condition: Looking up Twitch viewer by username: ${userNameOrId}`);
-                    viewer = await viewerDatabase.getViewerByUsername(userNameOrId);
-                } else {
-                    logger.debug(`viewerroles condition: Looking up Twitch viewer by userId: ${userNameOrId}`);
-                    viewer = await viewerDatabase.getViewerById(unkickifyUserId(userNameOrId));
-                }
-                if (viewer) {
-                    userId = viewer._id;
-                }
-            }
-        } catch (error) {
-            logger.error(`viewerroles condition: Error looking up viewer ${userNameOrId} on platform ${platform}: ${error}`);
-            return false;
-        }
-
-        if (!viewer || !userId) {
-            logger.warn(`viewerroles condition: No Twitch viewer found for: ${userNameOrId} on platform ${platform}`);
-            return false;
-        }
-
-        let hasRole = false;
-
-        if (typeof rightSideValue === "string" && rightSideValue.length === 36) { // Custom roles are UUIDs whereas built-in roles are simple strings
-            try {
-                const { customRolesManager } = firebot.modules;
-                hasRole = customRolesManager.userIsInRole(userId, [], [rightSideValue]);
-                logger.debug(`viewerroles condition: Checking custom role ${rightSideValue} for user ${userId} (${platform}), result=${hasRole}`);
-            } catch (error) {
-                logger.error(`viewerroles condition: Error checking custom role ${rightSideValue} for user ${userId} (${platform}): ${error}`);
-                return false;
-            }
-        } else {
-            hasRole = viewer?.twitchRoles.includes(String(rightSideValue));
-            logger.debug(`viewerroles condition: Checking Twitch role ${rightSideValue} for user ${userId} (${platform}), roles: ${viewer?.twitchRoles.join(", ")}, result=${hasRole}`);
-        }
-
+        // Call the role manager to check if the user has the role
+        const hasRole = await integration.kick.roleManager.userHasRole(platform, userNameOrId, String(rightSideValue));
         if (hasRole) {
             logger.debug(`viewerroles condition: Viewer ${userNameOrId} (${platform}) has role ${rightSideValue}`);
         } else {
-            logger.debug(`viewerroles condition: Viewer ${userNameOrId} (${platform}) does NOT have role ${rightSideValue} (roles: ${viewer?.twitchRoles.join(", ")})`);
+            logger.debug(`viewerroles condition: Viewer ${userNameOrId} (${platform}) does NOT have role ${rightSideValue}`);
         }
 
         switch (comparisonType) {

--- a/src/internal/__tests__/role-manager.test.ts
+++ b/src/internal/__tests__/role-manager.test.ts
@@ -1,0 +1,982 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+jest.mock('../../main', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+    },
+    firebot: {
+        modules: {
+            twitchApi: {
+                users: {
+                    getUserByName: jest.fn()
+                },
+                getClient: jest.fn(() => ({
+                    subscriptions: {
+                        getSubscriptionForUser: jest.fn()
+                    }
+                })),
+                moderation: {
+                    getModerators: jest.fn()
+                },
+                channels: {
+                    getVips: jest.fn()
+                }
+            },
+            customRolesManager: {
+                userIsInRole: jest.fn()
+            }
+        },
+        firebot: {
+            accounts: {
+                streamer: {
+                    userId: '1000000000',
+                    username: 'TestStreamer'
+                },
+                bot: {
+                    userId: '2000000000',
+                    username: 'TestBot'
+                }
+            }
+        }
+    }
+}));
+
+import { RoleManager } from '../role-manager';
+import { IKick } from '../kick-interface';
+import { FirebotViewer } from '@crowbartools/firebot-custom-scripts-types/types/modules/viewer-database';
+import { firebot } from '../../main';
+
+// Mock the kick interface
+const mockKick: jest.Mocked<IKick> = {
+    broadcaster: {
+        email: 'broadcaster@example.com',
+        name: 'TestKickBroadcaster',
+        profilePicture: 'https://example.com/broadcaster.jpg',
+        userId: 1000000001
+    },
+    bot: {
+        email: 'bot@example.com',
+        name: 'TestKickBot',
+        profilePicture: 'https://example.com/bot.jpg',
+        userId: 2000000001
+    },
+    userManager: {
+        getViewerById: jest.fn(),
+        getViewerByUsername: jest.fn()
+    },
+    channelManager: {} as any,
+    chatManager: {} as any,
+    userApi: {} as any,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    getAuthToken: jest.fn(),
+    setAuthToken: jest.fn(),
+    getBotAuthToken: jest.fn(),
+    setBotAuthToken: jest.fn(),
+    httpCallWithTimeout: jest.fn()
+};
+
+// Create proper mock clients for nested structures
+const mockSubscriptionClient = {
+    getSubscriptionForUser: jest.fn()
+};
+
+describe('RoleManager', () => {
+    let roleManager: RoleManager;
+
+    const createMockViewer = (overrides: Partial<FirebotViewer> = {}): FirebotViewer => ({
+        _id: '123456789',
+        username: 'testuser',
+        displayName: 'TestUser',
+        profilePicUrl: '',
+        twitch: true,
+        twitchRoles: ['mod'],
+        online: false,
+        onlineAt: 0,
+        lastSeen: 0,
+        joinDate: 0,
+        minutesInChannel: 0,
+        chatMessages: 0,
+        disableAutoStatAccrual: false,
+        disableActiveUserList: false,
+        disableViewerList: false,
+        metadata: {},
+        currency: {},
+        ranks: {},
+        ...overrides
+    });
+
+    beforeEach(() => {
+        roleManager = new RoleManager(mockKick);
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+
+        // Setup the nested mock structure
+        (firebot.modules.twitchApi.getClient as jest.Mock).mockReturnValue({
+            subscriptions: mockSubscriptionClient
+        });
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('twitchUserHasRole', () => {
+        describe('custom roles (UUID-based)', () => {
+            it('checks custom role for user ID', async () => {
+                const customRolesManager = firebot.modules.customRolesManager as jest.Mocked<typeof firebot.modules.customRolesManager>;
+                customRolesManager.userIsInRole.mockReturnValue(true);
+
+                const result = await roleManager.twitchUserHasRole('123456789', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(true);
+                expect(customRolesManager.userIsInRole).toHaveBeenCalledWith('123456789', [], ['12345678-1234-1234-1234-123456789012']);
+            });
+
+            it('checks custom role for username by looking up user ID', async () => {
+                const customRolesManager = firebot.modules.customRolesManager as jest.Mocked<typeof firebot.modules.customRolesManager>;
+
+                (firebot.modules.twitchApi.users.getUserByName as jest.Mock).mockResolvedValue({ id: '123456789' } as any);
+                customRolesManager.userIsInRole.mockReturnValue(true);
+
+                const result = await roleManager.twitchUserHasRole('testuser', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(true);
+                expect(firebot.modules.twitchApi.users.getUserByName).toHaveBeenCalledWith('testuser');
+                expect(customRolesManager.userIsInRole).toHaveBeenCalledWith('123456789', [], ['12345678-1234-1234-1234-123456789012']);
+            });
+
+            it('returns false when customRolesManager returns false', async () => {
+                const customRolesManager = firebot.modules.customRolesManager as jest.Mocked<typeof firebot.modules.customRolesManager>;
+                customRolesManager.userIsInRole.mockReturnValue(false);
+
+                const result = await roleManager.twitchUserHasRole('123456789', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(false);
+            });
+
+            it('handles errors when looking up username for custom role', async () => {
+                (firebot.modules.twitchApi.users.getUserByName as jest.Mock).mockRejectedValue(new Error('User not found'));
+
+                const result = await roleManager.twitchUserHasRole('testuser', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(false);
+            });
+
+            it('handles errors in customRolesManager', async () => {
+                const customRolesManager = firebot.modules.customRolesManager as jest.Mocked<typeof firebot.modules.customRolesManager>;
+                customRolesManager.userIsInRole.mockImplementation(() => {
+                    throw new Error('Custom roles error');
+                });
+
+                const result = await roleManager.twitchUserHasRole('123456789', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(false);
+            });
+        });
+
+        describe('built-in roles', () => {
+            describe('broadcaster role', () => {
+                it('returns false for non-broadcaster by user ID', async () => {
+                    const result = await roleManager.twitchUserHasRole('123456789', 'broadcaster');
+                    expect(result).toBe(false);
+                });
+
+                it('returns true for broadcaster by username', async () => {
+                    const result = await roleManager.twitchUserHasRole('teststreamer', 'broadcaster');
+                    expect(result).toBe(true);
+                });
+
+                it('returns true for broadcaster when user ID matches (non-numeric)', async () => {
+                    const result = await roleManager.twitchUserHasRole('1000000000', 'broadcaster');
+                    expect(result).toBe(true);
+                });
+
+                it('returns true for broadcaster when user ID matches (numeric)', async () => {
+                    const result = await roleManager.twitchUserHasRole(1000000000, 'broadcaster');
+                    expect(result).toBe(true);
+                });
+
+                it('returns false for non-broadcaster (numeric)', async () => {
+                    const result = await roleManager.twitchUserHasRole(420, 'broadcaster');
+                    expect(result).toBe(false);
+                });
+
+                it('returns false for non-broadcaster', async () => {
+                    const result = await roleManager.twitchUserHasRole('other-user-id', 'broadcaster');
+                    expect(result).toBe(false);
+                });
+
+                it('returns false when broadcaster userId is not available', async () => {
+                    // Temporarily clear broadcaster userId
+                    const originalUserId = firebot.firebot.accounts.streamer.userId;
+                    (firebot.firebot.accounts.streamer as any).userId = undefined;
+
+                    const result = await roleManager.twitchUserHasRole('1000000000', 'broadcaster');
+                    expect(result).toBe(false);
+
+                    // Restore original value
+                    firebot.firebot.accounts.streamer.userId = originalUserId;
+                });
+
+                it('returns false when broadcaster username is not available', async () => {
+                    // Temporarily clear broadcaster username
+                    const originalUsername = firebot.firebot.accounts.streamer.username;
+                    (firebot.firebot.accounts.streamer as any).username = undefined;
+
+                    const result = await roleManager.twitchUserHasRole('teststreamer', 'broadcaster');
+                    expect(result).toBe(false);
+
+                    // Restore original value
+                    firebot.firebot.accounts.streamer.username = originalUsername;
+                });
+
+                it('returns false when both broadcaster userId and username are not available', async () => {
+                    // Temporarily clear both broadcaster userId and username
+                    const originalUserId = firebot.firebot.accounts.streamer.userId;
+                    const originalUsername = firebot.firebot.accounts.streamer.username;
+                    (firebot.firebot.accounts.streamer as any).userId = undefined;
+                    (firebot.firebot.accounts.streamer as any).username = undefined;
+
+                    const result = await roleManager.twitchUserHasRole('teststreamer', 'broadcaster');
+                    expect(result).toBe(false);
+
+                    // Restore original values
+                    firebot.firebot.accounts.streamer.userId = originalUserId;
+                    firebot.firebot.accounts.streamer.username = originalUsername;
+                });
+            });
+
+            describe('bot role', () => {
+                it('returns true for bot by user ID', async () => {
+                    const result = await roleManager.twitchUserHasRole('2000000000', 'bot');
+                    expect(result).toBe(true);
+                });
+
+                it('returns true for bot by username', async () => {
+                    const result = await roleManager.twitchUserHasRole('testbot', 'bot');
+                    expect(result).toBe(true);
+                });
+
+                it('returns true for bot when user ID matches (numeric)', async () => {
+                    const result = await roleManager.twitchUserHasRole(2000000000, 'bot');
+                    expect(result).toBe(true);
+                });
+
+                it('returns false for non-bot by user ID', async () => {
+                    const result = await roleManager.twitchUserHasRole('123456789', 'bot');
+                    expect(result).toBe(false);
+                });
+
+                it('returns false for non-bot by username', async () => {
+                    const result = await roleManager.twitchUserHasRole('regularuser', 'bot');
+                    expect(result).toBe(false);
+                });
+
+                it('returns false for non-bot (numeric)', async () => {
+                    const result = await roleManager.twitchUserHasRole(420, 'bot');
+                    expect(result).toBe(false);
+                });
+
+                it('returns true when comparing bot username with different case', async () => {
+                    const result = await roleManager.twitchUserHasRole('TESTBOT', 'bot');
+                    expect(result).toBe(true);
+                });
+
+                it('returns false when comparing non-bot with mixed case', async () => {
+                    const result = await roleManager.twitchUserHasRole('OTHERUSER', 'bot');
+                    expect(result).toBe(false);
+                });
+
+                it('returns false when bot userId is not available', async () => {
+                    // Temporarily clear bot userId
+                    const originalUserId = firebot.firebot.accounts.bot.userId;
+                    (firebot.firebot.accounts.bot as any).userId = undefined;
+
+                    const result = await roleManager.twitchUserHasRole('2000000000', 'bot');
+                    expect(result).toBe(false);
+
+                    // Restore original value
+                    firebot.firebot.accounts.bot.userId = originalUserId;
+                });
+
+                it('returns false when bot username is not available', async () => {
+                    // Temporarily clear bot username
+                    const originalUsername = firebot.firebot.accounts.bot.username;
+                    (firebot.firebot.accounts.bot as any).username = undefined;
+
+                    const result = await roleManager.twitchUserHasRole('testbot', 'bot');
+                    expect(result).toBe(false);
+
+                    // Restore original value
+                    firebot.firebot.accounts.bot.username = originalUsername;
+                });
+
+                it('returns false when both bot userId and username are not available', async () => {
+                    // Temporarily clear both bot userId and username
+                    const originalUserId = firebot.firebot.accounts.bot.userId;
+                    const originalUsername = firebot.firebot.accounts.bot.username;
+                    (firebot.firebot.accounts.bot as any).userId = undefined;
+                    (firebot.firebot.accounts.bot as any).username = undefined;
+
+                    const result = await roleManager.twitchUserHasRole('testbot', 'bot');
+                    expect(result).toBe(false);
+
+                    // Restore original values
+                    firebot.firebot.accounts.bot.userId = originalUserId;
+                    firebot.firebot.accounts.bot.username = originalUsername;
+                });
+            });
+
+            describe('moderator role', () => {
+                it('returns true when user is a moderator by ID', async () => {
+                    (firebot.modules.twitchApi.moderation.getModerators as jest.Mock).mockResolvedValue([
+                        { userId: '123456789', userName: 'testmod' }
+                    ] as any);
+
+                    const result = await roleManager.twitchUserHasRole('123456789', 'mod');
+
+                    expect(result).toBe(true);
+                    expect(firebot.modules.twitchApi.moderation.getModerators).toHaveBeenCalled();
+                });
+
+                it('returns true when user is a moderator by username', async () => {
+                    (firebot.modules.twitchApi.moderation.getModerators as jest.Mock).mockResolvedValue([
+                        { userId: '123456789', userName: 'testmod' }
+                    ] as any);
+
+                    const result = await roleManager.twitchUserHasRole('testmod', 'mod');
+
+                    expect(result).toBe(true);
+                });
+
+                it('returns false when user is not a moderator', async () => {
+                    (firebot.modules.twitchApi.moderation.getModerators as jest.Mock).mockResolvedValue([
+                        { userId: '987654321', userName: 'othermod' }
+                    ] as any);
+
+                    const result = await roleManager.twitchUserHasRole('123456789', 'mod');
+
+                    expect(result).toBe(false);
+                });
+            });
+
+            describe('VIP role', () => {
+                it('returns true when user is a VIP by ID', async () => {
+                    (firebot.modules.twitchApi.channels.getVips as jest.Mock).mockResolvedValue([
+                        { id: '123456789', name: 'testvip' }
+                    ] as any);
+
+                    const result = await roleManager.twitchUserHasRole('123456789', 'vip');
+
+                    expect(result).toBe(true);
+                    expect(firebot.modules.twitchApi.channels.getVips).toHaveBeenCalled();
+                });
+
+                it('returns true when user is a VIP by username', async () => {
+                    (firebot.modules.twitchApi.channels.getVips as jest.Mock).mockResolvedValue([
+                        { id: '123456789', name: 'testvip' }
+                    ] as any);
+
+                    const result = await roleManager.twitchUserHasRole('testvip', 'vip');
+
+                    expect(result).toBe(true);
+                });
+
+                it('returns false when user is not a VIP', async () => {
+                    (firebot.modules.twitchApi.channels.getVips as jest.Mock).mockResolvedValue([
+                        { id: '987654321', name: 'othervip' }
+                    ] as any);
+
+                    const result = await roleManager.twitchUserHasRole('123456789', 'vip');
+
+                    expect(result).toBe(false);
+                });
+            });
+
+            describe('subscriber role', () => {
+                it('returns true when user is a subscriber by ID', async () => {
+                    mockSubscriptionClient.getSubscriptionForUser.mockResolvedValue({ tier: '1000' } as any);
+
+                    const result = await roleManager.twitchUserHasRole('123456789', 'sub');
+
+                    expect(result).toBe(true);
+                    expect(mockSubscriptionClient.getSubscriptionForUser).toHaveBeenCalledWith('1000000000', '123456789');
+                });
+
+                it('returns true when user is a subscriber by username', async () => {
+                    (firebot.modules.twitchApi.users.getUserByName as jest.Mock).mockResolvedValue({ id: '123456789' } as any);
+                    mockSubscriptionClient.getSubscriptionForUser.mockResolvedValue({ tier: '1000' } as any);
+
+                    const result = await roleManager.twitchUserHasRole('testuser', 'sub');
+
+                    expect(result).toBe(true);
+                    expect(firebot.modules.twitchApi.users.getUserByName).toHaveBeenCalledWith('testuser');
+                    expect(mockSubscriptionClient.getSubscriptionForUser).toHaveBeenCalledWith('1000000000', '123456789');
+                });
+
+                it('returns false when user is not a subscriber', async () => {
+                    mockSubscriptionClient.getSubscriptionForUser.mockResolvedValue(null);
+
+                    const result = await roleManager.twitchUserHasRole('123456789', 'sub');
+
+                    expect(result).toBe(false);
+                });
+
+                it('handles subscription lookup errors', async () => {
+                    mockSubscriptionClient.getSubscriptionForUser.mockRejectedValue(new Error('API error'));
+
+                    const result = await roleManager.twitchUserHasRole('123456789', 'sub');
+
+                    expect(result).toBe(false);
+                });
+
+                it('handles username lookup errors for subscriber check', async () => {
+                    (firebot.modules.twitchApi.users.getUserByName as jest.Mock).mockRejectedValue(new Error('User not found'));
+
+                    const result = await roleManager.twitchUserHasRole('testuser', 'sub');
+
+                    expect(result).toBe(false);
+                });
+            });
+        });
+
+        describe('invalid inputs', () => {
+            it('returns false for empty user identifier', async () => {
+                const result = await roleManager.twitchUserHasRole('', 'mod');
+                expect(result).toBe(false);
+            });
+
+            it('returns false for unknown role', async () => {
+                const result = await roleManager.twitchUserHasRole('123456789', 'unknown-role');
+                expect(result).toBe(false);
+            });
+        });
+
+        describe('caching behavior', () => {
+            it('caches subscriber results', async () => {
+                mockSubscriptionClient.getSubscriptionForUser.mockResolvedValue({ tier: '1000' } as any);
+
+                // First call
+                await roleManager.twitchUserHasRole('123456789', 'sub');
+                // Second call
+                await roleManager.twitchUserHasRole('123456789', 'sub');
+
+                // API should only be called once due to caching
+                expect(mockSubscriptionClient.getSubscriptionForUser).toHaveBeenCalledTimes(1);
+            });
+
+            it('cache expires after TTL', async () => {
+                mockSubscriptionClient.getSubscriptionForUser.mockResolvedValue({ tier: '1000' } as any);
+
+                // First call
+                await roleManager.twitchUserHasRole('123456789', 'sub');
+
+                // Advance time beyond cache TTL (30 seconds)
+                jest.advanceTimersByTime(31000);
+
+                // Second call after cache expiry
+                await roleManager.twitchUserHasRole('123456789', 'sub');
+
+            });
+        });
+    });
+
+    describe('kickUserHasRole', () => {
+        describe('custom roles (UUID-based)', () => {
+            it('checks custom role for user ID', async () => {
+                const customRolesManager = firebot.modules.customRolesManager as jest.Mocked<typeof firebot.modules.customRolesManager>;
+                const mockViewer = createMockViewer({ _id: '123456789' });
+
+                mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+                customRolesManager.userIsInRole.mockReturnValue(true);
+
+                // For kick usernames starting with 'k', it should be treated as a user ID
+                const result = await roleManager.kickUserHasRole('k123456789', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(true);
+                expect(mockKick.userManager.getViewerById).toHaveBeenCalledWith('k123456789');
+                expect(customRolesManager.userIsInRole).toHaveBeenCalledWith('k123456789', [], ['12345678-1234-1234-1234-123456789012']);
+            });
+
+            it('checks custom role for username by looking up viewer', async () => {
+                const customRolesManager = firebot.modules.customRolesManager as jest.Mocked<typeof firebot.modules.customRolesManager>;
+                const mockViewer = createMockViewer({ _id: '123456789', username: 'testuser' });
+
+                mockKick.userManager.getViewerByUsername.mockResolvedValue(mockViewer);
+                customRolesManager.userIsInRole.mockReturnValue(true);
+
+                // Regular username should be looked up by username, gets kickified to testuser@kick
+                const result = await roleManager.kickUserHasRole('testuser', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(true);
+                expect(mockKick.userManager.getViewerByUsername).toHaveBeenCalledWith('testuser@kick');
+                expect(customRolesManager.userIsInRole).toHaveBeenCalledWith('k123456789', [], ['12345678-1234-1234-1234-123456789012']);
+            });
+
+            it('returns false when viewer not found for custom role', async () => {
+                const customRolesManager = firebot.modules.customRolesManager as jest.Mocked<typeof firebot.modules.customRolesManager>;
+                mockKick.userManager.getViewerById.mockResolvedValue(undefined);
+
+                // When viewer is not found, the method still tries to call customRolesManager
+                // but without a valid user ID, so we need to mock it to return false
+                customRolesManager.userIsInRole.mockReturnValue(false);
+
+                const result = await roleManager.kickUserHasRole('k123456789', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(false);
+            });
+
+            it('returns false when customRolesManager returns false', async () => {
+                const customRolesManager = firebot.modules.customRolesManager as jest.Mocked<typeof firebot.modules.customRolesManager>;
+                const mockViewer = createMockViewer({ _id: '123456789' });
+
+                mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+                customRolesManager.userIsInRole.mockReturnValue(false);
+
+                const result = await roleManager.kickUserHasRole('k123456789', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(false);
+            });
+        });
+
+        describe('built-in roles', () => {
+            it('returns true when viewer has the role in twitchRoles', async () => {
+                const mockViewer = createMockViewer({
+                    _id: '123456789',
+                    twitchRoles: ['mod', 'vip']
+                });
+
+                mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                const result = await roleManager.kickUserHasRole('k123456789', 'mod');
+
+                expect(result).toBe(true);
+                expect(mockKick.userManager.getViewerById).toHaveBeenCalledWith('k123456789');
+            });
+
+            it('returns false when viewer does not have the role', async () => {
+                const mockViewer = createMockViewer({
+                    _id: '123456789',
+                    twitchRoles: ['vip']
+                });
+
+                mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                const result = await roleManager.kickUserHasRole('k123456789', 'mod');
+
+                expect(result).toBe(false);
+            });
+
+            it('handles string conversion for role comparison', async () => {
+                const mockViewer = createMockViewer({
+                    _id: '123456789',
+                    twitchRoles: ['123']
+                });
+
+                mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                const result = await roleManager.kickUserHasRole('k123456789', 123 as any);
+
+                expect(result).toBe(true);
+            });
+
+            describe('specific built-in roles', () => {
+                it('returns true when viewer has bot role', async () => {
+                    // Test bot by user ID match
+                    const mockViewer = createMockViewer({
+                        _id: '2000000001', // Matches mockKick.bot.userId
+                        twitchRoles: []
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('k2000000001', 'bot');
+
+                    expect(result).toBe(true);
+                });
+
+                it('returns true when viewer has bot role by username', async () => {
+                    // Test bot by username match
+                    const mockViewer = createMockViewer({
+                        _id: '123456789',
+                        username: 'TestKickBot', // This will become 'TestKickBot@kick' after kickifyUsername
+                        twitchRoles: []
+                    });
+
+                    mockKick.userManager.getViewerByUsername.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('TestKickBot@kick', 'bot');
+
+                    expect(result).toBe(true);
+                });
+
+                it('returns true when viewer has bot role by username (case insensitive)', async () => {
+                    // Test bot by username match (case insensitive)
+                    const mockViewer = createMockViewer({
+                        _id: '123456789',
+                        username: 'testkickbot', // This will become 'testkickbot@kick' after kickifyUsername
+                        twitchRoles: []
+                    });
+
+                    mockKick.userManager.getViewerByUsername.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('testkickbot@kick', 'bot');
+
+                    expect(result).toBe(true);
+                });
+
+                it('returns false when viewer does not have bot role', async () => {
+                    const mockViewer = createMockViewer({
+                        _id: '123456789', // Different from bot user ID
+                        username: 'regularuser', // Different from bot name
+                        twitchRoles: ['mod', 'vip']
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('k123456789', 'bot');
+
+                    expect(result).toBe(false);
+                });
+
+                it('returns false when bot info is not available', async () => {
+                    // Temporarily set bot to null
+                    const originalBot = mockKick.bot;
+                    mockKick.bot = null;
+
+                    const mockViewer = createMockViewer({
+                        _id: '123456789',
+                        twitchRoles: []
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('k123456789', 'bot');
+
+                    expect(result).toBe(false);
+
+                    // Restore bot info
+                    mockKick.bot = originalBot;
+                });
+
+                it('returns true when viewer has broadcaster role', async () => {
+                    // Test broadcaster by user ID match
+                    const mockViewer = createMockViewer({
+                        _id: '1000000001', // Matches mockKick.broadcaster.userId
+                        twitchRoles: []
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('k1000000001', 'broadcaster');
+
+                    expect(result).toBe(true);
+                });
+
+                it('returns true when viewer has broadcaster role by username', async () => {
+                    // Test broadcaster by username match
+                    const mockViewer = createMockViewer({
+                        _id: '123456789',
+                        username: 'TestKickBroadcaster', // Matches mockKick.broadcaster.name
+                        twitchRoles: []
+                    });
+
+                    mockKick.userManager.getViewerByUsername.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('TestKickBroadcaster@kick', 'broadcaster');
+
+                    expect(result).toBe(true);
+                });
+
+                it('returns true when viewer has broadcaster role by username (case insensitive)', async () => {
+                    // Test broadcaster by username match (case insensitive)
+                    const mockViewer = createMockViewer({
+                        _id: '123456789',
+                        username: 'testkickbroadcaster', // Different case than mockKick.broadcaster.name
+                        twitchRoles: []
+                    });
+
+                    mockKick.userManager.getViewerByUsername.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('testkickbroadcaster@kick', 'broadcaster');
+
+                    expect(result).toBe(true);
+                });
+
+                it('returns false when viewer does not have broadcaster role', async () => {
+                    const mockViewer = createMockViewer({
+                        _id: '123456789', // Different from broadcaster user ID
+                        username: 'regularuser', // Different from broadcaster name
+                        twitchRoles: ['mod', 'vip']
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('k123456789', 'broadcaster');
+
+                    expect(result).toBe(false);
+                });
+
+                it('returns false when broadcaster info is not available', async () => {
+                    // Temporarily set broadcaster to null
+                    const originalBroadcaster = mockKick.broadcaster;
+                    mockKick.broadcaster = null;
+
+                    const mockViewer = createMockViewer({
+                        _id: '123456789',
+                        twitchRoles: []
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('k123456789', 'broadcaster');
+
+                    expect(result).toBe(false);
+
+                    // Restore broadcaster info
+                    mockKick.broadcaster = originalBroadcaster;
+                });
+
+                it('returns true when viewer has subscriber role', async () => {
+                    const mockViewer = createMockViewer({
+                        _id: '123456789',
+                        twitchRoles: ['sub', 'mod']
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('k123456789', 'sub');
+
+                    expect(result).toBe(true);
+                });
+
+                it('returns false when viewer does not have subscriber role', async () => {
+                    const mockViewer = createMockViewer({
+                        _id: '123456789',
+                        twitchRoles: ['mod', 'vip']
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('k123456789', 'sub');
+
+                    expect(result).toBe(false);
+                });
+
+                it('returns true when viewer has multiple roles including target role', async () => {
+                    // Create a user who is both broadcaster and has other roles in twitchRoles
+                    const mockViewer = createMockViewer({
+                        _id: '1000000001', // Matches broadcaster userId
+                        username: 'TestKickBroadcaster', // Matches broadcaster name
+                        twitchRoles: ['mod', 'vip', 'sub']
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+                    mockKick.userManager.getViewerByUsername.mockResolvedValue(mockViewer);
+
+                    // Test broadcaster role (checked against kick.broadcaster)
+                    expect(await roleManager.kickUserHasRole('k1000000001', 'broadcaster')).toBe(true);
+                    expect(await roleManager.kickUserHasRole('TestKickBroadcaster@kick', 'broadcaster')).toBe(true);
+
+                    // Test roles from twitchRoles array
+                    expect(await roleManager.kickUserHasRole('k1000000001', 'mod')).toBe(true);
+                    expect(await roleManager.kickUserHasRole('k1000000001', 'vip')).toBe(true);
+                    expect(await roleManager.kickUserHasRole('k1000000001', 'sub')).toBe(true);
+
+                    // Test bot role (should be false since this user is broadcaster, not bot)
+                    expect(await roleManager.kickUserHasRole('k1000000001', 'bot')).toBe(false);
+                });
+
+                it('returns true when bot has roles in twitchRoles array', async () => {
+                    // Create a user who is both bot and has other roles in twitchRoles
+                    const mockViewer = createMockViewer({
+                        _id: '2000000001', // Matches bot userId
+                        username: 'TestKickBot', // Matches bot name
+                        twitchRoles: ['mod', 'vip']
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+                    mockKick.userManager.getViewerByUsername.mockResolvedValue(mockViewer);
+
+                    // Test bot role (checked against kick.bot)
+                    expect(await roleManager.kickUserHasRole('k2000000001', 'bot')).toBe(true);
+                    expect(await roleManager.kickUserHasRole('TestKickBot@kick', 'bot')).toBe(true);
+
+                    // Test roles from twitchRoles array
+                    expect(await roleManager.kickUserHasRole('k2000000001', 'mod')).toBe(true);
+                    expect(await roleManager.kickUserHasRole('k2000000001', 'vip')).toBe(true);
+
+                    // Test broadcaster role (should be false since this user is bot, not broadcaster)
+                    expect(await roleManager.kickUserHasRole('k2000000001', 'broadcaster')).toBe(false);
+                });
+
+                it('returns false for all roles when viewer has empty twitchRoles and is not broadcaster/bot', async () => {
+                    const mockViewer = createMockViewer({
+                        _id: '123456789', // Different from broadcaster and bot IDs
+                        username: 'regularuser', // Different from broadcaster and bot names
+                        twitchRoles: []
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                    // Test each role - all should be false
+                    expect(await roleManager.kickUserHasRole('k123456789', 'broadcaster')).toBe(false);
+                    expect(await roleManager.kickUserHasRole('k123456789', 'mod')).toBe(false);
+                    expect(await roleManager.kickUserHasRole('k123456789', 'vip')).toBe(false);
+                    expect(await roleManager.kickUserHasRole('k123456789', 'sub')).toBe(false);
+                    expect(await roleManager.kickUserHasRole('k123456789', 'bot')).toBe(false);
+                });
+            });
+
+            describe('user lookup scenarios', () => {
+                it('looks up by username when provided username', async () => {
+                    const mockViewer = createMockViewer({
+                        _id: '123456789',
+                        username: 'testuser',
+                        twitchRoles: ['mod']
+                    });
+
+                    mockKick.userManager.getViewerByUsername.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('testuser', 'mod');
+
+                    expect(result).toBe(true);
+                    expect(mockKick.userManager.getViewerByUsername).toHaveBeenCalledWith('testuser@kick');
+                    expect(mockKick.userManager.getViewerById).not.toHaveBeenCalled();
+                });
+
+                it('looks up by user ID when provided numeric ID', async () => {
+                    const mockViewer = createMockViewer({
+                        _id: '123456789',
+                        twitchRoles: ['mod']
+                    });
+
+                    mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                    const result = await roleManager.kickUserHasRole('k123456789', 'mod');
+
+                    expect(result).toBe(true);
+                    expect(mockKick.userManager.getViewerById).toHaveBeenCalledWith('k123456789');
+                    expect(mockKick.userManager.getViewerByUsername).not.toHaveBeenCalled();
+                });
+
+                it('returns false when viewer not found', async () => {
+                    mockKick.userManager.getViewerByUsername.mockResolvedValue(undefined);
+
+                    const result = await roleManager.kickUserHasRole('testuser', 'mod');
+
+                    expect(result).toBe(false);
+                });
+            });
+        });
+
+        describe('invalid inputs', () => {
+            it('returns false for empty user identifier', async () => {
+                // Empty string: isNaN(Number("")) is false, so it's treated as numeric ID
+                // unkickifyUserId("") returns "", kickifyUserId("") returns "k"
+                // So id="k", name=undefined, and it will try to look up viewer by ID "k"
+                // When no viewer is found, it continues to check built-in roles but viewer is undefined
+                mockKick.userManager.getViewerById.mockResolvedValue(undefined);
+
+                const result = await roleManager.kickUserHasRole('', 'mod');
+                expect(result).toBe(false);
+            });
+
+            it('returns false for null user identifier', async () => {
+                const result = await roleManager.kickUserHasRole(null as any, 'mod');
+                expect(result).toBe(false);
+            });
+        });
+    });
+
+    describe('userHasRole', () => {
+        describe('platform detection', () => {
+            it('uses kick platform when explicitly specified', async () => {
+                const mockViewer = createMockViewer({ twitchRoles: ['mod'] });
+                mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                const result = await roleManager.userHasRole('kick', 'k123456789', 'mod');
+
+                expect(result).toBe(true);
+                expect(mockKick.userManager.getViewerById).toHaveBeenCalledWith('k123456789');
+            });
+
+            it('uses twitch platform when explicitly specified', async () => {
+                const customRolesManager = firebot.modules.customRolesManager as jest.Mocked<typeof firebot.modules.customRolesManager>;
+                customRolesManager.userIsInRole.mockReturnValue(true);
+
+                const result = await roleManager.userHasRole('twitch', '123456789', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(true);
+                expect(customRolesManager.userIsInRole).toHaveBeenCalled();
+            });
+
+            it('auto-detects kick platform for kickified username', async () => {
+                const mockViewer = createMockViewer({ twitchRoles: ['mod'] });
+                mockKick.userManager.getViewerByUsername.mockResolvedValue(mockViewer);
+
+                // Username ending with @kick should be detected as kick platform
+                const result = await roleManager.userHasRole('unknown', 'testuser@kick', 'mod');
+
+                expect(result).toBe(true);
+                expect(mockKick.userManager.getViewerByUsername).toHaveBeenCalledWith('testuser@kick');
+            });
+
+            it('auto-detects kick platform for kickified user ID', async () => {
+                const mockViewer = createMockViewer({ twitchRoles: ['mod'] });
+                mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                // User ID starting with 'k' followed by numbers should be detected as kick platform
+                const result = await roleManager.userHasRole('unknown', 'k123456789', 'mod');
+
+                expect(result).toBe(true);
+                expect(mockKick.userManager.getViewerById).toHaveBeenCalledWith('k123456789');
+            });
+
+            it('defaults to twitch platform for regular usernames', async () => {
+                (firebot.modules.twitchApi.moderation.getModerators as jest.Mock).mockResolvedValue([
+                    { userId: '123456789', userName: 'testuser' }
+                ] as any);
+
+                const result = await roleManager.userHasRole('unknown', 'testuser', 'mod');
+
+                expect(result).toBe(true);
+                expect(firebot.modules.twitchApi.moderation.getModerators).toHaveBeenCalled();
+            });
+
+            it('defaults to twitch platform for numeric user IDs', async () => {
+                (firebot.modules.twitchApi.moderation.getModerators as jest.Mock).mockResolvedValue([
+                    { userId: '123456789', userName: 'testuser' }
+                ] as any);
+
+                const result = await roleManager.userHasRole('unknown', '123456789', 'mod');
+
+                expect(result).toBe(true);
+                expect(firebot.modules.twitchApi.moderation.getModerators).toHaveBeenCalled();
+            });
+        });
+
+        describe('delegation to platform methods', () => {
+            it('properly delegates to kickUserHasRole', async () => {
+                const mockViewer = createMockViewer({ twitchRoles: ['mod'] });
+                mockKick.userManager.getViewerById.mockResolvedValue(mockViewer);
+
+                const result = await roleManager.userHasRole('kick', 'k123456789', 'mod');
+
+                expect(result).toBe(true);
+            });
+
+            it('properly delegates to twitchUserHasRole', async () => {
+                const customRolesManager = firebot.modules.customRolesManager as jest.Mocked<typeof firebot.modules.customRolesManager>;
+                customRolesManager.userIsInRole.mockReturnValue(true);
+
+                const result = await roleManager.userHasRole('twitch', '123456789', '12345678-1234-1234-1234-123456789012');
+
+                expect(result).toBe(true);
+            });
+        });
+    });
+});

--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -6,6 +6,7 @@ import { KickChannelManager } from "./channel-manager";
 import { ChatManager } from "./chat-manager";
 import { HttpCallRequest, httpCallWithTimeout } from "./http";
 import { IKick } from "./kick-interface";
+import { RoleManager } from "./role-manager";
 import { KickUserApi } from "./user-api";
 import { KickUserManager } from "./user-manager";
 import { parseBasicKickUser } from "./webhook-handler/webhook-parsers";
@@ -19,6 +20,7 @@ export class Kick implements IKick {
     broadcaster: BasicKickUser | null = null;
     channelManager: KickChannelManager;
     chatManager: ChatManager;
+    roleManager: RoleManager;
     webhookSubscriptionManager: WebhookSubscriptionManager;
     userApi: KickUserApi;
     userManager: KickUserManager;
@@ -26,6 +28,7 @@ export class Kick implements IKick {
     constructor() {
         this.channelManager = new KickChannelManager(this);
         this.chatManager = new ChatManager(this);
+        this.roleManager = new RoleManager(this);
         this.userApi = new KickUserApi(this);
         this.userManager = new KickUserManager(this);
         this.webhookSubscriptionManager = new WebhookSubscriptionManager(this);

--- a/src/internal/role-manager.ts
+++ b/src/internal/role-manager.ts
@@ -1,0 +1,333 @@
+import { FirebotViewer } from '@crowbartools/firebot-custom-scripts-types/types/modules/viewer-database';
+import NodeCache from 'node-cache';
+import { firebot, logger } from "../main";
+import { IKick } from './kick-interface';
+import { kickifyUserId, kickifyUsername, unkickifyUserId, unkickifyUsername } from "./util";
+
+export class RoleManager {
+    private _kick: IKick;
+    private _twitchUserCache: NodeCache = new NodeCache({ stdTTL: 30 }); // For per-user role checks
+    private _twitchGlobalCache: NodeCache = new NodeCache({ stdTTL: 30 }); // For global lists like VIPs and moderators
+
+    constructor(kick: IKick) {
+        this._kick = kick;
+    }
+
+    // Twitch roles can be queried via the API. We keep a local cache to avoid
+    // hammering the API too much, but a relatively short TTL so that the data
+    // is reasonably fresh.
+    async twitchUserHasRole(userNameOrId: string | number, roleId: string): Promise<boolean> {
+        const { id, name } = this.parseTwitchUserNameOrId(userNameOrId);
+        if (!id && !name) {
+            return false;
+        }
+
+        if (roleId === "broadcaster") {
+            if (!firebot.firebot.accounts.streamer.userId || !firebot.firebot.accounts.streamer.username) {
+                logger.error(`twitchUserHasRole: Broadcaster information not available.`);
+                return false;
+            }
+
+            const isBroadcaster = (firebot.firebot.accounts.streamer.userId === id || firebot.firebot.accounts.streamer.username.toLowerCase() === name?.toLowerCase());
+            logger.debug(`twitchUserHasRole: Checking 'broadcaster' for user ${userNameOrId} (${id}/${name}), result=${isBroadcaster}`);
+            return isBroadcaster;
+        }
+
+        if (roleId === "bot") {
+            if (!firebot.firebot.accounts.bot.userId || !firebot.firebot.accounts.bot.username) {
+                logger.error(`twitchUserHasRole: Bot information not available.`);
+                return false;
+            }
+
+            const isBot = (firebot.firebot.accounts.bot.userId === id || firebot.firebot.accounts.bot.username.toLowerCase() === name?.toLowerCase());
+            logger.debug(`twitchUserHasRole: Checking 'bot' for user ${userNameOrId} (${id}/${name}), result=${isBot}`);
+            return isBot;
+        }
+
+        if (roleId.length !== 36) {
+            const result = await this.twitchUserHasTwitchRole(id, name, roleId);
+            logger.debug(`twitchUserHasRole: Checking Twitch role ${roleId} for user ${userNameOrId} (${id}/${name}), result=${result}`);
+            return result;
+        }
+
+        if (id) {
+            return this.userHasCustomRole(id, roleId);
+        }
+
+        try {
+            const { twitchApi } = firebot.modules;
+            if (!name) {
+                logger.error(`twitchUserHasRole: Username is undefined, cannot fetch user by name.`);
+                return false;
+            }
+            const user = await twitchApi.users.getUserByName(name);
+            return this.userHasCustomRole(user.id, roleId);
+        } catch (error) {
+            logger.error(`twitchUserHasRole: Error fetching user ID for ${name}: ${error}`);
+            return false;
+        }
+    }
+
+    // Kick roles cannot be queried via the API, so we are dependent on
+    // observing the most recent badges that were sent with the chat message. We
+    // can also check our subscriber database to guess whether a user is a
+    // subscriber or not.
+    async kickUserHasRole(userNameOrId: string | number, roleId: string): Promise<boolean> {
+        let { id, name } = this.parseKickUserNameOrId(userNameOrId);
+        if (!id && !name) {
+            return false;
+        }
+
+        let viewer: FirebotViewer | undefined = undefined;
+        if (id) {
+            logger.debug(`kickUserHasRole: Looking up Kick viewer by user ID: ${id}`);
+            viewer = await this._kick.userManager.getViewerById(id);
+        } else if (name) {
+            logger.debug(`kickUserHasRole: Looking up Kick viewer by username: ${name}`);
+            viewer = await this._kick.userManager.getViewerByUsername(name);
+        }
+        if (viewer) {
+            id = kickifyUserId(viewer._id);
+            name = kickifyUsername(viewer.username);
+        }
+
+        if (roleId.length === 36) {
+            if (!id) {
+                logger.error(`kickUserHasRole: Cannot look up custom role ${roleId} without user ID for user ${userNameOrId}`);
+                return false;
+            }
+            return this.userHasCustomRole(id, roleId);
+        }
+
+        if (roleId === "broadcaster") {
+            if (!this._kick.broadcaster) {
+                logger.error(`kickUserHasRole: Broadcaster information not available.`);
+                return false;
+            }
+
+            const isBroadcaster = (unkickifyUserId(id) === unkickifyUserId(this._kick.broadcaster.userId) || unkickifyUsername(name).toLowerCase() === unkickifyUsername(this._kick.broadcaster.name).toLowerCase());
+            logger.debug(`kickUserHasRole: Checking 'broadcaster' for user ${userNameOrId} (${id}/${name}), result=${isBroadcaster}`);
+            return isBroadcaster;
+        }
+
+        if (roleId === "bot") {
+            if (!this._kick.bot) {
+                logger.error(`kickUserHasRole: Bot information not available.`);
+                return false;
+            }
+
+            const isBot = (unkickifyUserId(id) === unkickifyUserId(this._kick.bot.userId) || unkickifyUsername(name).toLowerCase() === unkickifyUsername(this._kick.bot.name).toLowerCase());
+            logger.debug(`kickUserHasRole: Checking 'bot' for user ${userNameOrId} (${id}/${name}), result=${isBot}`);
+            return isBot;
+        }
+
+        if (!viewer) {
+            logger.warn(`kickUserHasRole: No Kick viewer found for: ${userNameOrId}`);
+            return false;
+        }
+
+        const result = viewer.twitchRoles.includes(String(roleId));
+        logger.debug(`kickUserHasRole: Checking Kick role ${roleId} for user ${userNameOrId} (${id}/${name}), result=${result} (roles: ${viewer.twitchRoles.join(", ")})`);
+        return result;
+    }
+
+    async userHasRole(platform: string, userNameOrId: string | number, roleId: string): Promise<boolean> {
+        if (platform !== "twitch" && platform !== "kick") {
+            if (typeof userNameOrId === "string" && isNaN(Number(unkickifyUserId(userNameOrId))) && unkickifyUsername(userNameOrId) !== userNameOrId) {
+                platform = "kick";
+            } else if (typeof userNameOrId === "string" && !isNaN(Number(unkickifyUserId(userNameOrId))) && unkickifyUserId(userNameOrId) !== userNameOrId) {
+                platform = "kick";
+            } else {
+                platform = "twitch";
+            }
+        }
+
+        if (platform === "kick") {
+            return this.kickUserHasRole(userNameOrId, roleId);
+        }
+        return this.twitchUserHasRole(userNameOrId, roleId);
+    }
+
+    private userHasCustomRole(userId: string, roleId: string): boolean {
+        try {
+            const { customRolesManager } = firebot.modules;
+            const hasRole = customRolesManager.userIsInRole(userId, [], [roleId]);
+            logger.debug(`userHasCustomRole: Checking custom role ${roleId} for user ${userId} (result=${hasRole})`);
+            return hasRole;
+        } catch (error) {
+            logger.error(`userHasCustomRole: Error checking custom role ${roleId} for user ${userId}: ${error}`);
+            return false;
+        }
+    }
+
+    private async twitchUserHasTwitchRole(id: string | undefined, name: string | undefined, roleId: string): Promise<boolean> {
+        switch (roleId) {
+            case "broadcaster": {
+                return (firebot.firebot.accounts.streamer.userId === id || firebot.firebot.accounts.streamer.username.toLowerCase() === name?.toLowerCase());
+            }
+            case "bot": {
+                return (firebot.firebot.accounts.bot.userId === id || firebot.firebot.accounts.bot.username.toLowerCase() === name?.toLowerCase());
+            }
+            case "sub": {
+                return this.isTwitchSub(id, name);
+            }
+            case "vip": {
+                return this.isTwitchVip(id, name);
+            }
+            case "mod": {
+                return this.isTwitchModerator(id, name);
+            }
+            default: {
+                logger.warn(`twitchUserHasTwitchRole: Unknown Twitch roleId provided: ${roleId}`);
+                return false;
+            }
+        }
+    }
+
+    private async isTwitchSub(id: string | undefined, name: string | undefined): Promise<boolean> {
+        let cacheKey: string;
+        if (id) {
+            cacheKey = `twitchsub:id:${id}`;
+        } else if (name) {
+            cacheKey = `twitchsub:name:${name.toLowerCase()}`;
+        } else {
+            logger.warn(`isTwitchSub: No valid id or name provided to check for sub status`);
+            return false;
+        }
+
+        if (this._twitchUserCache.has(cacheKey)) {
+            return this._twitchUserCache.get(cacheKey) ?? false;
+        }
+
+        const { twitchApi } = firebot.modules;
+        if (name && !id) {
+            try {
+                const startTime = performance.now();
+                const user = await twitchApi.users.getUserByName(name);
+                id = user.id;
+                logger.debug(`isTwitchSub: Fetched user ID for ${name} in ${(performance.now() - startTime).toFixed(2)} ms`);
+            } catch (error) {
+                logger.error(`isTwitchSub: Error fetching user ID for ${name}: ${error}`);
+                return false;
+            }
+        }
+
+        if (!id) {
+            logger.warn(`isTwitchSub: No user ID available to check for sub status`);
+            return false;
+        }
+
+        const streamerId = firebot.firebot.accounts.streamer.userId;
+        try {
+            const startTime = performance.now();
+            const subInfo = await twitchApi.getClient().subscriptions.getSubscriptionForUser(streamerId, id);
+            const isSub = subInfo !== null;
+            this._twitchUserCache.set(cacheKey, isSub);
+            logger.debug(`isTwitchSub: Checked subscription status for user ${id} in ${(performance.now() - startTime).toFixed(2)} ms`);
+            return isSub;
+        } catch (error) {
+            logger.error(`isTwitchSub: Error checking subscription status for user ${id}: ${error}`);
+            return false;
+        }
+    }
+
+    private async isTwitchVip(id: string | undefined, name: string | undefined): Promise<boolean> {
+        if (typeof id === "string" && id.trim().length > 0) {
+            await this.loadTwitchVips();
+            const vips = this._twitchGlobalCache.get('vips');
+            return Array.isArray(vips) ? vips.includes(`id:${id}`) : false;
+        }
+
+        if (typeof name === "string" && name.trim().length > 0) {
+            await this.loadTwitchVips();
+            const vips = this._twitchGlobalCache.get('vips');
+            return Array.isArray(vips) ? vips.includes(`name:${name.toLowerCase()}`) : false;
+        }
+
+        logger.warn(`isTwitchVip: No valid id or name provided to check for VIP status`);
+        return false;
+    }
+
+    private async isTwitchModerator(id: string | undefined, name: string | undefined): Promise<boolean> {
+        if (typeof id === "string" && id.trim().length > 0) {
+            await this.loadTwitchModerators();
+            const moderators = this._twitchGlobalCache.get('moderators');
+            return Array.isArray(moderators) ? moderators.includes(`id:${id}`) : false;
+        }
+
+        if (typeof name === "string" && name.trim().length > 0) {
+            await this.loadTwitchModerators();
+            const moderators = this._twitchGlobalCache.get('moderators');
+            return Array.isArray(moderators) ? moderators.includes(`name:${name.toLowerCase()}`) : false;
+        }
+
+        logger.warn(`isTwitchModerator: No valid id or name provided to check for moderator status`);
+        return false;
+    }
+
+    private async loadTwitchModerators(): Promise<void> {
+        if (!this._twitchGlobalCache.has('moderators')) {
+            const startTime = performance.now();
+            const { twitchApi } = firebot.modules;
+            const moderators = await twitchApi.moderation.getModerators();
+            this._twitchGlobalCache.set('moderators', [
+                ...moderators.map(mod => `id:${mod.userId}`),
+                ...moderators.map(mod => `name:${mod.userName.toLowerCase()}`)
+            ]);
+            logger.debug(`Loaded ${moderators.length} moderators from Twitch API. Took ${(performance.now() - startTime).toFixed(2)} ms.`);
+        }
+    }
+
+    private async loadTwitchVips(): Promise<void> {
+        if (!this._twitchGlobalCache.has('vips')) {
+            const startTime = performance.now();
+            const { twitchApi } = firebot.modules;
+            const vips = await twitchApi.channels.getVips();
+            this._twitchGlobalCache.set('vips', [
+                ...vips.map(vip => `id:${vip.id}`),
+                ...vips.map(vip => `name:${vip.name.toLowerCase()}`)
+            ]);
+            logger.debug(`Loaded ${vips.length} VIPs from Twitch API. Took ${(performance.now() - startTime).toFixed(2)} ms.`);
+        }
+    }
+
+    private parseTwitchUserNameOrId(userNameOrId: string | number): { id: string | undefined, name: string | undefined } {
+        let id: string | undefined;
+        let name: string | undefined;
+
+        if (typeof userNameOrId === "string" && isNaN(Number(userNameOrId))) {
+            name = userNameOrId;
+            id = undefined;
+        } else if (typeof userNameOrId === "string" && !isNaN(Number(userNameOrId))) {
+            id = userNameOrId;
+            name = undefined;
+        } else if (typeof userNameOrId === "number") {
+            id = String(userNameOrId);
+            name = undefined;
+        } else {
+            logger.warn(`parseTwitchUserNameOrId: Invalid userNameOrId provided: ${userNameOrId}`);
+        }
+
+        return { id, name };
+    }
+
+    private parseKickUserNameOrId(userNameOrId: string | number): { id: string | undefined, name: string | undefined } {
+        let id: string | undefined;
+        let name: string | undefined;
+
+        if (typeof userNameOrId === "string" && isNaN(Number(unkickifyUserId(userNameOrId)))) {
+            name = kickifyUsername(userNameOrId);
+            id = undefined;
+        } else if (typeof userNameOrId === "string" && !isNaN(Number(unkickifyUserId(userNameOrId)))) {
+            id = kickifyUserId(userNameOrId);
+            name = undefined;
+        } else if (typeof userNameOrId === "number") {
+            id = kickifyUserId(String(userNameOrId));
+            name = undefined;
+        } else {
+            logger.warn(`parseKickUserNameOrId: Invalid userNameOrId provided: ${userNameOrId}`);
+        }
+
+        return { id, name };
+    }
+}


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This updates the "platform independent" role condition to look up Twitch status (mod, VIP, subscriber) in real time, with a 30 second TTL. The previous implementation was using cached values from the beginning of the stream, so if someone subscribed during the stream, they couldn't immediately use the new benefits.

Much of the change is refactoring the older code into a new RoleManager so things are more separated and easier to test. This also now supports the "stream bot" role.

### Motivation
Twitch subs should be recognized immediately upon subscribing and this helps facilitate that. Kick subs will still fall back to badges but we could expand this later to look at historical subscription roles from the database.

### Testing
Tested with broadcaster, bot, moderator, and VIP, along with a non-subscriber. I couldn't test subscribers because I don't have access to any.
