### PR TITLE
Add reflector function and version checking

### DIFF
--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -23,6 +23,7 @@ import { AuthManager } from "./internal/auth";
 import { Kick } from "./internal/kick";
 import { Poller } from "./internal/poll";
 import { KickPusher } from "./internal/pusher/pusher";
+import { reflectorExtension } from "./internal/reflector";
 import { firebot, logger } from "./main";
 import { platformRestriction } from "./restrictions/platform";
 import { getDataFilePath } from "./util/datafile";
@@ -298,6 +299,15 @@ export class KickIntegration extends EventEmitter {
         // Miscellaneous variables
         replaceVariableManager.registerReplaceVariable(platformVariable);
 
+        // UI Extensions
+        const { uiExtensionManager } = firebot.modules;
+        if (uiExtensionManager) {
+            uiExtensionManager.registerUIExtension(reflectorExtension);
+        } else {
+            logger.error("UI Extension Manager module not found. The Kick integration UI extension cannot be registered.");
+        }
+
+        // Restrictions
         const { restrictionManager } = firebot.modules;
         restrictionManager.registerRestriction(platformRestriction);
     }

--- a/src/internal/__tests__/reflector.test.ts
+++ b/src/internal/__tests__/reflector.test.ts
@@ -1,0 +1,312 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+jest.mock('../../main', () => ({
+    firebot: {
+        firebot: {
+            version: '5.65.0'
+        },
+        modules: {
+            frontendCommunicator: {
+                fireEventAsync: jest.fn()
+            }
+        }
+    },
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+    }
+}));
+
+import { reflectEvent } from '../reflector';
+import { firebot, logger } from '../../main';
+import { IntegrationConstants } from '../../constants';
+
+describe('reflectEvent', () => {
+    let mockFrontendCommunicator: jest.Mocked<typeof firebot.modules.frontendCommunicator>;
+    let mockLogger: jest.Mocked<typeof logger>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+
+        mockFrontendCommunicator = firebot.modules.frontendCommunicator as jest.Mocked<typeof firebot.modules.frontendCommunicator>;
+        mockLogger = logger as jest.Mocked<typeof logger>;
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('version checking', () => {
+        it('should throw error for Firebot version < 5.65', async () => {
+            (firebot.firebot as any).version = '5.64.0';
+
+            await expect(reflectEvent('test-event', { data: 'test' }))
+                .rejects
+                .toThrow('Firebot version must be >= 5.65 to use this feature (got 5.64.0).');
+        });
+
+        it('should throw error for Firebot version < 5', async () => {
+            (firebot.firebot as any).version = '4.99.0';
+
+            await expect(reflectEvent('test-event', { data: 'test' }))
+                .rejects
+                .toThrow('Firebot version must be >= 5.65 to use this feature (got 4.99.0).');
+        });
+
+        it('should work with Firebot version = 5.65', async () => {
+            (firebot.firebot as any).version = '5.65.0';
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue({ result: 'success' });
+
+            const result = await reflectEvent('test-event', { data: 'test' });
+
+            expect(result).toEqual({ result: 'success' });
+        });
+
+        it('should work with Firebot version > 5.65', async () => {
+            (firebot.firebot as any).version = '6.0.0';
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue({ result: 'success' });
+
+            const result = await reflectEvent('test-event', { data: 'test' });
+
+            expect(result).toEqual({ result: 'success' });
+        });
+
+        it('should handle complex version numbers', async () => {
+            (firebot.firebot as any).version = '5.65.1-beta.2';
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue({ result: 'success' });
+
+            const result = await reflectEvent('test-event', { data: 'test' });
+
+            expect(result).toEqual({ result: 'success' });
+        });
+    });
+
+    describe('successful event reflection', () => {
+        beforeEach(() => {
+            (firebot.firebot as any).version = '5.65.0';
+        });
+
+        it('should reflect async event successfully', async () => {
+            const eventData = { userId: '123', message: 'Hello World' };
+            const expectedResponse = { success: true, eventId: 'abc123' };
+
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue(expectedResponse);
+
+            const result = await reflectEvent('chat-message', eventData, true);
+
+            expect(result).toEqual(expectedResponse);
+            expect(mockFrontendCommunicator.fireEventAsync).toHaveBeenCalledWith(
+                `${IntegrationConstants.INTEGRATION_ID}:reflect-async`,
+                {
+                    async: true,
+                    eventName: 'chat-message',
+                    eventData
+                }
+            );
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                'Sending reflect event to frontend: eventName=chat-message, isAsync=true'
+            );
+        });
+
+        it('should reflect sync event successfully', async () => {
+            const eventData = { action: 'ban', userId: '456' };
+            const expectedResponse = { acknowledged: true };
+
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue(expectedResponse);
+
+            const result = await reflectEvent('moderation-action', eventData, false);
+
+            expect(result).toEqual(expectedResponse);
+            expect(mockFrontendCommunicator.fireEventAsync).toHaveBeenCalledWith(
+                `${IntegrationConstants.INTEGRATION_ID}:reflect-async`,
+                {
+                    async: false,
+                    eventName: 'moderation-action',
+                    eventData
+                }
+            );
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                'Sending reflect event to frontend: eventName=moderation-action, isAsync=false'
+            );
+        });
+
+        it('should default to async=true when not specified', async () => {
+            const eventData = { type: 'subscription' };
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue({ ok: true });
+
+            await reflectEvent('sub-event', eventData);
+
+            expect(mockFrontendCommunicator.fireEventAsync).toHaveBeenCalledWith(
+                `${IntegrationConstants.INTEGRATION_ID}:reflect-async`,
+                {
+                    async: true,
+                    eventName: 'sub-event',
+                    eventData
+                }
+            );
+        });
+
+        it('should handle null event data', async () => {
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue({ received: true });
+
+            const result = await reflectEvent('null-data-event', null);
+
+            expect(result).toEqual({ received: true });
+            expect(mockFrontendCommunicator.fireEventAsync).toHaveBeenCalledWith(
+                `${IntegrationConstants.INTEGRATION_ID}:reflect-async`,
+                {
+                    async: true,
+                    eventName: 'null-data-event',
+                    eventData: null
+                }
+            );
+        });
+
+        it('should handle complex event data structures', async () => {
+            const complexEventData = {
+                user: { id: '789', name: 'TestUser', roles: ['mod', 'vip'] },
+                message: { text: 'Complex message', timestamp: new Date().toISOString() },
+                metadata: { platform: 'kick', channel: 'test-channel' }
+            };
+
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue({ processed: true });
+
+            await reflectEvent('complex-event', complexEventData);
+
+            expect(mockFrontendCommunicator.fireEventAsync).toHaveBeenCalledWith(
+                `${IntegrationConstants.INTEGRATION_ID}:reflect-async`,
+                {
+                    async: true,
+                    eventName: 'complex-event',
+                    eventData: complexEventData
+                }
+            );
+        });
+    });
+
+    describe('timeout handling', () => {
+        beforeEach(() => {
+            (firebot.firebot as any).version = '5.65.0';
+        });
+
+        it('should timeout after 1000ms when frontend does not respond', async () => {
+            // Mock a promise that never resolves
+            mockFrontendCommunicator.fireEventAsync.mockImplementation(
+                () => new Promise(() => {
+                    // Intentionally never resolves
+                })
+            );
+
+            const reflectPromise = reflectEvent('slow-event', { data: 'test' });
+
+            // Advance timers by 1000ms
+            jest.advanceTimersByTime(1000);
+
+            await expect(reflectPromise).rejects.toThrow('Reflect event timeout');
+        });
+
+        it('should not timeout when frontend responds quickly', async () => {
+            const quickResponse = { fast: true };
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue(quickResponse);
+
+            const result = await reflectEvent('fast-event', { data: 'test' });
+
+            expect(result).toEqual(quickResponse);
+        });
+
+        it('should not timeout when frontend responds just before timeout', async () => {
+            const responseData = { justInTime: true };
+
+            // Mock a promise that resolves after 999ms
+            mockFrontendCommunicator.fireEventAsync.mockImplementation(
+                () => new Promise((resolve) => {
+                    setTimeout(() => {
+                        resolve(responseData);
+                    }, 999);
+                })
+            );
+
+            const reflectPromise = reflectEvent('just-in-time-event', { data: 'test' });
+
+            // Advance timers by 999ms (just before timeout)
+            jest.advanceTimersByTime(999);
+
+            const result = await reflectPromise;
+            expect(result).toEqual(responseData);
+        });
+    });
+
+    describe('error handling', () => {
+        beforeEach(() => {
+            (firebot.firebot as any).version = '5.65.0';
+        });
+
+        it('should propagate frontend communicator errors', async () => {
+            const frontendError = new Error('Frontend communication failed');
+            mockFrontendCommunicator.fireEventAsync.mockRejectedValue(frontendError);
+
+            await expect(reflectEvent('error-event', { data: 'test' }))
+                .rejects
+                .toThrow('Frontend communication failed');
+        });
+
+        it('should handle empty event name', async () => {
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue({ ok: true });
+
+            await reflectEvent('', { data: 'test' });
+
+            expect(mockFrontendCommunicator.fireEventAsync).toHaveBeenCalledWith(
+                `${IntegrationConstants.INTEGRATION_ID}:reflect-async`,
+                {
+                    async: true,
+                    eventName: '',
+                    eventData: { data: 'test' }
+                }
+            );
+        });
+    });
+
+    describe('type safety', () => {
+        beforeEach(() => {
+            (firebot.firebot as any).version = '5.65.0';
+        });
+
+        it('should preserve return type through generic parameter', async () => {
+            interface CustomResponse {
+                status: 'success' | 'error';
+                data: string[];
+            }
+
+            const typedResponse: CustomResponse = {
+                status: 'success',
+                data: ['item1', 'item2']
+            };
+
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue(typedResponse);
+
+            const result = await reflectEvent<CustomResponse>('typed-event', { input: 'test' });
+
+            expect(result.status).toBe('success');
+            expect(result.data).toEqual(['item1', 'item2']);
+        });
+    });
+
+    describe('integration with constants', () => {
+        beforeEach(() => {
+            (firebot.firebot as any).version = '5.65.0';
+        });
+
+        it('should use correct integration ID in event name', async () => {
+            mockFrontendCommunicator.fireEventAsync.mockResolvedValue({ ok: true });
+
+            await reflectEvent('test-event', { data: 'test' });
+
+            expect(mockFrontendCommunicator.fireEventAsync).toHaveBeenCalledWith(
+                'mage-kick-integration:reflect-async',
+                expect.any(Object)
+            );
+        });
+    });
+});

