### PR TITLE
Prevent the same account from being used for streamer and bot

### DIFF
--- a/src/internal/kick.ts
+++ b/src/internal/kick.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { IntegrationConstants } from "../constants";
 import { integration } from "../integration";
 import { logger } from "../main";
@@ -74,6 +75,13 @@ export class Kick implements IKick {
             } else {
                 logger.debug("No bot token is given.");
                 this.bot = null;
+            }
+
+            // Check for same account used for both streamer and bot
+            if (this.broadcaster && this.bot && this.broadcaster.userId === this.bot.userId) {
+                logger.warn(`Same account detected: User ID ${this.broadcaster.userId} (${this.broadcaster.name}) is authorized for both streamer and bot. Bot functionality will be disabled.`);
+                this.bot = null;
+                integration.sendCriticalErrorNotification(`Bot account is the same as streamer account (${this.broadcaster.name}). Bot functionality has been disabled. Please authorize a different account for the bot in Settings > Integrations > ${IntegrationConstants.INTEGRATION_NAME}.`);
             }
 
             if (integration.getSettings().webhookProxy) {

--- a/src/internal/user-api.ts
+++ b/src/internal/user-api.ts
@@ -65,6 +65,11 @@ export class KickUserApi {
             throw new Error("banUser: Cannot ban broadcaster.");
         }
 
+        const botUserId = this.kick.bot?.userId || 0;
+        if (botUserId && realUserId === botUserId) {
+            throw new Error("banUser: Cannot ban bot account.");
+        }
+
         const payload: Record<string, any> = {
             // eslint-disable-next-line camelcase
             broadcaster_user_id: broadcasterUserId,


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This will disallow someone from registering the bot as the same account as the streamer.

### Motivation
Avoids possible confusion.

### Testing
Unit tests added/updated. I also re-authorized the streamer and bot in my setup under both scenarios and it worked as intended.
