### PR TITLE
Cheering with kicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ _Events are generally trigged by receiving a webhook or a websocket event from K
 | Goal updated | Possible * | Possible * | No public API support |
 | Host (raid) (incoming) | :white_check_mark: &#42; | :white_check_mark: &#42; | No public API support |
 | Host (raid) (outgoing) | :white_check_mark: &#42; | :white_check_mark: &#42; | No public API support |
+| Kicks (like bits) | :white_check_mark: &#42; | :white_check_mark: &#42; | No public API support |
 | Message deleted | Possible * | Possible * | No public API support |
 | Message pinned | Possible * | Possible * | No public API support |
 | Message un-pinned | Possible * | Possible * | No public API support |
@@ -103,7 +104,7 @@ _Events are generally trigged by receiving a webhook or a websocket event from K
 | Currency: Watch time | :x: | No viewer list API endpoint on Kick &#x1F1F0; |
 | Moderation: Banned words / URLs | :x: | Kick API lacks ability to delete messages &#x1F1F0; |
 | Ranks | :x: | Pointless without proper currency support |
-| Roles | :white_check_mark: | Seems to mostly work; Twitch role filters emulated in platform-aware filter |
+| Roles | :white_check_mark: | Twitch role filters emulated in platform-aware filter |
 | Viewer database | :x: | Firebot assumes all users are Twitch users &#x1F525; |
 
 &#x1F1F0; = Denotes that the feature cannot be fully supported due to [Kick limitations](#limitations-due-to-kick)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,7 +1003,7 @@
         },
         "node_modules/@crowbartools/firebot-custom-scripts-types": {
             "version": "5.64.0",
-            "resolved": "git+ssh://git@github.com/TheStaticMage/firebot-custom-scripts-types.git#fca17ac74418297c65883c065c13be5179a4f1ae",
+            "resolved": "git+ssh://git@github.com/TheStaticMage/firebot-custom-scripts-types.git#9efe2998fcd256826ec5f040da6b583611c51347",
             "dev": true,
             "license": "ISC",
             "dependencies": {

--- a/src/__tests__/kicks.e2e.test.ts
+++ b/src/__tests__/kicks.e2e.test.ts
@@ -1,0 +1,154 @@
+const triggerEventMock = jest.fn();
+const mockGetSettings = jest.fn();
+
+jest.mock('../integration', () => ({
+    integration: {
+        kick: {
+            broadcaster: {
+                userId: "123456",
+                name: "teststreamer",
+                profilePicture: "https://example.com/profile.jpg"
+            }
+        },
+        getSettings: () => mockGetSettings()
+    }
+}));
+
+jest.mock('../main', () => ({
+    firebot: {
+        modules: {
+            eventManager: {
+                triggerEvent: triggerEventMock
+            },
+            frontendCommunicator: {
+                send: jest.fn()
+            }
+        }
+    },
+    logger: {
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn()
+    }
+}));
+
+import { IntegrationConstants } from '../constants';
+import { KickPusher } from '../internal/pusher/pusher';
+
+describe('e2e kicks gifted events', () => {
+    let pusher: KickPusher;
+
+    beforeEach(() => {
+        pusher = new KickPusher();
+        // Mock the delay method to resolve immediately for testing
+        jest.spyOn(pusher as any, 'delay').mockResolvedValue(undefined);
+        jest.clearAllMocks();
+        mockGetSettings.mockReturnValue({
+            triggerTwitchEvents: { cheer: false },
+            logging: { logWebhooks: false }
+        });
+    });
+
+    describe('pusher only - KicksGifted', () => {
+        it('handles pusher kicks gifted event', async () => {
+            const pusherEvent = 'KicksGifted';
+
+            /* eslint-disable camelcase */
+            const pusherPayload = {
+                message: "",
+                sender: {
+                    id: 12345678,
+                    username: "gifter-username",
+                    username_color: "#ffffcc"
+                },
+                gift: {
+                    amount: 69
+                }
+            };
+            /* eslint-enable camelcase */
+
+            const expectedKickMetadata = {
+                userId: 'k12345678',
+                username: 'gifter-username@kick',
+                userDisplayName: 'gifter-username',
+                amount: 69,
+                bits: 69, // Mapped to bits for Twitch compatibility
+                platform: 'kick'
+            };
+
+            // Simulate pusher event dispatch
+            await (pusher as any).dispatchChannelEvent(pusherEvent, pusherPayload);
+
+            // With mocked delay, the event should process immediately
+            // Allow all async operations to complete
+            await new Promise(resolve => setImmediate(resolve));
+
+            // Should trigger kicks-gifted event
+            expect(triggerEventMock).toHaveBeenCalledWith(
+                IntegrationConstants.INTEGRATION_ID,
+                "kicks-gifted",
+                expectedKickMetadata
+            );
+
+            // Should NOT trigger Twitch cheer event since it's disabled
+            expect(triggerEventMock).not.toHaveBeenCalledWith(
+                "twitch",
+                "cheer",
+                expect.any(Object)
+            );
+        });
+
+        it('handles pusher kicks gifted event with twitch forwarding enabled', async () => {
+            // Enable Twitch cheer forwarding
+            mockGetSettings.mockReturnValue({
+                triggerTwitchEvents: { cheer: true },
+                logging: { logWebhooks: false }
+            });
+
+            const pusherEvent = 'KicksGifted';
+
+            /* eslint-disable camelcase */
+            const pusherPayload = {
+                message: "",
+                sender: {
+                    id: 12345678,
+                    username: "gifter-username",
+                    username_color: "#ffffcc"
+                },
+                gift: {
+                    amount: 69
+                }
+            };
+            /* eslint-enable camelcase */
+
+            const expectedMetadata = {
+                userId: 'k12345678',
+                username: 'gifter-username@kick',
+                userDisplayName: 'gifter-username',
+                amount: 69,
+                bits: 69,
+                platform: 'kick'
+            };
+
+            // Simulate pusher event dispatch
+            await (pusher as any).dispatchChannelEvent(pusherEvent, pusherPayload);
+
+            // Allow all async operations to complete
+            await new Promise(resolve => setImmediate(resolve));
+
+            // Should trigger both kicks-gifted and Twitch cheer events
+            expect(triggerEventMock).toHaveBeenCalledWith(
+                IntegrationConstants.INTEGRATION_ID,
+                "kicks-gifted",
+                expectedMetadata
+            );
+
+            expect(triggerEventMock).toHaveBeenCalledWith(
+                "twitch",
+                "cheer",
+                expectedMetadata
+            );
+        });
+    });
+});

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -359,6 +359,26 @@ export const eventSource: EventSource = {
                 webhookType: "chat.message.sent",
                 webhookVersion: "1"
             }
+        },
+        {
+            id: "kicks-gifted",
+            name: "Kicks Gifted",
+            description: "When someone gifts Kicks (like bits) in your channel on Kick",
+            cached: false,
+            manualMetadata: {
+                gifterUsername: "Firebot@kick",
+                gifterUserId: "k1234567",
+                amount: 100
+            },
+            activityFeed: {
+                icon: "fad fa-coins",
+                getMessage: (eventData) => {
+                    const username = typeof eventData.gifterUsername === "string" ? unkickifyUsername(eventData.gifterUsername) : "Unknown User";
+                    const userDisplayName = typeof eventData.userDisplayName === "string" ? eventData.userDisplayName : username;
+                    const amount = getNumberFromUnknown(eventData.amount, "Unknown");
+                    return `**${userDisplayName}** gifted **${amount} Kicks** on Kick`;
+                }
+            }
         }
     ]
 };