--- a/src/internal/__tests__/version.test.ts
+++ b/src/internal/__tests__/version.test.ts
@@ -1,0 +1,239 @@
+jest.mock('../../main', () => ({
+    firebot: {
+        firebot: {
+            version: '5.65.0'
+        }
+    }
+}));
+
+import { requireVersion } from '../version';
+import { firebot } from '../../main';
+
+describe('requireVersion', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('firebot availability checks', () => {
+        it('should throw error when firebot.firebot is not available', () => {
+            const originalFirebotInner = firebot.firebot;
+            (firebot as any).firebot = undefined;
+
+            expect(() => {
+                requireVersion('5.65.0');
+            }).toThrow('Firebot version information is not available.');
+
+            (firebot as any).firebot = originalFirebotInner;
+        });
+
+        it('should throw error when version is not available', () => {
+            const originalVersion = firebot.firebot.version;
+            (firebot.firebot as any).version = undefined;
+
+            expect(() => {
+                requireVersion('5.65.0');
+            }).toThrow('Firebot version information is not available.');
+
+            (firebot.firebot as any).version = originalVersion;
+        });
+    });
+
+    describe('major.minor version checking (no patch)', () => {
+        it('should pass when major version is higher', () => {
+            (firebot.firebot as any).version = '6.0.0';
+            expect(() => {
+                requireVersion('5.65');
+            }).not.toThrow();
+        });
+
+        it('should pass when major.minor version is equal', () => {
+            (firebot.firebot as any).version = '5.65.0';
+            expect(() => {
+                requireVersion('5.65');
+            }).not.toThrow();
+        });
+
+        it('should pass when major is equal and minor is higher', () => {
+            (firebot.firebot as any).version = '5.70.0';
+            expect(() => {
+                requireVersion('5.65');
+            }).not.toThrow();
+        });
+
+        it('should throw when major version is lower', () => {
+            (firebot.firebot as any).version = '4.99.0';
+            expect(() => {
+                requireVersion('5.65');
+            }).toThrow('Firebot version must be >= 5.65 to use this feature (got 4.99.0).');
+        });
+
+        it('should throw when major is equal but minor is lower', () => {
+            (firebot.firebot as any).version = '5.64.0';
+            expect(() => {
+                requireVersion('5.65');
+            }).toThrow('Firebot version must be >= 5.65 to use this feature (got 5.64.0).');
+        });
+    });
+
+    describe('major.minor.patch version checking', () => {
+        it('should pass when major.minor.patch version is equal', () => {
+            (firebot.firebot as any).version = '5.65.3';
+            expect(() => {
+                requireVersion('5.65.3');
+            }).not.toThrow();
+        });
+
+        it('should pass when patch version is higher', () => {
+            (firebot.firebot as any).version = '5.65.5';
+            expect(() => {
+                requireVersion('5.65.3');
+            }).not.toThrow();
+        });
+
+        it('should pass when minor version is higher (patch ignored)', () => {
+            (firebot.firebot as any).version = '5.66.0';
+            expect(() => {
+                requireVersion('5.65.3');
+            }).not.toThrow();
+        });
+
+        it('should pass when major version is higher (minor and patch ignored)', () => {
+            (firebot.firebot as any).version = '6.0.0';
+            expect(() => {
+                requireVersion('5.65.3');
+            }).not.toThrow();
+        });
+
+        it('should throw when patch version is lower', () => {
+            (firebot.firebot as any).version = '5.65.2';
+            expect(() => {
+                requireVersion('5.65.3');
+            }).toThrow('Firebot version must be >= 5.65.3 to use this feature (got 5.65.2).');
+        });
+
+        it('should throw when minor version is lower (regardless of patch)', () => {
+            (firebot.firebot as any).version = '5.64.9';
+            expect(() => {
+                requireVersion('5.65.0');
+            }).toThrow('Firebot version must be >= 5.65.0 to use this feature (got 5.64.9).');
+        });
+
+        it('should throw when major version is lower (regardless of minor and patch)', () => {
+            (firebot.firebot as any).version = '4.99.99';
+            expect(() => {
+                requireVersion('5.0.0');
+            }).toThrow('Firebot version must be >= 5.0.0 to use this feature (got 4.99.99).');
+        });
+    });
+
+    describe('edge cases and malformed versions', () => {
+        it('should handle version with missing minor component in firebot version', () => {
+            (firebot.firebot as any).version = '5';
+            expect(() => {
+                requireVersion('5.0');
+            }).not.toThrow();
+        });
+
+        it('should handle version with missing patch component in firebot version', () => {
+            (firebot.firebot as any).version = '5.65';
+            expect(() => {
+                requireVersion('5.65.0');
+            }).not.toThrow();
+        });
+
+        it('should handle requirement with missing minor component', () => {
+            (firebot.firebot as any).version = '5.65.0';
+            expect(() => {
+                requireVersion('5');
+            }).not.toThrow();
+        });
+
+        it('should treat missing components as zero in firebot version', () => {
+            (firebot.firebot as any).version = '5';
+            expect(() => {
+                requireVersion('5.1');
+            }).toThrow('Firebot version must be >= 5.1 to use this feature (got 5).');
+        });
+
+        it('should treat missing components as zero in requirement version', () => {
+            (firebot.firebot as any).version = '5.0.0';
+            expect(() => {
+                requireVersion('5');
+            }).not.toThrow();
+        });
+
+        it('should handle beta/pre-release versions', () => {
+            (firebot.firebot as any).version = '5.65.1-beta.2';
+            expect(() => {
+                requireVersion('5.65.0');
+            }).not.toThrow();
+        });
+
+        it('should handle version with non-numeric patch part', () => {
+            (firebot.firebot as any).version = '5.65.1-alpha';
+            expect(() => {
+                requireVersion('5.65.1');
+            }).not.toThrow();
+        });
+    });
+
+    describe('zero versions', () => {
+        it('should handle zero major version', () => {
+            (firebot.firebot as any).version = '0.5.0';
+            expect(() => {
+                requireVersion('0.5');
+            }).not.toThrow();
+        });
+
+        it('should handle zero minor version', () => {
+            (firebot.firebot as any).version = '5.0.3';
+            expect(() => {
+                requireVersion('5.0.2');
+            }).not.toThrow();
+        });
+
+        it('should handle zero patch version', () => {
+            (firebot.firebot as any).version = '5.65.0';
+            expect(() => {
+                requireVersion('5.65.0');
+            }).not.toThrow();
+        });
+
+        it('should handle all zero version', () => {
+            (firebot.firebot as any).version = '0.0.0';
+            expect(() => {
+                requireVersion('0.0.0');
+            }).not.toThrow();
+        });
+    });
+
+    describe('real-world scenarios', () => {
+        it('should handle current typical usage (5.65)', () => {
+            (firebot.firebot as any).version = '5.65.0';
+            expect(() => {
+                requireVersion('5.65');
+            }).not.toThrow();
+        });
+
+        it('should handle future major version bump', () => {
+            (firebot.firebot as any).version = '6.0.0';
+            expect(() => {
+                requireVersion('5.65');
+            }).not.toThrow();
+        });
+
+        it('should handle specific patch requirements', () => {
+            (firebot.firebot as any).version = '5.65.4';
+            expect(() => {
+                requireVersion('5.65.3');
+            }).not.toThrow();
+        });
+
+        it('should fail for insufficient patch version', () => {
+            (firebot.firebot as any).version = '5.65.2';
+            expect(() => {
+                requireVersion('5.65.3');
+            }).toThrow('Firebot version must be >= 5.65.3 to use this feature (got 5.65.2).');
+        });
+    });
+});

