### PR TITLE
Slash commands

### DIFF
--- a/src/internal/__tests__/chat-manager.test.ts
+++ b/src/internal/__tests__/chat-manager.test.ts
@@ -45,7 +45,10 @@ describe('ChatManager', () => {
             bot: { userId: 'botId' },
             httpCallWithTimeout: jest.fn().mockResolvedValue(undefined),
             getAuthToken: jest.fn().mockReturnValue('authToken'),
-            getBotAuthToken: jest.fn().mockReturnValue('botAuthToken')
+            getBotAuthToken: jest.fn().mockReturnValue('botAuthToken'),
+            userApi: {
+                banUserByUsername: jest.fn().mockResolvedValue(true)
+            }
         };
 
         // Mock integration settings
@@ -205,5 +208,458 @@ describe('ChatManager', () => {
         expect(result).toBe(false);
         expect(mockKick.httpCallWithTimeout).not.toHaveBeenCalled();
         expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Error handling slash command'));
+    });
+
+    it('handles /timeout command with duration conversion - values below 1 minute', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        // Test 30 seconds -> should round up to 1 minute
+        const payload = {
+            message: "/timeout testuser 30 test reason",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('testuser', 1, true, 'test reason');
+    });
+
+    it('handles /timeout command with duration conversion - exact minutes', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        // Test 120 seconds -> should be exactly 2 minutes
+        const payload = {
+            message: "/timeout testuser 120",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('testuser', 2, true, 'No reason given');
+    });
+
+    it('handles /timeout command with duration conversion - rounding to nearest minute', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        // Test 90 seconds -> should round to 2 minutes (90/60 = 1.5 -> rounds to 2)
+        const payload = {
+            message: "/timeout testuser 90 rounded reason",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('testuser', 2, true, 'rounded reason');
+    });
+
+    it('handles /timeout command with duration conversion - rounding down', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        // Test 80 seconds -> should round to 1 minute (80/60 = 1.33 -> rounds to 1)
+        const payload = {
+            message: "/timeout testuser 80",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('testuser', 1, true, 'No reason given');
+    });
+
+    it('throws error for /timeout command with duration exceeding maximum', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        // Test duration that exceeds 10800 minutes (648030 seconds = 10800.5 minutes -> rounds to 10801)
+        const payload = {
+            message: "/timeout testuser 648030 too long",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).not.toHaveBeenCalled();
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Timeout duration cannot exceed 10800 minutes'));
+    });
+
+    it('handles /timeout command at maximum duration limit', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        // Test exactly 10800 minutes (648000 seconds)
+        const payload = {
+            message: "/timeout testuser 648000 max duration",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('testuser', 10800, true, 'max duration');
+    });
+
+    it('handles /ban command successfully with reason', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        const payload = {
+            message: "/ban baduser spamming chat",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('baduser', 0, true, 'spamming chat');
+    });
+
+    it('handles /ban command successfully without reason', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        const payload = {
+            message: "/ban baduser",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('baduser', 0, true, 'No reason given');
+    });
+
+    it('throws error for /ban command with missing username', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/ban",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).not.toHaveBeenCalled();
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Usage: /ban <user> [reason]'));
+    });
+
+    it('throws error when /ban command API fails', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(false);
+
+        const payload = {
+            message: "/ban baduser reason",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('baduser', 0, true, 'reason');
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Failed to ban user: baduser'));
+    });
+
+    it('handles /unban command successfully', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        const payload = {
+            message: "/unban testuser",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('testuser', 0, false);
+    });
+
+    it('handles /untimeout command successfully', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(true);
+
+        const payload = {
+            message: "/untimeout testuser",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('testuser', 0, false);
+    });
+
+    it('throws error for /unban command with missing username', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/unban",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).not.toHaveBeenCalled();
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Usage: /unban <user>'));
+    });
+
+    it('throws error for /untimeout command with missing username', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/untimeout",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).not.toHaveBeenCalled();
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Usage: /untimeout <user>'));
+    });
+
+    it('throws error when /unban command API fails', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(false);
+
+        const payload = {
+            message: "/unban testuser",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('testuser', 0, false);
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Failed to unban/untimeout user: testuser'));
+    });
+
+    it('throws error when /untimeout command API fails', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(false);
+
+        const payload = {
+            message: "/untimeout testuser",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('testuser', 0, false);
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Failed to unban/untimeout user: testuser'));
+    });
+
+    it('handles /announcegreen command correctly', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/announcegreen This is a green announcement",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.httpCallWithTimeout).toHaveBeenCalledWith(
+            '/public/v1/chat',
+            'POST',
+            expect.stringContaining('[Announcement] This is a green announcement'),
+            null,
+            undefined,
+            'authToken'
+        );
+    });
+
+    it('handles /announceorange command correctly', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/announceorange Orange announcement here",
+            accountType: "Bot" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.httpCallWithTimeout).toHaveBeenCalledWith(
+            '/public/v1/chat',
+            'POST',
+            expect.stringContaining('[Announcement] Orange announcement here'),
+            null,
+            undefined,
+            'botAuthToken'
+        );
+    });
+
+    it('handles /announcepurple command correctly', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/announcepurple Purple message test",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(true);
+        expect(mockKick.httpCallWithTimeout).toHaveBeenCalledWith(
+            '/public/v1/chat',
+            'POST',
+            expect.stringContaining('[Announcement] Purple message test'),
+            null,
+            undefined,
+            'authToken'
+        );
+    });
+
+    it('throws error for announcement commands with missing message', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/announcegreen",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.httpCallWithTimeout).not.toHaveBeenCalled();
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('No message specified for /announcegreen command'));
+    });
+
+    it('throws error for /timeout command with invalid duration', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/timeout testuser invalid",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).not.toHaveBeenCalled();
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Duration must be a positive integer representing seconds'));
+    });
+
+    it('throws error for /timeout command with negative duration', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/timeout testuser -60",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).not.toHaveBeenCalled();
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Duration must be a positive integer representing seconds'));
+    });
+
+    it('throws error for /timeout command with zero duration', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/timeout testuser 0",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).not.toHaveBeenCalled();
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Duration must be a positive integer representing seconds'));
+    });
+
+    it('throws error for /timeout command with missing duration', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+
+        const payload = {
+            message: "/timeout testuser",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).not.toHaveBeenCalled();
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Usage: /timeout <user> <duration> [reason]'));
+    });
+
+    it('throws error when /timeout command API fails', async () => {
+        // Clear any previous calls
+        jest.clearAllMocks();
+        mockKick.userApi.banUserByUsername.mockResolvedValue(false);
+
+        const payload = {
+            message: "/timeout testuser 300 timeout reason",
+            accountType: "Streamer" as const,
+            replyToMessageId: undefined
+        };
+
+        const result = await chatManager['handleChatMessageTypedInChatFeed'](payload);
+
+        expect(result).toBe(false);
+        expect(mockKick.userApi.banUserByUsername).toHaveBeenCalledWith('testuser', 5, true, 'timeout reason');
+        expect(logger.error as jest.Mock).toHaveBeenCalledWith(expect.stringContaining('Failed to timeout user: testuser'));
     });
 });

