### PR TITLE
Add additional data fields to kicks

### DIFF
--- a/src/__tests__/kicks.e2e.test.ts
+++ b/src/__tests__/kicks.e2e.test.ts
@@ -39,6 +39,44 @@ import { KickPusher } from '../internal/pusher/pusher';
 describe('e2e kicks gifted events', () => {
     let pusher: KickPusher;
 
+    const pusherEvent = 'KicksGifted';
+
+    /* eslint-disable camelcase */
+    const pusherPayload = {
+        message: "Test message",
+        sender: {
+            id: 12345678,
+            username: "gifter-username",
+            username_color: "#ffffcc"
+        },
+        gift: {
+            gift_id: "super_gift",
+            name: "Super Gift",
+            type: "BASIC",
+            tier: "BASIC",
+            character_limit: 69,
+            pinned_time: 123456789,
+            amount: 25
+        }
+    };
+    /* eslint-enable camelcase */
+
+    const expectedKickMetadata = {
+        userId: 'k12345678',
+        username: 'gifter-username@kick',
+        userDisplayName: 'gifter-username',
+        amount: 25,
+        bits: 25, // Mapped to bits for Twitch compatibility
+        characterLimit: 69,
+        cheerMessage: 'Test message',
+        giftId: 'super_gift',
+        giftName: 'Super Gift',
+        giftType: 'BASIC',
+        giftTier: 'BASIC',
+        pinnedTime: 123456789,
+        platform: 'kick'
+    };
+
     beforeEach(() => {
         pusher = new KickPusher();
         // Mock the delay method to resolve immediately for testing
@@ -52,30 +90,6 @@ describe('e2e kicks gifted events', () => {
 
     describe('pusher only - KicksGifted', () => {
         it('handles pusher kicks gifted event', async () => {
-            const pusherEvent = 'KicksGifted';
-
-            /* eslint-disable camelcase */
-            const pusherPayload = {
-                message: "",
-                sender: {
-                    id: 12345678,
-                    username: "gifter-username",
-                    username_color: "#ffffcc"
-                },
-                gift: {
-                    amount: 69
-                }
-            };
-            /* eslint-enable camelcase */
-
-            const expectedKickMetadata = {
-                userId: 'k12345678',
-                username: 'gifter-username@kick',
-                userDisplayName: 'gifter-username',
-                amount: 69,
-                bits: 69, // Mapped to bits for Twitch compatibility
-                platform: 'kick'
-            };
 
             // Simulate pusher event dispatch
             await (pusher as any).dispatchChannelEvent(pusherEvent, pusherPayload);
@@ -106,31 +120,6 @@ describe('e2e kicks gifted events', () => {
                 logging: { logWebhooks: false }
             });
 
-            const pusherEvent = 'KicksGifted';
-
-            /* eslint-disable camelcase */
-            const pusherPayload = {
-                message: "",
-                sender: {
-                    id: 12345678,
-                    username: "gifter-username",
-                    username_color: "#ffffcc"
-                },
-                gift: {
-                    amount: 69
-                }
-            };
-            /* eslint-enable camelcase */
-
-            const expectedMetadata = {
-                userId: 'k12345678',
-                username: 'gifter-username@kick',
-                userDisplayName: 'gifter-username',
-                amount: 69,
-                bits: 69,
-                platform: 'kick'
-            };
-
             // Simulate pusher event dispatch
             await (pusher as any).dispatchChannelEvent(pusherEvent, pusherPayload);
 
@@ -141,13 +130,13 @@ describe('e2e kicks gifted events', () => {
             expect(triggerEventMock).toHaveBeenCalledWith(
                 IntegrationConstants.INTEGRATION_ID,
                 "kicks-gifted",
-                expectedMetadata
+                expectedKickMetadata
             );
 
             expect(triggerEventMock).toHaveBeenCalledWith(
                 "twitch",
                 "cheer",
-                expectedMetadata
+                expectedKickMetadata
             );
         });
     });

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -368,7 +368,15 @@ export const eventSource: EventSource = {
             manualMetadata: {
                 gifterUsername: "Firebot@kick",
                 gifterUserId: "k1234567",
-                amount: 100
+                amount: 100,
+                bits: 100, // Mapped to bits for Twitch compatibility
+                characterLimit: 69,
+                cheerMessage: "Test message",
+                giftId: "super_gift",
+                giftName: "Super Gift",
+                giftType: "BASIC",
+                giftTier: "BASIC",
+                pinnedTime: 123456789
             },
             activityFeed: {
                 icon: "fad fa-coins",

--- a/src/events/kicks.ts
+++ b/src/events/kicks.ts
@@ -17,6 +17,13 @@ class KicksHandler {
             userDisplayName: data.gifter.displayName || unkickifyUsername(data.gifter.username),
             amount: data.kicks,
             bits: data.kicks, // Map to bits for Twitch compatibility
+            cheerMessage: data.message,
+            giftId: data.giftId,
+            giftName: data.giftName,
+            giftType: data.giftType,
+            giftTier: data.giftTier,
+            characterLimit: data.characterLimit,
+            pinnedTime: data.pinnedTime,
             platform: "kick"
         };
         eventManager.triggerEvent(IntegrationConstants.INTEGRATION_ID, "kicks-gifted", metadata);

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -24,6 +24,7 @@ import { Kick } from "./internal/kick";
 import { Poller } from "./internal/poll";
 import { KickPusher } from "./internal/pusher/pusher";
 import { reflectorExtension } from "./internal/reflector";
+import { requireVersion } from "./internal/version";
 import { firebot, logger } from "./main";
 import { platformRestriction } from "./restrictions/platform";
 import { getDataFilePath } from "./util/datafile";
@@ -32,12 +33,16 @@ import { kickCategoryIdVariable } from "./variables/category-id";
 import { kickCategoryImageUrlVariable } from "./variables/category-image-url";
 import { kickChannelIdVariable } from "./variables/channel-id";
 import { kickChatMessageVariable } from "./variables/chat-message";
-import { cheerKicksAmountVariable } from "./variables/cheer-kicks-amount";
 import { kickCurrentViewerCountVariable } from "./variables/current-viewer-count";
 import { hostTargetUserDisplayName } from "./variables/host-target-user-display-name";
 import { hostTargetUserId } from "./variables/host-target-user-id";
 import { hostTargetUsername } from "./variables/host-target-username";
 import { hostViewerCount } from "./variables/host-viewer-count";
+import { cheerKicksAmountVariable } from "./variables/kicks/cheer-kicks-amount";
+import { kicksGiftIdVariable } from "./variables/kicks/kicks-gift-id";
+import { kicksGiftNameVariable } from "./variables/kicks/kicks-gift-name";
+import { kicksGiftTierVariable } from "./variables/kicks/kicks-gift-tier";
+import { kicksGiftTypeVariable } from "./variables/kicks/kicks-gift-type";
 import { kickModReason } from "./variables/mod-reason";
 import { kickModeratorVariable } from "./variables/moderator";
 import { platformVariable } from "./variables/platform";
@@ -61,7 +66,6 @@ import { kickUnbanTypeVariable } from "./variables/unban-type";
 import { kickUptimeVariable } from "./variables/uptime";
 import { kickUserDisplayNameVariable } from "./variables/user-display-name";
 import { webhookReceivedEventTypeVariable, webhookReceivedEventVersionVariable, webhookReceivedLatencyVariable } from "./variables/webhook-received";
-import { requireVersion } from "./internal/version";
 
 type IntegrationParameters = {
     connectivity: {
@@ -302,6 +306,10 @@ export class KickIntegration extends EventEmitter {
 
         // Kicks (like bits) variables
         replaceVariableManager.registerReplaceVariable(cheerKicksAmountVariable);
+        replaceVariableManager.registerReplaceVariable(kicksGiftIdVariable);
+        replaceVariableManager.registerReplaceVariable(kicksGiftNameVariable);
+        replaceVariableManager.registerReplaceVariable(kicksGiftTierVariable);
+        replaceVariableManager.registerReplaceVariable(kicksGiftTypeVariable);
 
         // Miscellaneous variables
         replaceVariableManager.registerReplaceVariable(platformVariable);
@@ -330,6 +338,7 @@ export class KickIntegration extends EventEmitter {
             replaceVariableManager.addEventToVariable("chatMessage", IntegrationConstants.INTEGRATION_ID, "chat-message");
             replaceVariableManager.addEventToVariable("chatMessage", IntegrationConstants.INTEGRATION_ID, "viewer-arrived");
             replaceVariableManager.addEventToVariable("cheerBitsAmount", IntegrationConstants.INTEGRATION_ID, "kicks-gifted");
+            replaceVariableManager.addEventToVariable("cheerMessage", IntegrationConstants.INTEGRATION_ID, "kicks-gifted");
             replaceVariableManager.addEventToVariable("moderator", IntegrationConstants.INTEGRATION_ID, "banned");
             replaceVariableManager.addEventToVariable("moderator", IntegrationConstants.INTEGRATION_ID, "timeout");
             replaceVariableManager.addEventToVariable("moderator", IntegrationConstants.INTEGRATION_ID, "unbanned");

--- a/src/internal/pusher/kicks.d.ts
+++ b/src/internal/pusher/kicks.d.ts
@@ -6,6 +6,12 @@ interface KickGiftedEventData {
         username_color: string;
     };
     gift: {
+        gift_id: string;
+        name: string;
         amount: number;
+        type: string;
+        tier: string;
+        character_limit: number;
+        pinned_time: number;
     };
 }

--- a/src/internal/pusher/pusher-parsers.ts
+++ b/src/internal/pusher/pusher-parsers.ts
@@ -258,6 +258,13 @@ export function parseKicksGiftedEvent(data: any): KicksGiftedEvent {
 
     return {
         gifter: gifter,
-        kicks: d.gift.amount
+        kicks: d.gift.amount,
+        giftId: d.gift.gift_id,
+        giftName: d.gift.name,
+        giftType: d.gift.type,
+        giftTier: d.gift.tier,
+        characterLimit: d.gift.character_limit,
+        pinnedTime: d.gift.pinned_time,
+        message: d.message || ""
     };
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -191,6 +191,11 @@ export interface ReflectedEvent {
 export interface KicksGiftedEvent {
     gifter: KickUser,
     kicks: number,
-    // More to come, possibly, if this gets added to the API
-    // or I get better data from actual events
+    giftId: string,
+    giftName: string,
+    giftType: string,
+    giftTier: string,
+    characterLimit: number,
+    pinnedTime: number,
+    message: string
 }

--- a/src/variables/kicks/cheer-kicks-amount.ts
+++ b/src/variables/kicks/cheer-kicks-amount.ts
@@ -3,13 +3,12 @@ import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/type
 export const cheerKicksAmountVariable: ReplaceVariable = {
     definition: {
         handle: "cheerKicksAmount",
-        aliases: ["kickGameId"],
         description: "The amount of kicks (like bits) in the cheer.",
         categories: ["common"],
         possibleDataOutput: ["number"]
     },
     evaluator: async (trigger) => {
-        const kicks = trigger.metadata.eventData?.kicks ?? 0;
+        const kicks = trigger.metadata.eventData?.amount ?? trigger.metadata.eventData?.bits ?? 0;
         return kicks;
     }
 };

--- a/src/variables/kicks/kicks-gift-id.ts
+++ b/src/variables/kicks/kicks-gift-id.ts
@@ -1,0 +1,14 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+
+export const kicksGiftIdVariable: ReplaceVariable = {
+    definition: {
+        handle: "kicksGiftId",
+        description: "The gift ID of the kicks cheer.",
+        categories: ["common"],
+        possibleDataOutput: ["text"]
+    },
+    evaluator: async (trigger) => {
+        const giftId = trigger.metadata.eventData?.giftId ?? "";
+        return giftId;
+    }
+};

--- a/src/variables/kicks/kicks-gift-name.ts
+++ b/src/variables/kicks/kicks-gift-name.ts
@@ -1,0 +1,14 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+
+export const kicksGiftNameVariable: ReplaceVariable = {
+    definition: {
+        handle: "kicksGiftName",
+        description: "The gift name of the kicks cheer.",
+        categories: ["common"],
+        possibleDataOutput: ["text"]
+    },
+    evaluator: async (trigger) => {
+        const giftName = trigger.metadata.eventData?.giftName ?? "";
+        return giftName;
+    }
+};

--- a/src/variables/kicks/kicks-gift-tier.ts
+++ b/src/variables/kicks/kicks-gift-tier.ts
@@ -1,0 +1,14 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+
+export const kicksGiftTierVariable: ReplaceVariable = {
+    definition: {
+        handle: "kicksGiftTier",
+        description: "The gift tier of the kicks cheer.",
+        categories: ["common"],
+        possibleDataOutput: ["text"]
+    },
+    evaluator: async (trigger) => {
+        const giftTier = trigger.metadata.eventData?.giftTier ?? "";
+        return giftTier;
+    }
+};

--- a/src/variables/kicks/kicks-gift-type.ts
+++ b/src/variables/kicks/kicks-gift-type.ts
@@ -1,0 +1,14 @@
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+
+export const kicksGiftTypeVariable: ReplaceVariable = {
+    definition: {
+        handle: "kicksGiftType",
+        description: "The gift type of the kicks cheer.",
+        categories: ["common"],
+        possibleDataOutput: ["text"]
+    },
+    evaluator: async (trigger) => {
+        const giftType = trigger.metadata.eventData?.giftType ?? "";
+        return giftType;
+    }
+};


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Add these fields to the metadata for the "Kicks" event (in addition to what's already there):
- giftId
- giftName
- giftTier
- giftType
- cheerMessage
- pinnedTime
- characterLimit

Add variables for `$kicksGiftId`, `$kicksGiftName`, `$kicksGiftTier`, and `$kicksGiftType`.

Add event support for `$cheerMessage`.

### Motivation
<!-- Please describe WHY you are making this change. This may include links to GitHub issues if relevant. -->

### Testing
Simulated events
