### PR TITLE
Proxy server API endpoint to manage users

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,45 @@
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+# Install git and ca-certificates (needed for fetching dependencies)
+RUN apk add --no-cache git ca-certificates
+
+# Set the working directory
+WORKDIR /app
+
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy the source code
+COPY . .
+
+# Build the application with the specified flags
+RUN go build -tags netgo -ldflags '-s -w' -o app
+
+# Final stage
+FROM alpine:latest
+
+# Create a non-root user
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the binary from the builder stage
+COPY --from=builder /app/app .
+
+# Change ownership of the app to the non-root user
+RUN chown appuser:appgroup app
+
+# Switch to the non-root user
+USER appuser
+
+# Expose the port (adjust if your app uses a different port)
+EXPOSE 10000
+
+# Run the application
+CMD ["./app"]

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - ADMIN_TOKEN=${ADMIN_TOKEN}
+      - CLIENT_ID=${CLIENT_ID}
+      - CLIENT_SECRET=${CLIENT_SECRET}
+      - USERS_FILE=/etc/secrets/users.txt
+    volumes:
+      - ${USERS_FILE:-/dev/null}:/etc/secrets/users.txt
+    ports:
+      - "10000:10000"
+    restart: unless-stopped

--- a/server/go.mod
+++ b/server/go.mod
@@ -6,6 +6,12 @@ require (
 	github.com/caarlos0/env/v10 v10.0.0
 	github.com/google/uuid v1.6.0
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.11.1
 )
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/server/go.sum
+++ b/server/go.sum
@@ -10,10 +10,13 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/server/pkg/config/users.go
+++ b/server/pkg/config/users.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+func (cfg *Config) KickNameToID(kickName string) (string, bool) {
+	cfg.kickNameToIDMu.RLock()
+	defer cfg.kickNameToIDMu.RUnlock()
+	id, ok := cfg.kickNameToID[strings.ToLower(kickName)]
+	return id, ok
+}
+
+func (cfg *Config) KickNamesToIDs() map[string]string {
+	cfg.kickNameToIDMu.RLock()
+	defer cfg.kickNameToIDMu.RUnlock()
+	// Return a copy to avoid modification
+	copy := make(map[string]string)
+	for k, v := range cfg.kickNameToID {
+		copy[k] = v
+	}
+	return copy
+}
+
+func (cfg *Config) IDToKickName(id string) (string, bool) {
+	cfg.idToKickNameMu.RLock()
+	defer cfg.idToKickNameMu.RUnlock()
+	kickName, ok := cfg.idToKickName[id]
+	return kickName, ok
+}
+
+func (cfg *Config) SetUser(username, uuid string, shouldDelete bool) {
+	cfg.idToKickNameMu.Lock()
+	defer cfg.idToKickNameMu.Unlock()
+	cfg.kickNameToIDMu.Lock()
+	defer cfg.kickNameToIDMu.Unlock()
+
+	username = strings.ToLower(username)
+
+	if shouldDelete {
+		// Only delete from idToKickName if UUID is not empty
+		if uuid != "" {
+			delete(cfg.idToKickName, uuid)
+		}
+		delete(cfg.kickNameToID, username)
+		return
+	}
+
+	// Check if this username is currently mapped to a different UUID and clean up
+	if oldUUID, exists := cfg.kickNameToID[username]; exists && oldUUID != uuid {
+		// Remove the old mapping from idToKickName (only if oldUUID is not empty)
+		if oldUUID != "" {
+			delete(cfg.idToKickName, oldUUID)
+		}
+	}
+
+	// Check if this UUID already exists and remove the old username mapping
+	// Only do this for non-empty UUIDs to allow multiple users with empty UUID
+	if uuid != "" {
+		if oldUsername, exists := cfg.idToKickName[uuid]; exists {
+			delete(cfg.kickNameToID, oldUsername)
+		}
+		cfg.idToKickName[uuid] = username
+	}
+
+	cfg.kickNameToID[username] = uuid
+}
+
+func (cfg *Config) loadUsers() error {
+	cfg.idToKickName = make(map[string]string)
+	cfg.kickNameToID = make(map[string]string)
+
+	if cfg.UsersFile == "" {
+		return nil
+	}
+
+	file, err := os.Open(cfg.UsersFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		uuid := strings.TrimSpace(parts[0])
+		kickName := strings.TrimSpace(parts[1])
+		if strings.HasPrefix(uuid, "#") {
+			continue
+		}
+		if uuid != "" && kickName != "" {
+			cfg.idToKickName[uuid] = strings.ToLower(kickName)
+		}
+		if kickName != "" {
+			cfg.kickNameToID[strings.ToLower(kickName)] = uuid
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/server/pkg/config/users_test.go
+++ b/server/pkg/config/users_test.go
@@ -1,0 +1,825 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_loadUsers(t *testing.T) {
+	tests := []struct {
+		name             string
+		fileContent      string
+		expectedIDToName map[string]string
+		expectedNameToID map[string]string
+		expectError      bool
+	}{
+		{
+			name: "valid users file",
+			fileContent: `user1-uuid:alice
+user2-uuid:bob
+user3-uuid:charlie`,
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+				"user3-uuid": "charlie",
+			},
+			expectedNameToID: map[string]string{
+				"alice":   "user1-uuid",
+				"bob":     "user2-uuid",
+				"charlie": "user3-uuid",
+			},
+			expectError: false,
+		},
+		{
+			name: "mixed case usernames are normalized to lowercase",
+			fileContent: `user1-uuid:Alice
+user2-uuid:BOB
+user3-uuid:ChArLiE`,
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+				"user3-uuid": "charlie",
+			},
+			expectedNameToID: map[string]string{
+				"alice":   "user1-uuid",
+				"bob":     "user2-uuid",
+				"charlie": "user3-uuid",
+			},
+			expectError: false,
+		},
+		{
+			name: "whitespace trimming",
+			fileContent: `  user1-uuid  :  alice
+	user2-uuid	:	bob
+user3-uuid: charlie `,
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+				"user3-uuid": "charlie",
+			},
+			expectedNameToID: map[string]string{
+				"alice":   "user1-uuid",
+				"bob":     "user2-uuid",
+				"charlie": "user3-uuid",
+			},
+			expectError: false,
+		},
+		{
+			name: "empty lines and invalid lines are skipped",
+			fileContent: `user1-uuid:alice
+
+invalid-line-without-colon
+user2-uuid:bob
+:empty-uuid
+empty-name:
+user3-uuid:charlie`,
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+				"user3-uuid": "charlie",
+			},
+			expectedNameToID: map[string]string{
+				"alice":      "user1-uuid",
+				"bob":        "user2-uuid",
+				"charlie":    "user3-uuid",
+				"empty-uuid": "", // This gets added because kickName is not empty (it's "empty-uuid")
+			},
+			expectError: false,
+		},
+		{
+			name: "commented lines are skipped",
+			fileContent: `user1-uuid:alice
+#user2-uuid:bob
+# This is a comment
+user3-uuid:charlie
+#commented-uuid:commented-user`,
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice",
+				"user3-uuid": "charlie",
+			},
+			expectedNameToID: map[string]string{
+				"alice":   "user1-uuid",
+				"charlie": "user3-uuid",
+			},
+			expectError: false,
+		},
+		{
+			name:             "empty file",
+			fileContent:      "",
+			expectedIDToName: map[string]string{},
+			expectedNameToID: map[string]string{},
+			expectError:      false,
+		},
+		{
+			name: "file with only comments and empty lines",
+			fileContent: `# This is a comment
+# Another comment
+
+# Yet another comment`,
+			expectedIDToName: map[string]string{},
+			expectedNameToID: map[string]string{},
+			expectError:      false,
+		},
+		{
+			name: "colons in usernames are handled correctly",
+			fileContent: `user1-uuid:alice:with:colons
+user2-uuid:bob:another:colon`,
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice:with:colons",
+				"user2-uuid": "bob:another:colon",
+			},
+			expectedNameToID: map[string]string{
+				"alice:with:colons": "user1-uuid",
+				"bob:another:colon": "user2-uuid",
+			},
+			expectError: false,
+		},
+		{
+			name: "duplicate usernames - last one wins",
+			fileContent: `user1-uuid:alice
+user2-uuid:alice
+user3-uuid:bob`,
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "alice",
+				"user3-uuid": "bob",
+			},
+			expectedNameToID: map[string]string{
+				"alice": "user2-uuid", // Last one wins
+				"bob":   "user3-uuid",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary file
+			tempDir := t.TempDir()
+			tempFile := filepath.Join(tempDir, "users.txt")
+
+			err := os.WriteFile(tempFile, []byte(tt.fileContent), 0644)
+			require.NoError(t, err)
+
+			// Create config and set the users file path
+			cfg := &Config{
+				UsersFile: tempFile,
+			}
+
+			// Call loadUsers
+			err = cfg.loadUsers()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Test IDToKickName function
+			for expectedID, expectedName := range tt.expectedIDToName {
+				actualName, ok := cfg.IDToKickName(expectedID)
+				assert.True(t, ok, "ID %s should be found", expectedID)
+				assert.Equal(t, expectedName, actualName, "Name for ID %s should match", expectedID)
+			}
+
+			// Test that non-existent IDs return false
+			nonExistentName, ok := cfg.IDToKickName("non-existent-id")
+			assert.False(t, ok, "Non-existent ID should return false")
+			assert.Empty(t, nonExistentName, "Non-existent ID should return empty string")
+
+			// Test KickNameToID function
+			for expectedName, expectedID := range tt.expectedNameToID {
+				actualID, ok := cfg.KickNameToID(expectedName)
+				assert.True(t, ok, "Name %s should be found", expectedName)
+				assert.Equal(t, expectedID, actualID, "ID for name %s should match", expectedName)
+			}
+
+			// Test case insensitive lookup for KickNameToID
+			for expectedName, expectedID := range tt.expectedNameToID {
+				// Test uppercase
+				actualID, ok := cfg.KickNameToID(strings.ToUpper(expectedName))
+				if expectedName != "" {
+					assert.True(t, ok, "Uppercase name %s should be found", strings.ToUpper(expectedName))
+					assert.Equal(t, expectedID, actualID, "ID for uppercase name %s should match", strings.ToUpper(expectedName))
+				}
+			}
+
+			// Test that non-existent names return false
+			nonExistentID, ok := cfg.KickNameToID("non-existent-name")
+			assert.False(t, ok, "Non-existent name should return false")
+			assert.Empty(t, nonExistentID, "Non-existent name should return empty string")
+
+			// Test KickNamesToIDs function
+			actualNameToID := cfg.KickNamesToIDs()
+			assert.Equal(t, tt.expectedNameToID, actualNameToID, "KickNamesToIDs should return expected map")
+
+			// Verify that modifying the returned map doesn't affect the internal state
+			if len(actualNameToID) > 0 {
+				for name := range actualNameToID {
+					actualNameToID[name] = "modified"
+					break
+				}
+				// Get the map again and verify it's unchanged
+				freshMap := cfg.KickNamesToIDs()
+				assert.Equal(t, tt.expectedNameToID, freshMap, "Internal map should not be affected by modifications to returned map")
+			}
+		})
+	}
+}
+
+func TestConfig_loadUsers_FileNotFound(t *testing.T) {
+	cfg := &Config{
+		UsersFile: "/non/existent/file.txt",
+	}
+
+	err := cfg.loadUsers()
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err), "Error should be file not found error")
+}
+
+func TestConfig_loadUsers_EmptyUsersFile(t *testing.T) {
+	cfg := &Config{
+		UsersFile: "",
+	}
+
+	err := cfg.loadUsers()
+	assert.NoError(t, err, "Empty UsersFile should not cause error")
+
+	// Maps should be empty when UsersFile is empty
+	assert.Empty(t, cfg.idToKickName)
+	assert.Empty(t, cfg.kickNameToID)
+}
+
+func TestConfig_loadUsers_ConcurrentAccess(t *testing.T) {
+	// Create temporary file
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "users.txt")
+
+	content := `user1-uuid:alice
+user2-uuid:bob
+user3-uuid:charlie`
+
+	err := os.WriteFile(tempFile, []byte(content), 0644)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		UsersFile: tempFile,
+	}
+
+	// Load users
+	err = cfg.loadUsers()
+	require.NoError(t, err)
+
+	// Test concurrent access to the maps
+	done := make(chan bool, 2)
+
+	// Goroutine 1: Read operations
+	go func() {
+		defer func() { done <- true }()
+		for i := 0; i < 100; i++ {
+			_, _ = cfg.KickNameToID("alice")
+			_, _ = cfg.IDToKickName("user1-uuid")
+			_ = cfg.KickNamesToIDs()
+		}
+	}()
+
+	// Goroutine 2: More read operations
+	go func() {
+		defer func() { done <- true }()
+		for i := 0; i < 100; i++ {
+			_, _ = cfg.KickNameToID("bob")
+			_, _ = cfg.IDToKickName("user2-uuid")
+			_ = cfg.KickNamesToIDs()
+		}
+	}()
+
+	// Wait for both goroutines to complete
+	<-done
+	<-done
+
+	// Verify data integrity after concurrent access
+	name, ok := cfg.IDToKickName("user1-uuid")
+	assert.True(t, ok)
+	assert.Equal(t, "alice", name)
+
+	id, ok := cfg.KickNameToID("alice")
+	assert.True(t, ok)
+	assert.Equal(t, "user1-uuid", id)
+}
+
+func TestConfig_SetUser(t *testing.T) {
+	tests := []struct {
+		name             string
+		initialUsers     map[string]string // uuid -> username
+		operations       []setUserOperation
+		expectedIDToName map[string]string
+		expectedNameToID map[string]string
+	}{
+		{
+			name: "add new user",
+			initialUsers: map[string]string{
+				"user1-uuid": "alice",
+			},
+			operations: []setUserOperation{
+				{username: "bob", uuid: "user2-uuid", shouldDelete: false},
+			},
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+			},
+			expectedNameToID: map[string]string{
+				"alice": "user1-uuid",
+				"bob":   "user2-uuid",
+			},
+		},
+		{
+			name: "update existing user",
+			initialUsers: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+			},
+			operations: []setUserOperation{
+				{username: "charlie", uuid: "user1-uuid", shouldDelete: false},
+			},
+			expectedIDToName: map[string]string{
+				"user1-uuid": "charlie",
+				"user2-uuid": "bob",
+			},
+			expectedNameToID: map[string]string{
+				"charlie": "user1-uuid", // New name points to the UUID
+				"bob":     "user2-uuid", // Old "alice" mapping should be removed
+			},
+		},
+		{
+			name: "delete existing user",
+			initialUsers: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+				"user3-uuid": "charlie",
+			},
+			operations: []setUserOperation{
+				{username: "alice", uuid: "user1-uuid", shouldDelete: true},
+			},
+			expectedIDToName: map[string]string{
+				"user2-uuid": "bob",
+				"user3-uuid": "charlie",
+			},
+			expectedNameToID: map[string]string{
+				"bob":     "user2-uuid",
+				"charlie": "user3-uuid",
+			},
+		},
+		{
+			name: "delete non-existent user (no error)",
+			initialUsers: map[string]string{
+				"user1-uuid": "alice",
+			},
+			operations: []setUserOperation{
+				{username: "bob", uuid: "user2-uuid", shouldDelete: true},
+			},
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice",
+			},
+			expectedNameToID: map[string]string{
+				"alice": "user1-uuid",
+			},
+		},
+		{
+			name:         "case normalization on add",
+			initialUsers: map[string]string{},
+			operations: []setUserOperation{
+				{username: "ALICE", uuid: "user1-uuid", shouldDelete: false},
+				{username: "Bob", uuid: "user2-uuid", shouldDelete: false},
+			},
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+			},
+			expectedNameToID: map[string]string{
+				"alice": "user1-uuid",
+				"bob":   "user2-uuid",
+			},
+		},
+		{
+			name: "case normalization on delete",
+			initialUsers: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+			},
+			operations: []setUserOperation{
+				{username: "ALICE", uuid: "user1-uuid", shouldDelete: true},
+			},
+			expectedIDToName: map[string]string{
+				"user2-uuid": "bob",
+			},
+			expectedNameToID: map[string]string{
+				"bob": "user2-uuid",
+			},
+		},
+		{
+			name: "multiple operations",
+			initialUsers: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+			},
+			operations: []setUserOperation{
+				{username: "charlie", uuid: "user3-uuid", shouldDelete: false}, // add
+				{username: "alice", uuid: "user1-uuid", shouldDelete: true},    // delete
+				{username: "diana", uuid: "user2-uuid", shouldDelete: false},   // update
+			},
+			expectedIDToName: map[string]string{
+				"user2-uuid": "diana",
+				"user3-uuid": "charlie",
+			},
+			expectedNameToID: map[string]string{
+				"diana":   "user2-uuid", // New name points to the UUID (old "bob" removed)
+				"charlie": "user3-uuid",
+			},
+		},
+		{
+			name: "username collision - last one wins",
+			initialUsers: map[string]string{
+				"user1-uuid": "alice",
+			},
+			operations: []setUserOperation{
+				{username: "alice", uuid: "user2-uuid", shouldDelete: false}, // Same username, different UUID
+			},
+			expectedIDToName: map[string]string{
+				"user2-uuid": "alice", // Only the new UUID mapping remains
+				// user1-uuid is cleaned up to prevent orphans
+			},
+			expectedNameToID: map[string]string{
+				"alice": "user2-uuid", // Last one wins
+			},
+		},
+		{
+			name: "old username mapping is properly removed on update",
+			initialUsers: map[string]string{
+				"user1-uuid": "alice",
+				"user2-uuid": "bob",
+				"user3-uuid": "charlie",
+			},
+			operations: []setUserOperation{
+				{username: "alice_updated", uuid: "user1-uuid", shouldDelete: false}, // Update alice
+				{username: "bob_updated", uuid: "user2-uuid", shouldDelete: false},   // Update bob
+			},
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice_updated",
+				"user2-uuid": "bob_updated",
+				"user3-uuid": "charlie",
+			},
+			expectedNameToID: map[string]string{
+				"alice_updated": "user1-uuid",
+				"bob_updated":   "user2-uuid",
+				"charlie":       "user3-uuid",
+				// "alice" and "bob" should NOT be present
+			},
+		},
+		{
+			name: "multiple users with empty UUID",
+			initialUsers: map[string]string{
+				"user1-uuid": "alice",
+			},
+			operations: []setUserOperation{
+				{username: "bob", uuid: "", shouldDelete: false},     // Add user with empty UUID
+				{username: "charlie", uuid: "", shouldDelete: false}, // Add another user with empty UUID
+			},
+			expectedIDToName: map[string]string{
+				"user1-uuid": "alice", // Only non-empty UUIDs appear here
+				// Empty UUIDs should NOT appear in idToKickName
+			},
+			expectedNameToID: map[string]string{
+				"alice":   "user1-uuid",
+				"bob":     "", // Users with empty UUID still appear in kickNameToID
+				"charlie": "", // Users with empty UUID still appear in kickNameToID
+			},
+		},
+		{
+			name: "reassign username from real UUID to empty UUID (orphan cleanup)",
+			initialUsers: map[string]string{
+				"bob-uuid": "bob",
+			},
+			operations: []setUserOperation{
+				{username: "bob", uuid: "", shouldDelete: false}, // Reassign bob to empty UUID
+			},
+			expectedIDToName: map[string]string{
+				// bob-uuid should be removed to prevent orphans
+			},
+			expectedNameToID: map[string]string{
+				"bob": "", // bob now maps to empty UUID
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Initialize config with initial users
+			cfg := &Config{
+				idToKickName: make(map[string]string),
+				kickNameToID: make(map[string]string),
+			}
+
+			// Set up initial state
+			for uuid, username := range tt.initialUsers {
+				cfg.idToKickName[uuid] = strings.ToLower(username)
+				cfg.kickNameToID[strings.ToLower(username)] = uuid
+			}
+
+			// Perform operations
+			for _, op := range tt.operations {
+				cfg.SetUser(op.username, op.uuid, op.shouldDelete)
+			}
+
+			// Test IDToKickName function
+			for expectedID, expectedName := range tt.expectedIDToName {
+				actualName, ok := cfg.IDToKickName(expectedID)
+				assert.True(t, ok, "ID %s should be found", expectedID)
+				assert.Equal(t, expectedName, actualName, "Name for ID %s should match", expectedID)
+			}
+
+			// Test that deleted IDs are not found
+			for uuid := range tt.initialUsers {
+				if _, exists := tt.expectedIDToName[uuid]; !exists {
+					_, ok := cfg.IDToKickName(uuid)
+					assert.False(t, ok, "Deleted ID %s should not be found", uuid)
+				}
+			}
+
+			// Test KickNameToID function
+			for expectedName, expectedID := range tt.expectedNameToID {
+				actualID, ok := cfg.KickNameToID(expectedName)
+				assert.True(t, ok, "Name %s should be found", expectedName)
+				assert.Equal(t, expectedID, actualID, "ID for name %s should match", expectedName)
+			}
+
+			// Test case insensitive lookup for KickNameToID
+			for expectedName, expectedID := range tt.expectedNameToID {
+				if expectedName != "" {
+					// Test uppercase
+					actualID, ok := cfg.KickNameToID(strings.ToUpper(expectedName))
+					assert.True(t, ok, "Uppercase name %s should be found", strings.ToUpper(expectedName))
+					assert.Equal(t, expectedID, actualID, "ID for uppercase name %s should match", strings.ToUpper(expectedName))
+				}
+			}
+
+			// Test that explicitly deleted names are not found
+			for _, op := range tt.operations {
+				if op.shouldDelete {
+					_, ok := cfg.KickNameToID(strings.ToLower(op.username))
+					assert.False(t, ok, "Explicitly deleted name %s should not be found", op.username)
+				}
+			}
+
+			// Test KickNamesToIDs function
+			actualNameToID := cfg.KickNamesToIDs()
+			assert.Equal(t, tt.expectedNameToID, actualNameToID, "KickNamesToIDs should return expected map")
+
+			// Additional check: verify old usernames are removed after updates
+			if tt.name == "old username mapping is properly removed on update" {
+				// Verify that "alice" and "bob" are no longer found
+				_, ok := cfg.KickNameToID("alice")
+				assert.False(t, ok, "Old username 'alice' should not be found after update")
+
+				_, ok = cfg.KickNameToID("bob")
+				assert.False(t, ok, "Old username 'bob' should not be found after update")
+			}
+
+			// Additional check: verify empty UUIDs are not in IDToKickName
+			if tt.name == "multiple users with empty UUID" {
+				// Empty UUID should not be found in IDToKickName
+				_, ok := cfg.IDToKickName("")
+				assert.False(t, ok, "Empty UUID should not be found in IDToKickName")
+			}
+		})
+	}
+}
+
+func TestConfig_SetUser_ConcurrentAccess(t *testing.T) {
+	cfg := &Config{
+		idToKickName: make(map[string]string),
+		kickNameToID: make(map[string]string),
+	}
+
+	// Initialize with some data
+	cfg.SetUser("alice", "user1-uuid", false)
+	cfg.SetUser("bob", "user2-uuid", false)
+
+	done := make(chan bool, 3)
+
+	// Goroutine 1: Add users
+	go func() {
+		defer func() { done <- true }()
+		for i := 0; i < 50; i++ {
+			cfg.SetUser("charlie", "user3-uuid", false)
+		}
+	}()
+
+	// Goroutine 2: Delete and re-add users
+	go func() {
+		defer func() { done <- true }()
+		for i := 0; i < 50; i++ {
+			cfg.SetUser("alice", "user1-uuid", true)  // delete
+			cfg.SetUser("alice", "user1-uuid", false) // re-add
+		}
+	}()
+
+	// Goroutine 3: Read operations
+	go func() {
+		defer func() { done <- true }()
+		for i := 0; i < 50; i++ {
+			_, _ = cfg.KickNameToID("bob")
+			_, _ = cfg.IDToKickName("user2-uuid")
+			_ = cfg.KickNamesToIDs()
+		}
+	}()
+
+	// Wait for all goroutines to complete
+	<-done
+	<-done
+	<-done
+
+	// Verify final state - alice and bob should exist
+	name, ok := cfg.IDToKickName("user1-uuid")
+	assert.True(t, ok)
+	assert.Equal(t, "alice", name)
+
+	id, ok := cfg.KickNameToID("alice")
+	assert.True(t, ok)
+	assert.Equal(t, "user1-uuid", id)
+
+	name, ok = cfg.IDToKickName("user2-uuid")
+	assert.True(t, ok)
+	assert.Equal(t, "bob", name)
+
+	id, ok = cfg.KickNameToID("bob")
+	assert.True(t, ok)
+	assert.Equal(t, "user2-uuid", id)
+}
+
+func TestConfig_SetUser_EmptyValues(t *testing.T) {
+	cfg := &Config{
+		idToKickName: make(map[string]string),
+		kickNameToID: make(map[string]string),
+	}
+
+	// Test with empty username
+	cfg.SetUser("", "user1-uuid", false)
+
+	// Should still add to idToKickName with empty string
+	name, ok := cfg.IDToKickName("user1-uuid")
+	assert.True(t, ok)
+	assert.Equal(t, "", name)
+
+	// Should add to kickNameToID with empty key
+	id, ok := cfg.KickNameToID("")
+	assert.True(t, ok)
+	assert.Equal(t, "user1-uuid", id)
+
+	// Test with empty UUID - should NOT be stored in idToKickName
+	cfg.SetUser("alice", "", false)
+
+	// Should NOT be found in idToKickName
+	name, ok = cfg.IDToKickName("")
+	assert.False(t, ok, "Empty UUID should not be found in IDToKickName")
+	assert.Empty(t, name)
+
+	// Should still be found in kickNameToID
+	id, ok = cfg.KickNameToID("alice")
+	assert.True(t, ok)
+	assert.Equal(t, "", id)
+}
+
+func TestConfig_SetUser_OrphanCleanup(t *testing.T) {
+	cfg := &Config{
+		idToKickName: make(map[string]string),
+		kickNameToID: make(map[string]string),
+	}
+
+	// Set up initial state: bob -> bob-uuid
+	cfg.SetUser("bob", "bob-uuid", false)
+
+	// Verify initial state
+	name, ok := cfg.IDToKickName("bob-uuid")
+	assert.True(t, ok)
+	assert.Equal(t, "bob", name)
+
+	id, ok := cfg.KickNameToID("bob")
+	assert.True(t, ok)
+	assert.Equal(t, "bob-uuid", id)
+
+	// Now call SetUser("bob", "") - this should clean up the orphan
+	cfg.SetUser("bob", "", false)
+
+	// Verify that the old mapping is cleaned up
+	_, ok = cfg.IDToKickName("bob-uuid")
+	assert.False(t, ok, "Old UUID 'bob-uuid' should not be found after reassigning username")
+
+	// But bob should still map to empty UUID
+	id, ok = cfg.KickNameToID("bob")
+	assert.True(t, ok)
+	assert.Equal(t, "", id)
+
+	// Test the reverse scenario: user with empty UUID gets reassigned to real UUID
+	cfg.SetUser("alice", "", false)
+	cfg.SetUser("alice", "alice-uuid", false)
+
+	// alice should now map to alice-uuid
+	id, ok = cfg.KickNameToID("alice")
+	assert.True(t, ok)
+	assert.Equal(t, "alice-uuid", id)
+
+	name, ok = cfg.IDToKickName("alice-uuid")
+	assert.True(t, ok)
+	assert.Equal(t, "alice", name)
+
+	// Test username reassignment between two real UUIDs
+	cfg.SetUser("charlie", "uuid1", false)
+	cfg.SetUser("charlie", "uuid2", false)
+
+	// charlie should now map to uuid2
+	id, ok = cfg.KickNameToID("charlie")
+	assert.True(t, ok)
+	assert.Equal(t, "uuid2", id)
+
+	// uuid2 should map to charlie
+	name, ok = cfg.IDToKickName("uuid2")
+	assert.True(t, ok)
+	assert.Equal(t, "charlie", name)
+
+	// uuid1 should no longer exist
+	_, ok = cfg.IDToKickName("uuid1")
+	assert.False(t, ok, "Old UUID 'uuid1' should not exist after reassignment")
+}
+
+func TestConfig_SetUser_MultipleEmptyUUIDs(t *testing.T) {
+	cfg := &Config{
+		idToKickName: make(map[string]string),
+		kickNameToID: make(map[string]string),
+	}
+
+	// Add multiple users with empty UUIDs
+	cfg.SetUser("alice", "", false)
+	cfg.SetUser("bob", "", false)
+	cfg.SetUser("charlie", "", false)
+
+	// IDToKickName should return false for empty UUID
+	name, ok := cfg.IDToKickName("")
+	assert.False(t, ok, "Empty UUID should not be found in IDToKickName")
+	assert.Empty(t, name, "Empty UUID should return empty name")
+
+	// All users should be found in KickNameToID
+	id, ok := cfg.KickNameToID("alice")
+	assert.True(t, ok, "alice should be found")
+	assert.Equal(t, "", id, "alice should have empty UUID")
+
+	id, ok = cfg.KickNameToID("bob")
+	assert.True(t, ok, "bob should be found")
+	assert.Equal(t, "", id, "bob should have empty UUID")
+
+	id, ok = cfg.KickNameToID("charlie")
+	assert.True(t, ok, "charlie should be found")
+	assert.Equal(t, "", id, "charlie should have empty UUID")
+
+	// KickNamesToIDs should contain all users
+	allUsers := cfg.KickNamesToIDs()
+	expectedUsers := map[string]string{
+		"alice":   "",
+		"bob":     "",
+		"charlie": "",
+	}
+	assert.Equal(t, expectedUsers, allUsers, "All users with empty UUIDs should be in KickNamesToIDs")
+
+	// Test deletion of user with empty UUID
+	cfg.SetUser("alice", "", true)
+
+	// alice should no longer be found
+	_, ok = cfg.KickNameToID("alice")
+	assert.False(t, ok, "alice should not be found after deletion")
+
+	// Other users should still exist
+	_, ok = cfg.KickNameToID("bob")
+	assert.True(t, ok, "bob should still exist")
+
+	_, ok = cfg.KickNameToID("charlie")
+	assert.True(t, ok, "charlie should still exist")
+
+	// KickNamesToIDs should only contain remaining users
+	allUsers = cfg.KickNamesToIDs()
+	expectedUsers = map[string]string{
+		"bob":     "",
+		"charlie": "",
+	}
+	assert.Equal(t, expectedUsers, allUsers, "Only remaining users should be in KickNamesToIDs")
+}
+
+type setUserOperation struct {
+	username     string
+	uuid         string
+	shouldDelete bool
+}

