### PR TITLE
Add events to compatible Twitch filters and variables

### DIFF
--- a/src/__tests__/moderation.test.ts
+++ b/src/__tests__/moderation.test.ts
@@ -54,7 +54,7 @@ describe('e2e moderation unbanned', () => {
         moderatorId: 'k444',
         moderatorUsername: 'mod2@kick',
         moderatorDisplayName: 'mod2',
-        moderator: 'mod2@kick',
+        moderator: 'mod2',
         banType: 'timeout',
         platform: 'kick'
     };

--- a/src/events/moderation-unbanned.ts
+++ b/src/events/moderation-unbanned.ts
@@ -16,7 +16,7 @@ export async function handleModerationUnbannedEvent(payload: ModerationUnbannedE
         moderatorUsername: kickifyUsername(payload.moderator.username),
         moderatorId: kickifyUserId(payload.moderator.userId.toString()),
         moderatorDisplayName: payload.moderator.displayName || unkickifyUsername(payload.moderator.username),
-        moderator: kickifyUsername(payload.moderator.username),
+        moderator: unkickifyUsername(payload.moderator.username),
         banType: payload.banType,
         platform: "kick"
     };

--- a/src/filters/host-viewer-count.ts
+++ b/src/filters/host-viewer-count.ts
@@ -7,7 +7,8 @@ export const hostViewerCountFilter: EventFilter = {
     name: "Host Viewer Count",
     description: "Filter by how many viewers have been brought by the host.",
     events: [
-        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "raid" }
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "raid" },
+        { eventSourceId: IntegrationConstants.INTEGRATION_ID, eventId: "raid-sent-off" }
     ],
     comparisonTypes: [
         ComparisonType.IS,

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -319,10 +319,31 @@ export class KickIntegration extends EventEmitter {
         restrictionManager.registerRestriction(platformRestriction);
 
         // Twitch filters and variables (adding events to filters and variables was added in Firebot 5.65+)
+        // via commit https://github.com/crowbartools/Firebot/commit/55744f55095d6d6ca791adced534c5a6fad37119
         try {
             requireVersion("5.65.0");
+
             eventFilterManager.addEventToFilter("firebot:cheerbitsamount", IntegrationConstants.INTEGRATION_ID, "kicks-gifted");
+            eventFilterManager.addEventToFilter("firebot:raid-viewer-count", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");
+            eventFilterManager.addEventToFilter("firebot:raid-viewer-count", IntegrationConstants.INTEGRATION_ID, "raid");
+
+            replaceVariableManager.addEventToVariable("chatMessage", IntegrationConstants.INTEGRATION_ID, "chat-message");
+            replaceVariableManager.addEventToVariable("chatMessage", IntegrationConstants.INTEGRATION_ID, "viewer-arrived");
             replaceVariableManager.addEventToVariable("cheerBitsAmount", IntegrationConstants.INTEGRATION_ID, "kicks-gifted");
+            replaceVariableManager.addEventToVariable("moderator", IntegrationConstants.INTEGRATION_ID, "banned");
+            replaceVariableManager.addEventToVariable("moderator", IntegrationConstants.INTEGRATION_ID, "timeout");
+            replaceVariableManager.addEventToVariable("moderator", IntegrationConstants.INTEGRATION_ID, "unbanned");
+            replaceVariableManager.addEventToVariable("modReason", IntegrationConstants.INTEGRATION_ID, "banned");
+            replaceVariableManager.addEventToVariable("modReason", IntegrationConstants.INTEGRATION_ID, "timeout");
+            replaceVariableManager.addEventToVariable("raidTargetUserDisplayName", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");
+            replaceVariableManager.addEventToVariable("raidTargetUserId", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");
+            replaceVariableManager.addEventToVariable("raidTargetUsername", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");
+            replaceVariableManager.addEventToVariable("raidViewerCount", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");
+            replaceVariableManager.addEventToVariable("raidViewerCount", IntegrationConstants.INTEGRATION_ID, "raid");
+            replaceVariableManager.addEventToVariable("rewardId", IntegrationConstants.INTEGRATION_ID, "channel-reward-redemption");
+            replaceVariableManager.addEventToVariable("rewardMessage", IntegrationConstants.INTEGRATION_ID, "channel-reward-redemption");
+            replaceVariableManager.addEventToVariable("rewardName", IntegrationConstants.INTEGRATION_ID, "channel-reward-redemption");
+            replaceVariableManager.addEventToVariable("timeoutDuration", IntegrationConstants.INTEGRATION_ID, "timeout");
         } catch (error) {
             logger.warn(`This version of Firebot does not support mapping certain Twitch filters and variables. Please update to Firebot 5.65 or later to enable these features: ${error}`);
         }

--- a/src/variables/chat-message.ts
+++ b/src/variables/chat-message.ts
@@ -8,7 +8,8 @@ export const kickChatMessageVariable: ReplaceVariable = {
         triggers: {
             "manual": true,
             "event": [
-                "mage-kick-integration:chat-message"
+                "mage-kick-integration:chat-message",
+                "mage-kick-integration:viewer-arrived"
             ]
         },
         categories: ["common"],


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds appropriate events to certain Firebot built-in filters and variables via the recently added ability to add events to filters and variables. These are the filters and variables for which the Kick integration produces metadata that is very much like the Twitch metadata, but for which we needed separate Kick variants due to the Firebot limitations. This requires Firebot 5.65+ (currently nightly builds). Older versions should gracefully ignore this, but log a warning.

### Motivation
We ultimately want to move these variables where possible. We'll keep the old stuff around until Firebot 5.65 gets officially released though.

### Testing

Starting to convert my setup! Will test as I go along.

- [x] eventFilterManager.addEventToFilter("firebot:cheerbitsamount", IntegrationConstants.INTEGRATION_ID, "kicks-gifted");
- [x] eventFilterManager.addEventToFilter("firebot:raid-viewer-count", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");
- [x] eventFilterManager.addEventToFilter("firebot:raid-viewer-count", IntegrationConstants.INTEGRATION_ID, "raid");
- [x] replaceVariableManager.addEventToVariable("chatMessage", IntegrationConstants.INTEGRATION_ID, "chat-message");
- [x] replaceVariableManager.addEventToVariable("chatMessage", IntegrationConstants.INTEGRATION_ID, "viewer-arrived");
- [x] replaceVariableManager.addEventToVariable("cheerBitsAmount", IntegrationConstants.INTEGRATION_ID, "kicks-gifted");
- [x] replaceVariableManager.addEventToVariable("moderator", IntegrationConstants.INTEGRATION_ID, "banned");
- [x] replaceVariableManager.addEventToVariable("moderator", IntegrationConstants.INTEGRATION_ID, "timeout");
- [x] replaceVariableManager.addEventToVariable("moderator", IntegrationConstants.INTEGRATION_ID, "unbanned");
- [x] replaceVariableManager.addEventToVariable("modReason", IntegrationConstants.INTEGRATION_ID, "banned");
- [x] replaceVariableManager.addEventToVariable("modReason", IntegrationConstants.INTEGRATION_ID, "timeout");
- [x] replaceVariableManager.addEventToVariable("raidTargetUserDisplayName", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");
- [x] replaceVariableManager.addEventToVariable("raidTargetUserId", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");
- [x] replaceVariableManager.addEventToVariable("raidTargetUsername", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");
- [x] replaceVariableManager.addEventToVariable("raidViewerCount", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");
- [x] replaceVariableManager.addEventToVariable("raidViewerCount", IntegrationConstants.INTEGRATION_ID, "raid");
- [x] replaceVariableManager.addEventToVariable("rewardId", IntegrationConstants.INTEGRATION_ID, "channel-reward-redemption");
- [ ] replaceVariableManager.addEventToVariable("rewardMessage", IntegrationConstants.INTEGRATION_ID, "channel-reward-redemption");
- [x] replaceVariableManager.addEventToVariable("rewardName", IntegrationConstants.INTEGRATION_ID, "channel-reward-redemption");
- [x] replaceVariableManager.addEventToVariable("timeoutDuration", IntegrationConstants.INTEGRATION_ID, "timeout");