--- a/src/internal/reflector.ts
+++ b/src/internal/reflector.ts
@@ -1,0 +1,51 @@
+import { AngularJsFactory, UIExtension } from "@crowbartools/firebot-custom-scripts-types/types/modules/ui-extension-manager";
+import { IntegrationConstants } from "../constants";
+import { firebot, logger } from "../main";
+import { ReflectedEvent } from "../shared/types";
+import { requireVersion } from "./version";
+
+const kickReflectorService: AngularJsFactory = {
+    name: "kickReflectorService",
+    function: (backendCommunicator: any) => {
+        // IntegrationConstants not available in here, so hardcoding
+        backendCommunicator.onAsync(`mage-kick-integration:reflect-async`, async (data: ReflectedEvent) => {
+            if (data == null || !data.eventName?.length) {
+                return;
+            }
+            if (data.async) {
+                return backendCommunicator.fireEventAsync(data.eventName, data.eventData);
+            }
+            return backendCommunicator.fireEventSync(data.eventName, data.eventData);
+        });
+
+        return {};
+    }
+};
+
+export const reflectorExtension: UIExtension = {
+    id: `${IntegrationConstants.INTEGRATION_ID}-reflector`,
+    providers: {
+        factories: [kickReflectorService]
+    }
+};
+
+export async function reflectEvent<T>(eventName: string, eventData: any, isAsync = true): Promise<T> {
+    // Needs commit d4352b4
+    requireVersion("5.65");
+
+    const payload: ReflectedEvent = {
+        async: isAsync,
+        eventName,
+        eventData
+    };
+    logger.debug(`Sending reflect event to frontend: eventName=${eventName}, isAsync=${isAsync}`);
+
+    const { frontendCommunicator } = firebot.modules;
+    const timeoutMs = 1000;
+    return await Promise.race([
+        frontendCommunicator.fireEventAsync<any>(`${IntegrationConstants.INTEGRATION_ID}:reflect-async`, payload),
+        new Promise<never>((_, reject) => setTimeout(() => {
+            reject(new Error("Reflect event timeout"));
+        }, timeoutMs))
+    ]) as T;
+}