--- a/src/internal/__tests__/util.test.ts
+++ b/src/internal/__tests__/util.test.ts
@@ -1,4 +1,168 @@
-import { userIdToCleanNumber, userIdToCleanString, parseDate } from '../util';
+import {
+    userIdToCleanNumber,
+    userIdToCleanString,
+    parseDate,
+    kickifyUserId,
+    unkickifyUserId,
+    kickifyUsername,
+    unkickifyUsername
+} from '../util';
+
+describe('kickifyUserId', () => {
+    it('returns empty string for undefined', () => {
+        expect(kickifyUserId(undefined)).toBe('');
+    });
+
+    it('returns empty string for null', () => {
+        expect(kickifyUserId(null as any)).toBe('');
+    });
+
+    it('adds k prefix to numeric userId', () => {
+        expect(kickifyUserId(12345)).toBe('k12345');
+    });
+
+    it('adds k prefix to string userId', () => {
+        expect(kickifyUserId('67890')).toBe('k67890');
+    });
+
+    it('does not add k prefix if already present', () => {
+        expect(kickifyUserId('k12345')).toBe('k12345');
+    });
+
+    it('handles zero userId', () => {
+        expect(kickifyUserId(0)).toBe('k0');
+    });
+
+    it('handles empty string', () => {
+        expect(kickifyUserId('')).toBe('k');
+    });
+
+    it('handles string that starts with k but is not kickified', () => {
+        expect(kickifyUserId('kabc')).toBe('kabc');
+    });
+});
+
+describe('unkickifyUserId', () => {
+    it('returns empty string for undefined', () => {
+        expect(unkickifyUserId(undefined)).toBe('');
+    });
+
+    it('returns empty string for null', () => {
+        expect(unkickifyUserId(null as any)).toBe('');
+    });
+
+    it('removes k prefix from kickified userId', () => {
+        expect(unkickifyUserId('k12345')).toBe('12345');
+    });
+
+    it('returns as-is for non-kickified userId', () => {
+        expect(unkickifyUserId('67890')).toBe('67890');
+    });
+
+    it('handles numeric input by converting to string', () => {
+        expect(unkickifyUserId(12345)).toBe('12345');
+    });
+
+    it('handles zero', () => {
+        expect(unkickifyUserId(0)).toBe('0');
+    });
+
+    it('handles empty string', () => {
+        expect(unkickifyUserId('')).toBe('');
+    });
+
+    it('handles single k character', () => {
+        expect(unkickifyUserId('k')).toBe('');
+    });
+
+    it('handles k with other text', () => {
+        expect(unkickifyUserId('kabc')).toBe('abc');
+    });
+});
+
+describe('kickifyUsername', () => {
+    it('returns empty string for undefined', () => {
+        expect(kickifyUsername(undefined)).toBe('');
+    });
+
+    it('returns empty string for empty string', () => {
+        expect(kickifyUsername('')).toBe('');
+    });
+
+    it('adds @kick suffix to username', () => {
+        expect(kickifyUsername('testuser')).toBe('testuser@kick');
+    });
+
+    it('does not add @kick suffix if already present', () => {
+        expect(kickifyUsername('testuser@kick')).toBe('testuser@kick');
+    });
+
+    it('handles username with @ symbol but not @kick', () => {
+        expect(kickifyUsername('user@other')).toBe('user@other@kick');
+    });
+
+    it('handles username that ends with partial @kick', () => {
+        expect(kickifyUsername('user@kic')).toBe('user@kic@kick');
+    });
+
+    it('handles single character username', () => {
+        expect(kickifyUsername('a')).toBe('a@kick');
+    });
+
+    it('removes leading @ symbol from username', () => {
+        expect(kickifyUsername('@testuser')).toBe('testuser@kick');
+    });
+
+    it('handles username with leading @ that already has @kick suffix', () => {
+        expect(kickifyUsername('@testuser@kick')).toBe('testuser@kick');
+    });
+
+    it('handles username with multiple leading @ symbols', () => {
+        expect(kickifyUsername('@@testuser')).toBe('@testuser@kick');
+    });
+});
+
+describe('unkickifyUsername', () => {
+    it('returns empty string for undefined', () => {
+        expect(unkickifyUsername(undefined)).toBe('');
+    });
+
+    it('returns empty string for empty string', () => {
+        expect(unkickifyUsername('')).toBe('');
+    });
+
+    it('removes @kick suffix from username', () => {
+        expect(unkickifyUsername('testuser@kick')).toBe('testuser');
+    });
+
+    it('returns as-is for username without @kick suffix', () => {
+        expect(unkickifyUsername('testuser')).toBe('testuser');
+    });
+
+    it('removes leading @ symbol after removing @kick', () => {
+        expect(unkickifyUsername('@testuser@kick')).toBe('testuser');
+    });
+
+    it('handles username that is just @kick', () => {
+        expect(unkickifyUsername('@kick')).toBe('');
+    });
+
+    it('handles username with @ but not @kick suffix', () => {
+        expect(unkickifyUsername('user@other')).toBe('user@other');
+    });
+
+    it('handles username with multiple @ symbols', () => {
+        expect(unkickifyUsername('@user@test@kick')).toBe('user@test');
+    });
+
+    it('removes @ prefix from regular username', () => {
+        expect(unkickifyUsername('@username')).toBe('username');
+    });
+
+    it('handles complex username with @ prefix and @kick suffix', () => {
+        expect(unkickifyUsername('@complex.user-name123@kick')).toBe('complex.user-name123');
+    });
+});
 
 describe('userIdToCleanString', () => {
     it('returns string for positive number', () => {

--- a/src/internal/http.ts
+++ b/src/internal/http.ts
@@ -55,7 +55,7 @@ export async function httpCallWithTimeout<T = any>(req: HttpCallRequest): Promis
         redirect: "manual"
     };
 
-    if (body !== undefined && body !== null && body !== "" && !["GET", "HEAD", "DELETE"].includes(method)) {
+    if (body !== undefined && body !== null && body !== "" && !["GET", "HEAD"].includes(method)) {
         fetchOptions['body'] = body;
     }
 

--- a/src/internal/user-api.ts
+++ b/src/internal/user-api.ts
@@ -1,6 +1,6 @@
 import { firebot, logger } from "../main";
 import { Kick } from "./kick";
-import { userIdToCleanNumber } from "./util";
+import { unkickifyUsername, userIdToCleanNumber } from "./util";
 
 interface UserBanRequest {
     username: string;
@@ -27,7 +27,9 @@ export class KickUserApi {
         logger.debug("User API stopped.");
     }
 
-    async banUserByUsername(username: string, duration: number, shouldBeBanned: boolean, reason = ''): Promise<boolean> {
+    async banUserByUsername(usernameIn: string, duration: number, shouldBeBanned: boolean, reason = ''): Promise<boolean> {
+        const username = unkickifyUsername(usernameIn);
+
         if (username.trim() === '') {
             logger.warn("banUserByUsername: No username provided.");
             return false;

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -16,14 +16,22 @@ export function kickifyUsername(username: string | undefined): string {
     if (!username) {
         return "";
     }
-    return username.endsWith("@kick") ? username : `${username}@kick`;
+    let result = username.endsWith("@kick") ? username : `${username}@kick`;
+    if (result.startsWith("@")) {
+        result = result.substring(1);
+    }
+    return result;
 }
 
 export function unkickifyUsername(username: string | undefined): string {
     if (!username) {
         return "";
     }
-    return username.endsWith("@kick") ? username.substring(0, username.length - 5) : username;
+    let result = username.endsWith("@kick") ? username.substring(0, username.length - 5) : username;
+    if (result.startsWith("@")) {
+        result = result.substring(1);
+    }
+    return result;
 }
 
 export function parseDate(dateString: string | undefined | null): Date | undefined {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Supports the following "slash commands" in the Firebot chat feed:
- `/announce` (and variants `/announcegreen`, `/announceblue`, `/announceorange`, `/announcepurple`)
- `/ban`
- `/timeout`
- `/unban` and `/untimeout`

Notes:
- Sometimes using the ban/unban/timeout commands on a Kick user will produce an error from the Twitch handler
- If you ban, unban, or timeout someone via this mechanism, that user on both Twitch and Kick will be affected
- Un-banning and un-timing out is the same action (so if you `/ban` and then `/untimeout` this will unban, for example)
- There is no announcement feature on Kick, so any of the `/announce` commands just post a regular message (and there is no colorization)

### Motivation
<!-- Please describe WHY you are making this change. This may include links to GitHub issues if relevant. -->

### Testing
- Unit tests covering slash commands
- Tested on my instance
