### PR TITLE
Improve log consistency in webhook proxy poller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ node_modules/
 
 # Go stuff
 /server/app
+/server/mage-kick-webhook-proxy
 
 # Coverage
 /coverage/
@@ -27,3 +28,4 @@ node_modules/
 # For local testing
 /test-payloads/
 /server/redis.db
+/server/test-data/

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - REDIS_URL=redis://redis:6379
       - USERS_FILE=/etc/secrets/users.txt
     volumes:
-      - ${USERS_FILE:-/dev/null}:/etc/secrets/users.txt
+      - ${USERS_FILE:-./test-data/users.txt}:/etc/secrets/users.txt
     ports:
       - "10000:10000"
     restart: unless-stopped


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This doesn't change anything on the client or server protocols. However we now log a consistent message as soon as we receive the polling request, and then one or two subsequent messages as we deal with that request.

### Motivation
<!-- Please describe WHY you are making this change. This may include links to GitHub issues if relevant. -->

### Testing
Tested in docker-compose.