--- a/src/events/kicks.ts
+++ b/src/events/kicks.ts
@@ -1,0 +1,30 @@
+import { IntegrationConstants } from "../constants";
+import { integration } from "../integration";
+import { kickifyUserId, kickifyUsername, unkickifyUsername } from "../internal/util";
+import { firebot } from "../main";
+import { KicksGiftedEvent } from "../shared/types";
+
+class KicksHandler {
+    async handleKicksGiftedEvent(payload: KicksGiftedEvent): Promise<void> {
+        this.triggerKicksGiftedEvent(payload);
+    }
+
+    private triggerKicksGiftedEvent(data: KicksGiftedEvent): void {
+        const { eventManager } = firebot.modules;
+        const metadata = {
+            userId: kickifyUserId(data.gifter.userId),
+            username: kickifyUsername(data.gifter.username),
+            userDisplayName: data.gifter.displayName || unkickifyUsername(data.gifter.username),
+            amount: data.kicks,
+            bits: data.kicks, // Map to bits for Twitch compatibility
+            platform: "kick"
+        };
+        eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "kicks-gifted", metadata);
+
+        if (integration.getSettings().triggerTwitchEvents.cheer) {
+            eventManager.triggerEvent("twitch", "cheer", metadata);
+        }
+    }
+}
+
+export const kicksHandler = new KicksHandler();

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -126,99 +126,91 @@ export const definition: IntegrationDefinition = {
                     title: "Chat Message",
                     tip: "Trigger the 'Twitch:Chat Message' event when someone chats on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 1
+                    default: false
+                },
+                cheer: {
+                    title: "Cheer (Kicks / Bits)",
+                    tip: "Trigger the 'Twitch:Cheer' event when someone cheers (with Kicks) on Kick",
+                    type: "boolean",
+                    default: false
                 },
                 follower: {
                     title: "Follower",
                     tip: "Trigger the 'Twitch:Follow' event when someone follows on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 2
+                    default: false
                 },
                 raid: {
                     title: "Host - Incoming",
                     tip: "Trigger the 'Twitch:Raid' event when someone hosts (raids) your stream on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 3
+                    default: false
                 },
                 raidSentOff: {
                     title: "Host - Outgoing",
                     tip: "Trigger the 'Twitch:Raid Sent Off' event when you send a host (raid) to another channel on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 4
+                    default: false
                 },
                 streamOffline: {
                     title: "Stream Ended",
                     tip: "Trigger the 'Twitch:Stream Ended' event when the Kick stream goes offline",
                     type: "boolean",
-                    default: false,
-                    sortRank: 5
+                    default: false
                 },
                 streamOnline: {
                     title: "Stream Started",
                     tip: "Trigger the 'Twitch:Stream Started' event when the Kick stream goes online",
                     type: "boolean",
-                    default: false,
-                    sortRank: 6
+                    default: false
                 },
                 sub: {
                     title: "Sub",
                     tip: "Trigger the 'Twitch:Sub' event when someone subscribes or resubscribes on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 7
+                    default: false
                 },
                 subCommunityGift: {
                     title: "Sub Community Gift",
                     tip: "Trigger the 'Twitch:Community Subs Gifted' event when someone gifts community subscriptions on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 8
+                    default: false
                 },
                 subGift: {
                     title: "Sub Gifted",
                     tip: "Trigger the 'Twitch:Sub Gifted' event when someone gifts a subscription on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 9
+                    default: false
                 },
                 titleChanged: {
                     title: "Title Changed",
                     tip: "Trigger the 'Twitch:Title Changed' event when the Kick stream title changes",
                     type: "boolean",
-                    default: false,
-                    sortRank: 10
+                    default: false
                 },
                 viewerArrived: {
                     title: "Viewer Arrived",
                     tip: "Trigger the 'Twitch:Viewer Arrived' event when a viewer arrives on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 11
+                    default: false
                 },
                 viewerBanned: {
                     title: "Viewer Banned",
                     tip: "Trigger the 'Twitch:Viewer Banned' event when a viewer is banned on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 12
+                    default: false
                 },
                 viewerTimeout: {
                     title: "Viewer Timeout",
                     tip: "Trigger the 'Twitch:Viewer Timeout' event when a viewer is timed out on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 13
+                    default: false
                 },
                 viewerUnbanned: {
                     title: "Viewer Unbanned",
                     tip: "Trigger the 'Twitch:Viewer Unbanned' event when a viewer is unbanned on Kick",
                     type: "boolean",
-                    default: false,
-                    sortRank: 14
+                    default: false
                 }
             }
         },