--- a/server/pkg/server/auth.go
+++ b/server/pkg/server/auth.go
@@ -138,7 +138,7 @@ func (s *Server) handleAuthorizationCode(ctx context.Context, w http.ResponseWri
 		return
 	}
 
-	if key, exists := config.FromContext(ctx).KickNameToID[strings.ToLower(userInfo.Data[0].Name)]; exists {
+	if key, exists := config.FromContext(ctx).KickNameToID(userInfo.Data[0].Name); exists {
 		response.ProxyPollKey = key
 		s.log(ctx, r, "User %s found in configured Kick IDs, setting ProxyPollKey to %s", userInfo.Data[0].Name, key)
 	} else {

--- a/server/pkg/server/connect.go
+++ b/server/pkg/server/connect.go
@@ -12,7 +12,7 @@ func (s *Server) HandleConnect(ctx context.Context) func(w http.ResponseWriter, 
 
 		// Look up the UUID from the URL path in the users map
 		uuid := r.URL.Path[len("/connect/"):]
-		kickID, exists := cfg.IDToKickName[uuid]
+		kickID, exists := cfg.IDToKickName(uuid)
 		if !exists {
 			http.Error(w, "User not found", http.StatusNotFound)
 			s.log(ctx, r, "Received connect request: user not found (uuid=%s)", uuid)

--- a/server/pkg/server/inject.go
+++ b/server/pkg/server/inject.go
@@ -101,8 +101,9 @@ func (s *Server) HandleInject(ctx context.Context) func(w http.ResponseWriter, r
 		}
 
 		// Add the webhook to the user's state
+		username, _ := config.FromContext(ctx).IDToKickName(keyID)
 		s.log(ctx, r, "Injected webhook! key=%s username=%s eventType=%s eventVersion=%s messageID=%s timestamp=%s",
-			keyID, config.FromContext(ctx).IDToKickName[keyID], webhook.EventType, webhook.EventVersion, webhook.EventMessageID, webhook.EventMessageTimestamp)
+			keyID, username, webhook.EventType, webhook.EventVersion, webhook.EventMessageID, webhook.EventMessageTimestamp)
 		s.state.Put(keyID, webhook)
 
 		// Signal any waiters that a webhook has been received

--- a/server/pkg/server/poll.go
+++ b/server/pkg/server/poll.go
@@ -16,7 +16,7 @@ func (s *Server) HandleClose(ctx context.Context) func(w http.ResponseWriter, r 
 
 		// Look up the UUID from the URL path in the users map
 		uuid := r.URL.Path[len("/poll/"):]
-		_, exists := cfg.IDToKickName[uuid]
+		_, exists := cfg.IDToKickName(uuid)
 		if !exists {
 			http.Error(w, "User not found", http.StatusNotFound)
 			s.log(ctx, r, "Received poll request: user not found (uuid=%s)", uuid)
@@ -37,7 +37,7 @@ func (s *Server) HandlePoll(ctx context.Context) func(w http.ResponseWriter, r *
 
 		// Look up the UUID from the URL path in the users map
 		uuid := r.URL.Path[len("/poll/"):]
-		_, exists := cfg.IDToKickName[uuid]
+		_, exists := cfg.IDToKickName(uuid)
 		if !exists {
 			http.Error(w, "User not found", http.StatusNotFound)
 			s.log(ctx, r, "Received poll request: user not found (uuid=%s)", uuid)

--- a/server/pkg/server/server.go
+++ b/server/pkg/server/server.go
@@ -103,6 +103,10 @@ func (s *Server) main(ctx context.Context, wg *sync.WaitGroup) {
 		s.HandleWebHook(ctx)(w, r)
 	})
 
+	http.HandleFunc("/admin/users", func(w http.ResponseWriter, r *http.Request) {
+		s.HandleUsers(ctx)(w, r)
+	})
+
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)

--- a/server/pkg/server/users.go
+++ b/server/pkg/server/users.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"mage-kick-webhook-proxy/pkg/config"
+	"net/http"
+)
+
+type UserPayload struct {
+	Username string `json:"username"`
+	UUID     string `json:"uuid"`
+}
+
+func (s *Server) HandleUsers(ctx context.Context) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Currently there's one static admin token for the entire site.
+		// We can do better if we have to.
+		if config.FromContext(ctx).AdminToken == "" {
+			s.log(ctx, r, "Rejecting users endpoint request: Admin token is not configured")
+			http.Error(w, "This endpoint is restricted", http.StatusForbidden)
+			return
+		}
+
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "Bearer "+config.FromContext(ctx).AdminToken && authHeader != "Token "+config.FromContext(ctx).AdminToken && authHeader != config.FromContext(ctx).AdminToken {
+			s.log(ctx, r, "Rejecting users endpoint request: Admin token mismatch")
+			http.Error(w, "This endpoint is restricted", http.StatusForbidden)
+			return
+		}
+
+		// Handle GET to list users
+		if r.Method == http.MethodGet {
+			s.handleListUsers(ctx, w, r)
+			return
+		}
+
+		body := json.NewDecoder(r.Body)
+		var userPayload UserPayload
+		if err := body.Decode(&userPayload); err != nil {
+			http.Error(w, "Bad Request: invalid JSON body", http.StatusBadRequest)
+			s.log(ctx, r, "Failed to parse user add request body: %v", err)
+			return
+		}
+
+		// Handle POST to add a user
+		if r.Method == http.MethodPost {
+			s.handleAddUser(ctx, w, r, userPayload)
+			return
+		}
+
+		// Handle DELETE to remove a user
+		if r.Method == http.MethodDelete {
+			s.handleRemoveUser(ctx, w, r, userPayload)
+			return
+		}
+
+		s.log(ctx, r, "Rejecting users endpoint request: Unknown method %s", r.Method)
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleListUsers(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	users := config.FromContext(ctx).KickNamesToIDs()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(users); err != nil {
+		http.Error(w, "Failed to encode user list", http.StatusInternalServerError)
+		s.log(ctx, r, "Failed to encode user list: %v", err)
+		return
+	}
+}
+
+func (s *Server) handleAddUser(ctx context.Context, w http.ResponseWriter, r *http.Request, userPayload UserPayload) {
+	config.FromContext(ctx).SetUser(userPayload.Username, userPayload.UUID, false)
+	s.log(ctx, r, "Added user: username=%s uuid=%s", userPayload.Username, userPayload.UUID)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (s *Server) handleRemoveUser(ctx context.Context, w http.ResponseWriter, r *http.Request, userPayload UserPayload) {
+	config.FromContext(ctx).SetUser(userPayload.Username, userPayload.UUID, true)
+	s.log(ctx, r, "Removed user: username=%s uuid=%s", userPayload.Username, userPayload.UUID)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/pkg/server/webhook.go
+++ b/server/pkg/server/webhook.go
@@ -7,7 +7,6 @@ import (
 	"mage-kick-webhook-proxy/pkg/config"
 	"mage-kick-webhook-proxy/pkg/model"
 	"net/http"
-	"strings"
 )
 
 func (s *Server) HandleWebHook(ctx context.Context) func(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +59,7 @@ func (s *Server) HandleWebHook(ctx context.Context) func(w http.ResponseWriter, 
 		}
 
 		// Match the webhook request to a user
-		keyID, exists := config.FromContext(ctx).KickNameToID[strings.ToLower(parsedWebhook.Broadcaster.UserName)]
+		keyID, exists := config.FromContext(ctx).KickNameToID(parsedWebhook.Broadcaster.UserName)
 		if !exists {
 			s.log(ctx, r, "Rejected webhook for unregistered kick user! username=%s eventType=%s eventVersion=%s",
 				parsedWebhook.Broadcaster.UserName, eventType, eventVersion)


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds API endpoint at `/admin/users` to delete, create/update, and list users. These are currently in the environment via the user file, but for now it avoids the need to redeploy in order to manage a user. This might someday have an option to store user to ID mappings more dynamically (e.g. in Redis).

### Motivation
Don't want to restart the service every time I have to add a new user.

### Testing
Unit tests added for user features + local testing with Docker.