--- a/src/internal/version.ts
+++ b/src/internal/version.ts
@@ -1,0 +1,39 @@
+import { firebot } from "../main";
+
+export function requireVersion(versionNumber: string): void {
+    if (!firebot || !firebot.firebot || !firebot.firebot.version) {
+        throw new Error("Firebot version information is not available.");
+    }
+
+    const firebotVersion = firebot.firebot.version;
+    const firebotParts = firebotVersion.split('.');
+    const majorVersion = parseInt(firebotParts[0], 10);
+    const minorVersion = parseInt(firebotParts[1] || '0', 10);
+    const patchVersion = parseInt(firebotParts[2] || '0', 10);
+
+    const reqParts = versionNumber.split('.');
+    const reqMajor = parseInt(reqParts[0], 10);
+    const reqMinor = parseInt(reqParts[1] || '0', 10);
+    const reqPatch = reqParts.length >= 3 ? parseInt(reqParts[2] || '0', 10) : undefined;
+
+    // Check major version
+    if (majorVersion < reqMajor) {
+        throw new Error(`Firebot version must be >= ${versionNumber} to use this feature (got ${firebotVersion}).`);
+    }
+    if (majorVersion > reqMajor) {
+        return; // Higher major version is always sufficient
+    }
+
+    // Major versions are equal, check minor version
+    if (minorVersion < reqMinor) {
+        throw new Error(`Firebot version must be >= ${versionNumber} to use this feature (got ${firebotVersion}).`);
+    }
+    if (minorVersion > reqMinor) {
+        return; // Higher minor version is sufficient
+    }
+
+    // Major and minor versions are equal, check patch version if specified
+    if (reqPatch !== undefined && patchVersion < reqPatch) {
+        throw new Error(`Firebot version must be >= ${versionNumber} to use this feature (got ${firebotVersion}).`);
+    }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -181,3 +181,9 @@ export interface WebhookReceivedEvent {
     isTestEvent: boolean;
     timestamp: Date | null;
 }
+
+export interface ReflectedEvent {
+    async: boolean;
+    eventName: string;
+    eventData: any;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "./dist/",
-        "target": "ES6",
+        "target": "ES2017",
         "module": "CommonJS",
         "allowSyntheticDefaultImports": true,
         "noImplicitAny": true,


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
A recent change to the `v5` branch of Firebot allows the creation of a "reflector" so that the backend can send events to the backend by "reflecting" them through the frontend. This PR implements a library that does that. It also includes version checking, to make sure the Firebot version is sufficiently recent.

### Motivation
Additional flexibility to trigger certain actions that are not exposed to the scripting interface.

### Testing
I had a dummy variable into which I was able to inject the JSON object of all counters.