--- a/src/internal/pusher/kicks.d.ts
+++ b/src/internal/pusher/kicks.d.ts
@@ -1,0 +1,11 @@
+interface KickGiftedEventData {
+    message: string;
+    sender: {
+        id: number;
+        username: string;
+        username_color: string;
+    };
+    gift: {
+        amount: number;
+    };
+}

--- a/src/internal/pusher/pusher-parsers.ts
+++ b/src/internal/pusher/pusher-parsers.ts
@@ -1,6 +1,6 @@
 import { integration } from "../../integration";
 import { logger } from "../../main";
-import { ChannelGiftSubscription, ChatMessage, KickUser, LivestreamStatusUpdated, ModerationBannedEvent, ModerationUnbannedEvent, RaidSentOffEvent, RewardRedeemedEvent, StreamHostedEvent } from "../../shared/types";
+import { ChannelGiftSubscription, ChatMessage, KicksGiftedEvent, KickUser, LivestreamStatusUpdated, ModerationBannedEvent, ModerationUnbannedEvent, RaidSentOffEvent, RewardRedeemedEvent, StreamHostedEvent } from "../../shared/types";
 import { parseDate } from "../util";
 
 export function parseChatMessageEvent(data: any, broadcaster: KickUser): ChatMessage {
@@ -241,5 +241,23 @@ export async function parseGiftSubEvent(data: any): Promise<ChannelGiftSubscript
         giftees: giftees,
         createdAt: new Date(),
         expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) // Assume 30 days from now
