### PR TITLE
Don't try to active the UI reflector at all in Firebot 5.64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "firebot-mage-kick-integration",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "firebot-mage-kick-integration",
-            "version": "0.6.0",
+            "version": "0.6.1",
             "license": "GNU3",
             "dependencies": {
                 "@seald-io/nedb": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "firebot-mage-kick-integration",
     "scriptOutputName": "firebot-mage-kick-integration",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "A Kick integration for Firebot",
     "main": "",
     "scripts": {

--- a/src/integration-singleton.ts
+++ b/src/integration-singleton.ts
@@ -314,14 +314,6 @@ export class KickIntegration extends EventEmitter {
         // Miscellaneous variables
         replaceVariableManager.registerReplaceVariable(platformVariable);
 
-        // UI Extensions
-        const { uiExtensionManager } = firebot.modules;
-        if (uiExtensionManager) {
-            uiExtensionManager.registerUIExtension(reflectorExtension);
-        } else {
-            logger.error("UI Extension Manager module not found. The Kick integration UI extension cannot be registered.");
-        }
-
         // Restrictions
         const { restrictionManager } = firebot.modules;
         restrictionManager.registerRestriction(platformRestriction);
@@ -330,6 +322,14 @@ export class KickIntegration extends EventEmitter {
         // via commit https://github.com/crowbartools/Firebot/commit/55744f55095d6d6ca791adced534c5a6fad37119
         try {
             requireVersion("5.65.0");
+
+            // UI Extensions
+            const { uiExtensionManager } = firebot.modules;
+            if (uiExtensionManager) {
+                uiExtensionManager.registerUIExtension(reflectorExtension);
+            } else {
+                logger.error("UI Extension Manager module not found. The Kick integration UI extension cannot be registered.");
+            }
 
             eventFilterManager.addEventToFilter("firebot:cheerbitsamount", IntegrationConstants.INTEGRATION_ID, "kicks-gifted");
             eventFilterManager.addEventToFilter("firebot:raid-viewer-count", IntegrationConstants.INTEGRATION_ID, "raid-sent-off");

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { definition, integration } from './integration';
 export let firebot: RunRequest<any>;
 export let logger: LogWrapper;
 
-export const scriptVersion = '0.6.0';
+export const scriptVersion = '0.6.1';
 
 const script: Firebot.CustomScript = {
     getScriptManifest: () => {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Avoid log spam in Firebot 5.64 due to the UI reflector.

### Motivation
<!-- Please describe WHY you are making this change. This may include links to GitHub issues if relevant. -->

### Testing
<!-- Outline any testing you've done for these changes. You may provide screen shots, copy/paste from logs, etc. as evidence. -->