+    };
+}
+
+export function parseKicksGiftedEvent(data: any): KicksGiftedEvent {
+    const d = data as KickGiftedEventData;
+
+    const gifter: KickUser = {
+        userId: d.sender.id.toString(),
+        username: d.sender.username,
+        displayName: d.sender.username,
+        profilePicture: '', // Not provided in event
+        isVerified: false, // Not provided in event
+        channelSlug: '' // Not provided in event
+    };
+
+    return {
+        gifter: gifter,
+        kicks: d.gift.amount
     };
 }

--- a/src/internal/pusher/pusher.ts
+++ b/src/internal/pusher/pusher.ts
@@ -1,4 +1,5 @@
 import { handleChatMessageSentEvent } from "../../events/chat-message-sent";
+import { kicksHandler } from "../../events/kicks";
 import { livestreamStatusUpdatedHandler } from "../../events/livestream-status-updated";
 import { moderationBannedEventHandler } from "../../events/moderation-banned";
 import { handleModerationUnbannedEvent } from "../../events/moderation-unbanned";
@@ -9,7 +10,7 @@ import { handleChannelSubscriptionGiftsEvent } from "../../events/sub-events";
 import { integration } from "../../integration";
 import { logger } from "../../main";
 import { KickUser } from "../../shared/types";
-import { parseChatMessageEvent, parseChatMoveToSupportedChannelEvent, parseGiftSubEvent, parseRewardRedeemedEvent, parseStopStreamBroadcast, parseStreamerIsLiveEvent, parseStreamHostedEvent, parseViewerBannedOrTimedOutEvent, parseViewerUnbannedEvent } from "./pusher-parsers";
+import { parseChatMessageEvent, parseChatMoveToSupportedChannelEvent, parseGiftSubEvent, parseKicksGiftedEvent, parseRewardRedeemedEvent, parseStopStreamBroadcast, parseStreamerIsLiveEvent, parseStreamHostedEvent, parseViewerBannedOrTimedOutEvent, parseViewerUnbannedEvent } from "./pusher-parsers";
 
 const Pusher = require('pusher-js');
 
@@ -107,6 +108,9 @@ export class KickPusher {
                     break;
                 case "App\\Events\\StreamerIsLiveEvent":
                     await livestreamStatusUpdatedHandler.handleLivestreamStatusUpdatedEvent(parseStreamerIsLiveEvent(data));
+                    break;
+                case "KicksGifted":
+                    await kicksHandler.handleKicksGiftedEvent(parseKicksGiftedEvent(data));
                     break;
                 case 'pusher:subscription_succeeded':
                     logger.info("Pusher subscribed successfully to channel events.");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -187,3 +187,10 @@ export interface ReflectedEvent {
     eventName: string;
     eventData: any;
 }
+
+export interface KicksGiftedEvent {
+    gifter: KickUser,
+    kicks: number,
+    // More to come, possibly, if this gets added to the API
+    // or I get better data from actual events
+}

--- a/src/variables/cheer-kicks-amount.ts
+++ b/src/variables/cheer-kicks-amount.ts
@@ -1,0 +1,15 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+
+export const cheerKicksAmountVariable: ReplaceVariable = {
+    definition: {
+        handle: "cheerKicksAmount",
+        aliases: ["kickGameId"],
+        description: "The amount of kicks (like bits) in the cheer.",
+        categories: ["common"],
+        possibleDataOutput: ["number"]
+    },
+    evaluator: async (trigger) => {
+        const kicks = trigger.metadata.eventData?.kicks ?? 0;
+        return kicks;
+    }
+};


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Supports cheering with "Kicks" (which are like Twitch bits):
- Event for "Kicks Gifted" (since that's what the websocket message says)
- Option to "forward" this event to the Twitch "cheer" event
- `$cheerKicksAmount` variable
- Available in `$cheerBitsAmount` with Firebot >= 5.65 (current nightly build)
- Cheer bits filter is available with Firebot >= 5.65 (current nightly build)

### Motivation
New feature!

### Testing
This is entirely designed based on someone who posted an example websocket message in the Discord. I have not ever seen this websocket message myself. It's possible this won't work if this implementation isn't correct.
